### PR TITLE
Request params with nil values are stripped from the notification

### DIFF
--- a/spec/notification_spec.rb
+++ b/spec/notification_spec.rb
@@ -368,6 +368,18 @@ describe Bugsnag::Notification do
     Bugsnag.notify(BugsnagTestException.new("It crashed"), {:request => {:params => {:password => "1234", :other_password => "123456", :other_data => "123456"}}})
   end
 
+  it "should not filter params from payload hashes if their values are nil" do
+    Bugsnag::Notification.should_receive(:deliver_exception_payload) do |endpoint, payload|
+      event = get_event_from_payload(payload)
+      event[:metaData].should_not be_nil
+      event[:metaData][:request].should_not be_nil
+      event[:metaData][:request][:params].should_not be_nil
+      event[:metaData][:request][:params].should have_key(:nil_param)
+    end
+
+    Bugsnag.notify(BugsnagTestException.new("It crashed"), {:request => {:params => {:nil_param => nil}}})
+  end
+
   it "should not notify if the exception class is in the default ignore_classes list" do
     Bugsnag::Notification.should_not_receive(:deliver_exception_payload)
 


### PR DESCRIPTION
Hi,

We've been trying to debug a couple of confusing exceptions this morning, and it turned out part of the confusion was due to Bugsnag removing any request params with nil values from the notification before sending. This is due to `Bugsnag::Helpers.cleanup_obj` being called on the metadata hash.

As nil params can still have an effect (passing nil to a Rails nested attributes setter was the specific problem we had), stripping these params out completely makes debugging a bit tricky...

Cheers,
Simon

edit: this is compounded since Rails started deliberately parsing JSON incorrectly to avoid an ActiveRecord injection vulnerability, converting empty JSON arrays into nil: https://github.com/rails/rails/issues/8832
