### PR TITLE
Capistrano v3 implementation for bugnsag:deploy (that works!)

### DIFF
--- a/lib/bugsnag/tasks/bugsnag.cap
+++ b/lib/bugsnag/tasks/bugsnag.cap
@@ -27,7 +27,7 @@ namespace :bugsnag do
     on primary(:app) do
       ALLOWED_ENV_SETTINGS = %w{BUGSNAG_RELEASE_STAGE BUGSNAG_REPOSITORY BUGSNAG_REVISION BUGSNAG_BRANCH BUGSNAG_API_KEY BUGSNAG_APP_VERSION}
 
-      rails_env    = fetch(:rails_env, 'production')
+      rails_env    = fetch(:rails_env) || fetch(:stage)
       bugsnag_env  = fetch(:bugsnag_env, rails_env)
 
       # Build the new environment to pass through to rake


### PR DESCRIPTION
The implementation in #64 (https://github.com/bugsnag/bugsnag-ruby/blob/master/lib/bugsnag/tasks/bugsnag.cap) seems to be a dud. There's no way `bugsnag:deploy` ever gets loaded and the commands are not Capistrano v3 compatible.

Here's a basic working implementation using the new v3 defaults and conventions.
