### PR TITLE
Eliminate allocations in run_callbacks

### DIFF
--- a/lib/bugsnag/rails/active_record_rescue.rb
+++ b/lib/bugsnag/rails/active_record_rescue.rb
@@ -3,7 +3,7 @@ module Bugsnag::Rails
     KINDS = [:commit, :rollback].freeze
 
     def run_callbacks(kind, *args, &block)
-      if kinds.include?(kind)
+      if KINDS.include?(kind)
         begin
           super
         rescue StandardError => exception


### PR DESCRIPTION
If there are a large number of models running callbacks, which is
possible multiple nested levels of autosave assocations, the short-lived
objects in this method can introduce non-negligible GC pressure.

As far as I know, kind will always be a symbol, so the to_s conversion
is unnecessary.

We can also pull the array to a constant which is allocated once, ever,
instead of once per model/request.
