### PR TITLE
Add `ignore_user_agents` configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,18 @@ By default, `ignore_classes` contains the following:
 ]
 ```
 
+###ignore_user_agents
+
+Sets an array of Regexps that can be used to ignore exceptions from
+certain user agents.
+
+```ruby
+config.ignore_user_agents << %r{SomeUserAgent}
+```
+
+By default, `ignore_user_agents` is empty, so exceptions caused by all
+user agents are reported.
+
 ###logger
 
 Sets which logger to use for Bugsnag log messages. In rails apps, this is

--- a/lib/bugsnag/configuration.rb
+++ b/lib/bugsnag/configuration.rb
@@ -13,6 +13,7 @@ module Bugsnag
     attr_accessor :app_version
     attr_accessor :params_filters
     attr_accessor :ignore_classes
+    attr_accessor :ignore_user_agents
     attr_accessor :endpoint
     attr_accessor :logger
     attr_accessor :middleware
@@ -35,6 +36,8 @@ module Bugsnag
       "Mongoid::Errors::DocumentNotFound"
     ].freeze
 
+    DEFAULT_IGNORE_USER_AGENTS = [].freeze
+
     def initialize
       # Set up the defaults
       self.release_stage = nil
@@ -43,6 +46,7 @@ module Bugsnag
       self.use_ssl = false
       self.params_filters = Set.new(DEFAULT_PARAMS_FILTERS)
       self.ignore_classes = Set.new(DEFAULT_IGNORE_CLASSES)
+      self.ignore_user_agents = Set.new(DEFAULT_IGNORE_USER_AGENTS)
       self.endpoint = DEFAULT_ENDPOINT
 
       # Set up logging

--- a/spec/notification_spec.rb
+++ b/spec/notification_spec.rb
@@ -390,6 +390,14 @@ describe Bugsnag::Notification do
     Bugsnag.notify_or_ignore(BugsnagTestException.new("It crashed"))
   end
 
+  it "should not notify if the user agent is present and matches a regex in ignore_user_agents" do
+    Bugsnag.configuration.ignore_user_agents << %r{BugsnagUserAgent}
+
+    Bugsnag::Notification.should_not_receive(:deliver_exception_payload)
+
+    Bugsnag.notify_or_ignore(BugsnagTestException.new("It crashed"), :request => { :userAgent => "BugsnagUserAgent" })
+  end
+
   it "should not unwrap the same exception twice" do
     Bugsnag::Notification.should_receive(:deliver_exception_payload) do |endpoint, payload|
       event = get_event_from_payload(payload)


### PR DESCRIPTION
This allows users to specify an array of Regexps to ignore specified user agents, which we found helpful because of certain badly-written crawlers scraping our site with mangled query params.

I wasn't totally happy with the extra call to `Notification#generate_meta_data`, duplicating the one in the `#deliver` method, but it seemed preferable to checking both the `@meta_data` and `@overrides` ivars for the same thing, and I didn't want to do more extensive messing about. What do you think?

Cheers,
Simon
