### PR TITLE
Add timeout_time configuration setting.

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,13 @@ you can set the `release_stage` that is reported to Bugsnag.
 config.release_stage = "development"
 ```
 
+By default the timeout time is 5 seconds. To increase the timout time of the bugsnag
+notify call you can set the `timeout_time` to an integer value.
+
+```ruby
+config.timeout_time = 10
+```
+
 In rails apps this value is automatically set from `RAILS_ENV`, and in rack
 apps it is automatically set to `RACK_ENV`. Otherwise the default is
 "production".

--- a/lib/bugsnag/configuration.rb
+++ b/lib/bugsnag/configuration.rb
@@ -23,6 +23,7 @@ module Bugsnag
     attr_accessor :proxy_port
     attr_accessor :proxy_user
     attr_accessor :proxy_password
+    attr_accessor :timeout_time
 
     THREAD_LOCAL_NAME = "bugsnag_req_data"
 
@@ -50,6 +51,7 @@ module Bugsnag
       self.ignore_classes = Set.new(DEFAULT_IGNORE_CLASSES)
       self.ignore_user_agents = Set.new(DEFAULT_IGNORE_USER_AGENTS)
       self.endpoint = DEFAULT_ENDPOINT
+      self.timeout_time = 5
 
       # Read the API key from the environment
       self.api_key = ENV["BUGSNAG_API_KEY"]

--- a/lib/bugsnag/notification.rb
+++ b/lib/bugsnag/notification.rb
@@ -81,6 +81,7 @@ module Bugsnag
       end
 
       self.class.http_proxy configuration.proxy_host, configuration.proxy_port, configuration.proxy_user, configuration.proxy_password if configuration.proxy_host
+      self.class.default_timeout @configuration.timeout_time if configuration.timeout_time
     end
 
     # Add a single value as custom data, to this notification

--- a/spec/notification_spec.rb
+++ b/spec/notification_spec.rb
@@ -574,4 +574,17 @@ describe Bugsnag::Notification do
 
     Bugsnag.notify("test message")
   end
+
+  it "should set the timeout time to the value in the configuration" do |*args|
+    Bugsnag.configure do |config|
+      config.timeout_time = 10
+    end
+
+    Bugsnag::Notification.should_receive(:default_timeout) do |*args|
+      args.length.should be == 1
+      args[0].should be == 10
+    end
+
+    Bugsnag.notify("test message")
+  end
 end


### PR DESCRIPTION
We've noticed in some of our environments that the default 5 second timeout time is too short.
For a lot of people 5 seconds is fine, but it would be great to change this. 

So I added a config setting of `timeout_time`.

Set this using `config.timeout_time = 10` (or any integer value)
