### PR TITLE
Support active record transaction error notification.

### DIFF
--- a/lib/bugsnag/rails.rb
+++ b/lib/bugsnag/rails.rb
@@ -4,6 +4,7 @@
 require "bugsnag"
 require "bugsnag/rails/controller_methods"
 require "bugsnag/rails/action_controller_rescue"
+require "bugsnag/rails/active_record_rescue"
 require "bugsnag/middleware/rails2_request"
 require "bugsnag/middleware/callbacks"
 
@@ -13,6 +14,9 @@ module Bugsnag
       if defined?(ActionController::Base)
         ActionController::Base.send(:include, Bugsnag::Rails::ActionControllerRescue)
         ActionController::Base.send(:include, Bugsnag::Rails::ControllerMethods)
+      end
+      if defined?(ActiveRecord::Base)
+        ActiveRecord::Base.send(:include, Bugsnag::Rails::ActiveRecordRescue)
       end
 
       # Try to find where to log to

--- a/lib/bugsnag/rails/active_record_rescue.rb
+++ b/lib/bugsnag/rails/active_record_rescue.rb
@@ -1,0 +1,18 @@
+module Bugsnag::Rails
+  module ActiveRecordRescue
+    def run_callbacks(kind, *args, &block)
+      if %w(commit rollback).include?(kind.to_s)
+        begin
+          super
+        rescue StandardError => exception
+          # This exception will NOT be escalated, so notify it here.
+          Bugsnag.auto_notify(exception)
+          raise
+        end
+      else
+        # Let the post process handle the exception
+        super
+      end
+    end
+  end
+end

--- a/lib/bugsnag/railtie.rb
+++ b/lib/bugsnag/railtie.rb
@@ -31,6 +31,10 @@ module Bugsnag
         require "bugsnag/rails/controller_methods"
         ::ActionController::Base.send(:include, Bugsnag::Rails::ControllerMethods)
       end
+      if defined?(ActiveRecord::Base)
+        require "bugsnag/rails/active_record_rescue"
+        ActiveRecord::Base.send(:include, Bugsnag::Rails::ActiveRecordRescue)
+      end
     end
 
     initializer "bugsnag.use_rack_middleware" do |app|


### PR DESCRIPTION
Hi,

I found Bugsnag can't notify exceptions in after_commit and after_rollback because it doesn't escalate any exception. Although there were lots of exception thrown in the after_commit callbacks, but I didn't know them because I had relied on Bugsnag too much and hadn't checked the error log.
I know this is very rare case, but I think it is better if Bugsnag handles this kind of situation. What do you think?
