### PR TITLE
Ignore exception if its ancestor is an ignored class.

### DIFF
--- a/lib/bugsnag/notification.rb
+++ b/lib/bugsnag/notification.rb
@@ -270,8 +270,11 @@ module Bugsnag
 
     def ignore_exception_class?
       ex = @exceptions.last
+      ex_name = error_class(ex)
+      ancestor_chain = ex.class.ancestors.select { |ancestor| ancestor.is_a?(Class) }.map { |ancestor| error_class(ancestor) }.to_set
+
       @configuration.ignore_classes.any? do |to_ignore|
-        to_ignore.is_a?(Proc) ? to_ignore.call(ex) : to_ignore == error_class(ex)
+        to_ignore.is_a?(Proc) ? to_ignore.call(ex) : ancestor_chain.include?(to_ignore)
       end
     end
 

--- a/spec/notification_spec.rb
+++ b/spec/notification_spec.rb
@@ -6,6 +6,7 @@ require 'ostruct'
 module ActiveRecord; class RecordNotFound < RuntimeError; end; end
 class NestedException < StandardError; attr_accessor :original_exception; end
 class BugsnagTestExceptionWithMetaData < Exception; include Bugsnag::MetaData; end
+class BugsnagSubclassTestException < BugsnagTestException; end
 
 class Ruby21Exception < RuntimeError
   attr_accessor :cause
@@ -491,6 +492,14 @@ describe Bugsnag::Notification do
     expect(Bugsnag::Notification).not_to receive(:deliver_exception_payload)
 
     Bugsnag.notify_or_ignore(BugsnagTestException.new("It crashed"))
+  end
+
+  it "does not notify if exception's ancestor is an ignored class" do
+    Bugsnag.configuration.ignore_classes << "BugsnagTestException"
+
+    expect(Bugsnag::Notification).not_to receive(:deliver_exception_payload)
+
+    Bugsnag.notify_or_ignore(BugsnagSubclassTestException.new("It crashed"))
   end
 
   it "does not notify if the exception is matched by an ignore_classes lambda function" do


### PR DESCRIPTION
When I add an ignored class, my expectation is that all subclasses
will be equally ignored. This makes it easy, for example, to ignore
all 4xx code HTTP response exceptions by specifying one generic
superclass.
