### PR TITLE
lib/bugsnag/middleware/rack_request: early load session for Rails 4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+??????
+------
+
+-   Fix Rails 4 sessions appearing in Custom tab instead of its own ([144](https://github.com/bugsnag/bugsnag-ruby/issues/144))
+
 2.4.0
 -----
 -   Allow filters to be regular expressions (thanks @tamird)

--- a/lib/bugsnag/middleware/rack_request.rb
+++ b/lib/bugsnag/middleware/rack_request.rb
@@ -39,7 +39,15 @@ module Bugsnag::Middleware
         notification.add_tab(:environment, env)
 
         # Add a session tab
-        notification.add_tab(:session, session) if session
+        if session
+          if session.is_a?(Hash)
+            # Rails 3
+            notification.add_tab(:session, session)
+          elsif session.respond_to?(:to_hash)
+            # Rails 4
+            notification.add_tab(:session, session.to_hash)
+          end
+        end
 
         # Add a cookies tab
         cookies = request.cookies


### PR DESCRIPTION
Fixes #144 (Rails 4 sessions appear in custom tab)

Context: https://github.com/rails/rails/issues/10813
