### PR TITLE
Fix release stage

### DIFF
--- a/lib/bugsnag/rails.rb
+++ b/lib/bugsnag/rails.rb
@@ -38,7 +38,13 @@ module Bugsnag
       # Auto-load configuration settings from config/bugsnag.yml if it exists
       config_file = File.join(RAILS_ROOT, "config", "bugsnag.yml")
       config = YAML.load_file(config_file) if File.exists?(config_file)
-      Bugsnag.configure(config[RAILS_ENV] ? config[RAILS_ENV] : config) if config
+      if config
+        if defined?(::Rails.env) && config[::Rails.env.to_s]
+          Bugsnag.configure(config[::Rails.env.to_s])
+        else
+          Bugsnag.configure(config)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Rails does not need to set `RAILS_ENV` to run. In some situations, only `RACK_ENV` exists and `Rails.env` can handle both of the env and return proper env.
I think we should follow the return value of `Rails.env`
