### PR TITLE
Notification: be more concrete in what file to skip

### DIFF
--- a/lib/bugsnag/notification.rb
+++ b/lib/bugsnag/notification.rb
@@ -367,7 +367,7 @@ module Bugsnag
         # Parse the stacktrace line
 
         # Skip stacktrace lines inside lib/bugsnag
-        next(nil) if file.nil? || file =~ %r{lib/bugsnag}
+        next(nil) if file.nil? || file =~ %r{lib/bugsnag(/|\.rb)}
 
         # Expand relative paths
         p = Pathname.new(file)


### PR DESCRIPTION
The old regexp skips even files unrelated to the Bugsnag Ruby project.
Namely, it was skipping stack traces for my bugsnag-demo project.
The new regexp ensures that it skips only Bugsnag Ruby files.
