### PR TITLE
bug using bugsnag with rake resque:work

### DIFF
--- a/lib/bugsnag/rake.rb
+++ b/lib/bugsnag/rake.rb
@@ -24,7 +24,7 @@ module Bugsnag::Rake
             notif.context ||= task.name
           }
 
-          yield
+          yield if block_given?
         rescue Exception => e
           Bugsnag.notify(e)
           raise


### PR DESCRIPTION
Somewhere inside of resque/tasks there's something that doesn't work with bugsnag unless bugsnag can tolerate rake tasks without a block to yield to.
