### PR TITLE
specify which exceptions to ignore in greater detail

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,22 +233,24 @@ By default, `params_filters` is set to `["password", "password_confirmation"]`
 ###ignore_classes
 
 Sets for which exception classes we should not send exceptions to bugsnag.com.
+Key is exception class, Value is regex to match for exception message or nil for all.
 
 ```ruby
-config.ignore_classes << "ActiveRecord::StatementInvalid"
+config.ignore_classes.merge! "Net::IMAP::Error" => /^connection closed$/
 ```
 
 By default, `ignore_classes` contains the following classes:
 
 ```ruby
-[
-  "ActiveRecord::RecordNotFound",
-  "ActionController::RoutingError",
-  "ActionController::InvalidAuthenticityToken",
-  "CGI::Session::CookieStore::TamperedWithCookie",
-  "ActionController::UnknownAction",
-  "AbstractController::ActionNotFound"
-]
+{
+  "ActiveRecord::RecordNotFound" => nil,
+  "ActionController::RoutingError" => nil,
+  "ActionController::InvalidAuthenticityToken" => nil,
+  "CGI::Session::CookieStore::TamperedWithCookie" => nil,
+  "ActionController::UnknownAction" => nil,
+  "AbstractController::ActionNotFound" => nil,
+  "Mongoid::Errors::DocumentNotFound" => nil
+}
 ```
 
 ###logger

--- a/lib/bugsnag/configuration.rb
+++ b/lib/bugsnag/configuration.rb
@@ -25,15 +25,15 @@ module Bugsnag
 
     DEFAULT_PARAMS_FILTERS = ["password"].freeze
 
-    DEFAULT_IGNORE_CLASSES = [
-      "ActiveRecord::RecordNotFound",
-      "ActionController::RoutingError",
-      "ActionController::InvalidAuthenticityToken",
-      "CGI::Session::CookieStore::TamperedWithCookie",
-      "ActionController::UnknownAction",
-      "AbstractController::ActionNotFound",
-      "Mongoid::Errors::DocumentNotFound"
-    ].freeze
+    DEFAULT_IGNORE_CLASSES = {
+      "ActiveRecord::RecordNotFound" => nil,
+      "ActionController::RoutingError" => nil,
+      "ActionController::InvalidAuthenticityToken" => nil,
+      "CGI::Session::CookieStore::TamperedWithCookie" => nil,
+      "ActionController::UnknownAction" => nil,
+      "AbstractController::ActionNotFound" => nil,
+      "Mongoid::Errors::DocumentNotFound" => nil
+    }.freeze
 
     def initialize
       # Set up the defaults
@@ -42,7 +42,7 @@ module Bugsnag
       self.auto_notify = true
       self.use_ssl = false
       self.params_filters = Set.new(DEFAULT_PARAMS_FILTERS)
-      self.ignore_classes = Set.new(DEFAULT_IGNORE_CLASSES)
+      self.ignore_classes = DEFAULT_IGNORE_CLASSES.dup
       self.endpoint = DEFAULT_ENDPOINT
 
       # Set up logging

--- a/lib/bugsnag/notification.rb
+++ b/lib/bugsnag/notification.rb
@@ -150,8 +150,15 @@ module Bugsnag
       end
     end
 
+    # Ignore any exceptions whose class names are keys in the ignore_classes Hash and whose message matches the Regex in the value.
+    # If the hash value is nil, ignore all exceptions of that class. 
     def ignore?
-      @configuration.ignore_classes.include?(error_class(@exceptions.last))
+      if @configuration.ignore_classes.has_key?(error_class(@exceptions.last))
+        message_regex = @configuration.ignore_classes[error_class(@exceptions.last)]
+        message_regex.nil? ? true : !!(@exceptions.last.message =~ message_regex)
+      else 
+        false
+      end
     end
 
     def request_data

--- a/spec/notification_spec.rb
+++ b/spec/notification_spec.rb
@@ -285,9 +285,33 @@ describe Bugsnag::Notification do
   end
 
   it "should not notify if the non-default exception class is added to the ignore_classes" do
-    Bugsnag.configuration.ignore_classes << "BugsnagTestException"
+    Bugsnag.configuration.ignore_classes.merge! "BugsnagTestException" => nil
 
     Bugsnag::Notification.should_not_receive(:deliver_exception_payload)
+
+    Bugsnag.notify_or_ignore(BugsnagTestException.new("It crashed"))
+  end
+
+   it "should not notify if the non-default exception class is added to the ignore_classes and nil is passed as the regex" do
+    Bugsnag.configuration.ignore_classes.merge! "BugsnagTestException" => nil
+
+    Bugsnag::Notification.should_not_receive(:deliver_exception_payload)
+
+    Bugsnag.notify_or_ignore(BugsnagTestException.new("It crashed"))
+  end
+  
+  it "should not notify if the non-default exception class is added to the ignore_classes and the message matches the regex" do
+    Bugsnag.configuration.ignore_classes.merge! "BugsnagTestException" => /^It crashed$/
+
+    Bugsnag::Notification.should_not_receive(:deliver_exception_payload)
+
+    Bugsnag.notify_or_ignore(BugsnagTestException.new("It crashed"))
+  end
+
+  it "should notify if the non-default exception class is added to the ignore_classes and the message does not match the regex" do
+    Bugsnag.configuration.ignore_classes.merge! "BugsnagTestException" => /Not found/
+
+    Bugsnag::Notification.should_receive(:deliver_exception_payload)
 
     Bugsnag.notify_or_ignore(BugsnagTestException.new("It crashed"))
   end


### PR DESCRIPTION
Added possibility to ignore exceptions with greater precision by including a regex in the ignore_classes that is matched against the exception.message.

I needed this to ignore certain exceptions and let others through based on the content of exception.message.
