### PR TITLE
Use BUGSNAG_API_KEY by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ How to Install
     end
     ```
 
+    If you don't configure the api_key, the Bugsnag module will read the `BUGSNAG_API_KEY`
+    environment variable.
+
 4.  **Rack/Sinatra apps only**: Activate the Bugsnag Rack middleware
 
     ```ruby

--- a/lib/bugsnag/configuration.rb
+++ b/lib/bugsnag/configuration.rb
@@ -49,6 +49,9 @@ module Bugsnag
       self.ignore_user_agents = Set.new(DEFAULT_IGNORE_USER_AGENTS)
       self.endpoint = DEFAULT_ENDPOINT
 
+      # Read the API key from the environment
+      self.api_key = ENV["BUGSNAG_API_KEY"]
+
       # Set up logging
       self.logger = Logger.new(STDOUT)
       self.logger.level = Logger::WARN


### PR DESCRIPTION
This will make it possible for the gem to "just work"™ when it's installed as part of the heroku addon.
