### PR TITLE
Add job detail for delayed_job

### DIFF
--- a/lib/bugsnag/delayed_job.rb
+++ b/lib/bugsnag/delayed_job.rb
@@ -13,7 +13,31 @@ unless defined? Delayed::Plugins::Bugsnag
       class Bugsnag < Plugin
         module Notify
           def error(job, error)
-            ::Bugsnag.auto_notify(error)
+            overrides = {
+              :job => {
+                :class => job.class.name,
+                :id => job.id,
+              }
+            }
+            if payload = job.payload_object
+              p = {
+                :class => payload.class.name,
+              }
+              p[:id]           = payload.id           if payload.respond_to?(:id)
+              p[:display_name] = payload.display_name if payload.respond_to?(:display_name)
+              p[:method_name]  = payload.method_name  if payload.respond_to?(:method_name)
+              p[:args]         = payload.args         if payload.respond_to?(:args)
+              if payload.is_a?(::Delayed::PerformableMethod) && (object = payload.object)
+                p[:object] = {
+                  :class => object.class.name,
+                }
+                p[:object][:id] = object.id if object.respond_to?(:id)
+              end
+              overrides[:job][:payload] = p
+            end
+
+            ::Bugsnag.auto_notify(error, overrides)
+
             super if defined?(super)
           end
         end


### PR DESCRIPTION
Hi bugsnag-team,

I added job detail into bugsnag notification for delayed_job errors. Could you consider to merge this improvement?
The job payloads are variable and might not have necessary methods, so I add very redundant conditions to make sure the method existence.
## PerformableMethod

![screen shot 2014-06-19 at 9 45 04 pm](https://cloud.githubusercontent.com/assets/1162120/3327475/ca91f2ba-f7af-11e3-8c9b-8819b37f5b5a.png)
## PerformableMailer

![screen shot 2014-06-19 at 9 51 52 pm](https://cloud.githubusercontent.com/assets/1162120/3327516/8134c948-f7b0-11e3-9bee-fb673226469a.png)
## Your Custom Job

![screen shot 2014-06-19 at 9 45 42 pm](https://cloud.githubusercontent.com/assets/1162120/3327485/ee376876-f7af-11e3-835c-22e101acd0f6.png)
