### PR TITLE
require 'bugsnag' in rake.rb

### DIFF
--- a/lib/bugsnag/rake.rb
+++ b/lib/bugsnag/rake.rb
@@ -1,3 +1,5 @@
+require 'bugsnag'
+
 Rake::TaskManager.record_task_metadata = true
 
 module Bugsnag::Rake


### PR DESCRIPTION
Requiring 'bugsnag/rake' in a Rakefile will fail with unknown constant Bugsnag if 'bugsnag' hasn't already been required (e.g. by bundler). Adding this require in rake.rb ensures that developers only need to require 'bugsnag/rake' as per the documentation.
