### PR TITLE
Bug introduced in gem version v1.8.7 - not requiring initializer file in bugsnag.rake

### DIFF
--- a/lib/bugsnag/tasks/bugsnag.rake
+++ b/lib/bugsnag/tasks/bugsnag.rake
@@ -21,7 +21,7 @@ namespace :bugsnag do
 
       # TODO: more reliable ways to infer this are needed
       path = defined?(Rails.root) ? Rails.root : Pathname.pwd
-      initializer = path + 'config/initializers/bugsnag'
+      initializer = path + 'config/initializers/bugsnag.rb'
       if File.exist?(initializer)
         require initializer
       else


### PR DESCRIPTION
This changeset https://github.com/bugsnag/bugsnag-ruby/compare/v1.8.6...v1.8.7#diff-1c05e1f13d0e55fa0c085142816b0d69R23 broke requiring the initializer file for config values (e.g. api_key)

`File.exist?` needs the file extension.
