### PR TITLE
fixed cleanup_hash helper method for nested hash

### DIFF
--- a/lib/bugsnag/helpers.rb
+++ b/lib/bugsnag/helpers.rb
@@ -5,7 +5,7 @@ module Bugsnag
     def self.cleanup_hash(hash)
       return nil unless hash
       hash.inject({}) do |h, (k, v)|
-        h[k.to_s.gsub(/\./, "-")] = v.to_s.slice(0, MAX_STRING_LENGTH)
+        h[k.to_s.gsub(/\./, "-")] = v.respond_to?(:to_hash) ? cleanup_hash(v) : v.to_s.slice(0, MAX_STRING_LENGTH)
         h
       end
     end


### PR DESCRIPTION
The cleanup_hash helper method was not working in case of nested hash. 

For example, say, 'number' and 'verification_value' are set for bugsnag params_filters and parameters are - 

{'credit_card' => {'number' => '4111111111111111', 'verification_value' => 123}}

Then Bugsnag logs number and verification values unfiltered.

Thanks
Jiten
