### PR TITLE
Allow groupingHash setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -470,6 +470,17 @@ rescue => e
 end
 ```
 
+### Grouping hash
+
+If you want to override Bugsnag's grouping algorithm, you can specify a grouping hash key as a parameter to `Bugsnag.notify`:
+
+```ruby
+rescue => e
+  Bugsnag.notify e, grouping_hash: "this-is-my-grouping-hash"
+end
+```
+
+All errors with the same groupingHash will be grouped together within the bugsnag dashboard.
 
 Deploy Tracking
 ---------------

--- a/lib/bugsnag/notification.rb
+++ b/lib/bugsnag/notification.rb
@@ -59,6 +59,11 @@ module Bugsnag
       self.severity = @overrides[:severity]
       @overrides.delete :severity
 
+      if @overrides.key? :grouping_hash
+        self.grouping_hash = @overrides[:grouping_hash]
+        @overrides.delete :grouping_hash
+      end
+
       if @overrides.key? :api_key
         self.api_key = @overrides[:api_key]
         @overrides.delete :api_key
@@ -143,6 +148,14 @@ module Bugsnag
       @severity || "error"
     end
 
+    def grouping_hash=(grouping_hash)
+      @grouping_hash = grouping_hash
+    end
+
+    def grouping_hash
+      @grouping_hash || nil
+    end
+
     def api_key=(api_key)
       @api_key = api_key
     end
@@ -183,7 +196,7 @@ module Bugsnag
           end
         end
 
-        [:user_id, :context, :user].each do |symbol|
+        [:user_id, :context, :user, :grouping_hash].each do |symbol|
           if @overrides[symbol]
             self.send("#{symbol}=", @overrides[symbol])
             @overrides.delete symbol
@@ -205,6 +218,7 @@ module Bugsnag
           :user => @user,
           :exceptions => exception_list,
           :severity => self.severity,
+          :groupingHash => self.grouping_hash,
           :metaData => Bugsnag::Helpers.cleanup_obj(generate_meta_data(@exceptions, @overrides), @configuration.params_filters)
         }.reject {|k,v| v.nil? }
 

--- a/spec/notification_spec.rb
+++ b/spec/notification_spec.rb
@@ -48,6 +48,15 @@ describe Bugsnag::Notification do
     Bugsnag.notify(BugsnagTestException.new("It crashed"), :api_key => "9d84383f9be2ca94902e45c756a9979d")
   end
 
+  it "should let you override the groupingHash" do
+    Bugsnag::Notification.should_receive(:deliver_exception_payload) do |endpoint, payload|
+      event = get_event_from_payload(payload)
+      event[:groupingHash].should be == "this is my grouping hash"
+    end
+
+    Bugsnag.notify(BugsnagTestException.new("It crashed"), {:grouping_hash => "this is my grouping hash"})
+  end
+
   it "should use the env variable apiKey" do
     ENV["BUGSNAG_API_KEY"] = "c9d60ae4c7e70c4b6c4ebd3e8056d2b9"
 


### PR DESCRIPTION
Let the user override  Bugsnag's grouping algorithm by specifying a
grouping hash as a parameter.
