### PR TITLE
Drops Ruby 1.8 support from build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,6 @@ rvm:
   - 1.9.3
   - jruby-19mode
 
-# Workaround for broken bundler on travis CI - https://github.com/bundler/bundler/issues/2784
-before_install:
-  - gem update --system 2.1.11
-  - gem --version
-
 notifications:
   hipchat:
     secure: "OLw2B1ggBDSeyJYgnZ2Ezf2fXbu5BHWSNFEJF38+TB4hYv+Wp3rElROhnyP6IttftLYz68Q8n9SjEUXTX9zXwTNt2fGBHIDwLnjt1uw7BrIOIHCUheOJdPheV2XxdJv9yem5MQ0vF+y33auLpyrA53b+nCbI5UsCXKISLe+C8ME="


### PR DESCRIPTION
It's about time. #justsaying.
Weird errors in Travis. (See: #86).
Besides, `rake` which your project depends on, it's no longer running on 1.8, so you either have to specify an older version, or well, do what the title suggests.
