### PR TITLE
specificed version of multi_json in gemspec

### DIFF
--- a/bugsnag.gemspec
+++ b/bugsnag.gemspec
@@ -54,14 +54,14 @@ Gem::Specification.new do |s|
     s.specification_version = 3
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency(%q<multi_json>, [">= 0"])
+      s.add_runtime_dependency(%q<multi_json>, [">= 1.3.4"])
       s.add_runtime_dependency(%q<httparty>, [">= 0"])
       s.add_development_dependency(%q<shoulda>, [">= 0"])
       s.add_development_dependency(%q<bundler>, ["~> 1.0.0"])
       s.add_development_dependency(%q<jeweler>, ["~> 1.6.4"])
       s.add_development_dependency(%q<rcov>, [">= 0"])
     else
-      s.add_dependency(%q<multi_json>, [">= 0"])
+      s.add_dependency(%q<multi_json>, [">= 1.3.4"])
       s.add_dependency(%q<httparty>, [">= 0"])
       s.add_dependency(%q<shoulda>, [">= 0"])
       s.add_dependency(%q<bundler>, ["~> 1.0.0"])
@@ -69,7 +69,7 @@ Gem::Specification.new do |s|
       s.add_dependency(%q<rcov>, [">= 0"])
     end
   else
-    s.add_dependency(%q<multi_json>, [">= 0"])
+    s.add_dependency(%q<multi_json>, [">= 1.3.4"])
     s.add_dependency(%q<httparty>, [">= 0"])
     s.add_dependency(%q<shoulda>, [">= 0"])
     s.add_dependency(%q<bundler>, ["~> 1.0.0"])


### PR DESCRIPTION
My app specified multi_json 1.1.0.  Because bugsnag did not require multi_json at a specific version, I would get an error with MultiJson.dump

```
>> Bugsnag.notify(RuntimeError.new("Something broke"))
NoMethodError: undefined method `dump' for MultiJson:Module
    from /Users/jon/.rvm/gems/ree-1.8.7-2012.02/gems/bugsnag-1.1.1/lib/bugsnag/notification.rb:83:in `deliver'
    from /Users/jon/.rvm/gems/ree-1.8.7-2012.02/gems/bugsnag-1.1.1/lib/bugsnag.rb:33:in `notify'
    from (irb):1
```

If I specificed multi_json at 1.3.6, the error worked fine.

MultiJson.dump was introduced at 1.3.4.
