### PR TITLE
Accept both String and Class instances as an ignored class.

### DIFF
--- a/lib/bugsnag/configuration.rb
+++ b/lib/bugsnag/configuration.rb
@@ -14,7 +14,6 @@ module Bugsnag
     attr_accessor :app_version
     attr_accessor :app_type
     attr_accessor :params_filters
-    attr_accessor :ignore_classes
     attr_accessor :ignore_user_agents
     attr_accessor :endpoint
     attr_accessor :logger
@@ -27,6 +26,8 @@ module Bugsnag
     attr_accessor :proxy_password
     attr_accessor :timeout
     attr_accessor :hostname
+
+    attr_writer :ignore_classes
 
     THREAD_LOCAL_NAME = "bugsnag_req_data"
 
@@ -66,6 +67,11 @@ module Bugsnag
       # Configure the bugsnag middleware stack
       self.middleware = Bugsnag::MiddlewareStack.new
       self.middleware.use Bugsnag::Middleware::Callbacks
+    end
+
+    # Accept both String and Class instances as an ignored class
+    def ignore_classes
+      @ignore_classes.map! { |klass| klass.is_a?(Class) ? klass.name : klass }
     end
 
     def should_notify?

--- a/spec/notification_spec.rb
+++ b/spec/notification_spec.rb
@@ -502,8 +502,8 @@ describe Bugsnag::Notification do
     Bugsnag.notify_or_ignore(BugsnagSubclassTestException.new("It crashed"))
   end
 
-  it "does not notify if the exception is matched by an ignore_classes lambda function" do
-    Bugsnag.configuration.ignore_classes << lambda {|e| e.message =~ /crashed/}
+  it "accepts both String and Class instances as an ignored class" do
+    Bugsnag.configuration.ignore_classes << BugsnagTestException
 
     expect(Bugsnag::Notification).not_to receive(:deliver_exception_payload)
 


### PR DESCRIPTION
If we accept actual Classes, developers can avoid typo-related
bugs if they so desire, e.g.:

``` ruby
configuration.ignore_classes << "NotFoundEror"
 # => didn't catch a typo, sadface

configuration.ignore_classes << NotFoundEror
 # => Ruby will complain it can't find a constant
```
