### PR TITLE
Rescue Exception instead of StandardError

### DIFF
--- a/lib/bugsnag/mailman.rb
+++ b/lib/bugsnag/mailman.rb
@@ -9,7 +9,7 @@ module Bugsnag
         }
 
         yield
-      rescue Exception => ex
+      rescue => ex
         raise ex if [Interrupt, SystemExit, SignalException].include? ex.class
         Bugsnag.auto_notify(ex)
         raise

--- a/lib/bugsnag/middleware_stack.rb
+++ b/lib/bugsnag/middleware_stack.rb
@@ -62,7 +62,7 @@ module Bugsnag
       begin
         # We reverse them, so we can call "call" on the first middleware
         middleware_procs.reverse.inject(notify_lambda) { |n,e| e.call(n) }.call(notification)
-      rescue StandardError => e
+      rescue => e
         # KLUDGE: Since we don't re-raise middleware exceptions, this breaks rspec
         raise if e.class.to_s == "RSpec::Expectations::ExpectationNotMetError"
 

--- a/lib/bugsnag/notification.rb
+++ b/lib/bugsnag/notification.rb
@@ -48,7 +48,7 @@ module Bugsnag
 
           do_post(endpoint, payload_string)
 
-        rescue StandardError => e
+        rescue => e
           # KLUDGE: Since we don't re-raise http exceptions, this breaks rspec
           raise if e.class.to_s == "RSpec::Expectations::ExpectationNotMetError"
 
@@ -63,7 +63,7 @@ module Bugsnag
           begin
             response = post(endpoint, {:body => payload_string})
             Bugsnag.debug("Notification to #{endpoint} finished, response was #{response.code}, payload was #{payload_string}")
-          rescue StandardError => e
+          rescue => e
             Bugsnag.warn("Notification to #{endpoint} failed, #{e.inspect}")
             Bugsnag.warn(e.backtrace)
           end

--- a/lib/bugsnag/rack.rb
+++ b/lib/bugsnag/rack.rb
@@ -34,7 +34,7 @@ module Bugsnag
 
       begin
         response = @app.call(env)
-      rescue Exception => raised
+      rescue => raised
         # Notify bugsnag of rack exceptions
         Bugsnag.auto_notify(raised)
 

--- a/lib/bugsnag/rails/active_record_rescue.rb
+++ b/lib/bugsnag/rails/active_record_rescue.rb
@@ -6,7 +6,7 @@ module Bugsnag::Rails
       if KINDS.include?(kind)
         begin
           super
-        rescue StandardError => exception
+        rescue => exception
           # This exception will NOT be escalated, so notify it here.
           Bugsnag.auto_notify(exception)
           raise

--- a/lib/bugsnag/rake.rb
+++ b/lib/bugsnag/rake.rb
@@ -32,7 +32,7 @@ module Bugsnag::Rake
           Thread.current[:bugsnag_running_task] = task
 
           yield(*block_args) if block_given?
-        rescue Exception => e
+        rescue => e
           Bugsnag.auto_notify(e)
           raise
         ensure

--- a/lib/bugsnag/sidekiq.rb
+++ b/lib/bugsnag/sidekiq.rb
@@ -10,7 +10,7 @@ module Bugsnag
         }
 
         yield
-      rescue Exception => ex
+      rescue => ex
         raise ex if [Interrupt, SystemExit, SignalException].include? ex.class
         Bugsnag.auto_notify(ex)
         raise


### PR DESCRIPTION
Hi,

It seems bugsnag can't report MySQL errors and I found it rescues `Exception` type error, which is not the same as `StandardError`.

http://robots.thoughtbot.com/rescue-standarderror-not-exception

Could you merge this fix?
