### PR TITLE
Ability to set a custom, per request user_id

### DIFF
--- a/lib/bugsnag/middleware/rack_request.rb
+++ b/lib/bugsnag/middleware/rack_request.rb
@@ -16,7 +16,7 @@ module Bugsnag::Middleware
         notification.context = "#{request.request_method} #{request.path}"
 
         # Set a sensible default for user_id
-        notification.user_id = request.ip
+        notification.user_id ||= request.ip
 
         # Build the clean url (hide the port if it is obvious)
         url = "#{request.scheme}://#{request.host}"


### PR DESCRIPTION
Prevent notification.user_id from being overridden when set from a before_bugsnag_notify method in a controller
