### PR TITLE
Rescue Exception instead of StandardError

### DIFF
--- a/lib/bugsnag/middleware_stack.rb
+++ b/lib/bugsnag/middleware_stack.rb
@@ -62,7 +62,7 @@ module Bugsnag
       begin
         # We reverse them, so we can call "call" on the first middleware
         middleware_procs.reverse.inject(notify_lambda) { |n,e| e.call(n) }.call(notification)
-      rescue StandardError => e
+      rescue Exception => e
         # KLUDGE: Since we don't re-raise middleware exceptions, this breaks rspec
         raise if e.class.to_s == "RSpec::Expectations::ExpectationNotMetError"
 

--- a/lib/bugsnag/rails/active_record_rescue.rb
+++ b/lib/bugsnag/rails/active_record_rescue.rb
@@ -6,7 +6,7 @@ module Bugsnag::Rails
       if KINDS.include?(kind)
         begin
           super
-        rescue StandardError => exception
+        rescue Exception => exception
           # This exception will NOT be escalated, so notify it here.
           Bugsnag.auto_notify(exception)
           raise


### PR DESCRIPTION
Apart of [the other PR below](https://github.com/bugsnag/bugsnag-ruby/pull/156), I found some of the plugin of this gem rescue StandardError but Exception. I think we should rescue Exception there.
