### PR TITLE
Load environment for deploy task

### DIFF
--- a/lib/bugsnag/tasks/bugsnag.rake
+++ b/lib/bugsnag/tasks/bugsnag.rake
@@ -2,7 +2,7 @@ require "bugsnag"
 
 namespace :bugsnag do
   desc "Notify Bugsnag of a new deploy."
-  task :deploy do
+  task :deploy => :load do
     api_key = ENV["BUGSNAG_API_KEY"]
     release_stage = ENV["BUGSNAG_RELEASE_STAGE"]
     app_version = ENV["BUGSNAG_APP_VERSION"]


### PR DESCRIPTION
This provides an alternative mechanism to the currently supported
environment variables to set options such as API key, and also allows
setting other options through the standard `config/bugsnag.yml` file
that were not previously available, i.e. endpoint and proxy.

I realize that this may be controversial since it increases the overhead of the deploy task... however, this does restore behavior that worked prior to the 2.0 release of the gem (e.g. previously, you could configure http proxy in a `bugsnag.yml` file or initializer and have that picked up by the deploy task).
