### PR TITLE
Implement and use the XForwardedFor middleware for user_id

### DIFF
--- a/lib/bugsnag/middleware/x_forwarded_for.rb
+++ b/lib/bugsnag/middleware/x_forwarded_for.rb
@@ -1,0 +1,14 @@
+module Bugsnag::Middleware
+  class XForwardedFor
+    def initialize(bugsnag)
+      @bugsnag = bugsnag
+    end
+
+    def call(notification)
+      if notification.user_id
+        notification.headers['X-Forwarded-For'] = notification.user[:id]
+      end
+      @bugsnag.call(notification)
+    end
+  end
+end


### PR DESCRIPTION
Fixes #143 (Use X-Forwarded-For for user id)

This commit also exposes a new API. We can now pass headers to HTTParty.
