### PR TITLE
Infinite loop on notifying with self-referential context

### DIFF
--- a/lib/bugsnag/helpers.rb
+++ b/lib/bugsnag/helpers.rb
@@ -10,8 +10,10 @@ module Bugsnag
   module Helpers
     MAX_STRING_LENGTH = 4096
 
-    def self.cleanup_obj(obj, filters = nil)
+    def self.cleanup_obj(obj, filters = nil, seen={})
       return nil unless obj
+      return "[RECURSION]" if seen[obj]
+      seen[obj] = true
 
       if obj.is_a?(Hash)
         clean_hash = {}
@@ -19,13 +21,13 @@ module Bugsnag
           if filters && filters.any? {|f| k.to_s.include?(f.to_s)}
             clean_hash[k] = "[FILTERED]"
           else
-            clean_obj = cleanup_obj(v, filters)
+            clean_obj = cleanup_obj(v, filters, seen)
             clean_hash[k] = clean_obj
           end
         end
         clean_hash
       elsif obj.is_a?(Array) || obj.is_a?(Set)
-        obj.map { |el| cleanup_obj(el, filters) }.compact
+        obj.map { |el| cleanup_obj(el, filters, seen) }.compact
       elsif obj.is_a?(Integer) || obj.is_a?(Float) || obj.is_a?(String)
         obj
       else

--- a/spec/helper_spec.rb
+++ b/spec/helper_spec.rb
@@ -1,6 +1,12 @@
 require 'spec_helper'
 
 describe Bugsnag::Helpers do
+  it "should be able to clean up recursive objects" do
+    a = {:a => {}}
+    a[:a][:b] = a
+    Bugsnag::Helpers.cleanup_obj(a).should == {:a => {:b => "[RECURSION]"}}
+  end
+
   it "should reduce hash size correctly" do
     meta_data = {
       :key_one => "this should not be truncated",


### PR DESCRIPTION
Sent this in an email as well but just thought I'd open an issue for it - if you try to notify with a context that refers to itself then the bugsnag gem goes into an infinite loop:

```
Loading development environment (Rails 3.2.13)
1.9.1 :001 > context = {}
 => {}
1.9.1 :002 > context[:key] = context
 => {:key=>{...}}
1.9.1 :003 > Bugsnag.notify(StandardError.new, context)
SystemStackError: stack level too deep
        from /home/arkadiy/.rvm/rubies/ruby-1.9.3-p448/lib/ruby/1.9.1/irb/workspace.rb:80
Maybe IRB bug!
1.9.1 :004 >
```
