### PR TITLE
Fix for delayed_job loading

### DIFF
--- a/lib/bugsnag/delayed_job.rb
+++ b/lib/bugsnag/delayed_job.rb
@@ -1,7 +1,7 @@
 require 'delayed_job'
 
 # See Issue #99
-unless defined?(Delayed::Plugins::Plugin)
+unless defined?(Delayed::Plugin)
   raise LoadError, "bugsnag requires delayed_job > 3.x"
 end
 


### PR DESCRIPTION
Hi bugsnag-team,

`Delayed::Job` does not have `Delayed::Plugins::Plugin`. The `Plugin` class inherited in official [clear_locks](https://github.com/collectiveidea/delayed_job/blob/v3.0.0/lib/delayed/plugins/clear_locks.rb) plugin is `Delayed::Plugin`.

Could you fix this issue?

https://github.com/collectiveidea/delayed_job/blob/v3.0.0/lib/delayed/plugin.rb
https://github.com/collectiveidea/delayed_job/blob/v4.0.0/lib/delayed/plugin.rb
