### PR TITLE
Fix parameter filtering in Rails 2.

### DIFF
--- a/bugsnag.gemspec
+++ b/bugsnag.gemspec
@@ -28,7 +28,9 @@ Gem::Specification.new do |s|
     s.add_development_dependency 'rake'
   end
 
-  s.add_development_dependency 'rspec'
+  s.add_development_dependency 'rspec', ">= 3.0.0"
+  s.add_development_dependency 'rspec-its'
+  s.add_development_dependency 'rspec-mocks'
   s.add_development_dependency 'rdoc'
   s.add_development_dependency 'pry'
 end

--- a/lib/bugsnag/rails.rb
+++ b/lib/bugsnag/rails.rb
@@ -2,6 +2,7 @@
 # For Rails 3+ hooks, see railtie.rb
 
 require "bugsnag"
+require "bugsnag/rails/filtered_request"
 require "bugsnag/rails/controller_methods"
 require "bugsnag/rails/action_controller_rescue"
 require "bugsnag/rails/active_record_rescue"

--- a/lib/bugsnag/rails/action_controller_rescue.rb
+++ b/lib/bugsnag/rails/action_controller_rescue.rb
@@ -16,7 +16,7 @@ module Bugsnag::Rails
     private
     def set_bugsnag_request_data
       Bugsnag.clear_request_data
-      Bugsnag.set_request_data(:rails2_request, request)
+      Bugsnag.set_request_data(:rails2_request, Bugsnag::Rails::FilteredRequest.new(self))
     end
 
     def rescue_action_in_public_with_bugsnag(exception)

--- a/lib/bugsnag/rails/filtered_request.rb
+++ b/lib/bugsnag/rails/filtered_request.rb
@@ -1,0 +1,37 @@
+module Bugsnag::Rails
+  class FilteredRequest
+
+    def initialize(controller)
+      @controller = controller
+      @request    = controller.__send__(:request)
+    end
+
+    # Rails 2 does parameter filtering via a dynamically-defined method on the
+    # controller. For this reason, these parameters are not accessible to the
+    # Bugsnag configuration and the filtering must be done while we still have
+    # the controller object.
+    #
+    def parameters
+      @parameters ||= if @controller.respond_to?(:filter_parameters)
+                        @controller.__send__(:filter_parameters, @request.parameters)
+                      else
+                        @request.parameters
+                      end
+    end
+
+    # Delegate everything else to the underlying request object.
+    #
+    def respond_to?(method, include_private = false)
+      @request.respond_to?(method, include_private) || super
+    end
+
+    def method_missing(method, *args, &block)
+      if @request.respond_to?(method)
+        @request.__send__(method, *args, &block)
+      else
+        super
+      end
+    end
+
+  end
+end

--- a/spec/rails_filtered_request_spec.rb
+++ b/spec/rails_filtered_request_spec.rb
@@ -1,0 +1,67 @@
+# Rails 2.x only
+require 'spec_helper'
+require 'bugsnag/rails/filtered_request'
+
+class TestRails2ControllerBase
+  # Simplified implementation of Rails 2 parameter filtering for test purposes.
+  def self.filter_parameter_logging(*filter_words, &block)
+    define_method(:filter_parameters) do |unfiltered_parameters|
+      filtered_parameters = {}
+      unfiltered_parameters.each do |key, value|
+        filtered_parameters[key] = filter_words.include?(key) ? '[FILTERED]' : value
+      end
+      filtered_parameters
+    end
+  end
+end
+
+class UnfilteredTestRails2Controller < TestRails2ControllerBase
+end
+
+class FilteredTestRails2Controller < TestRails2ControllerBase
+  filter_parameter_logging :ssn
+end
+
+describe Bugsnag::Rails::FilteredRequest do
+
+  let(:filtered_request) { described_class.new(controller) }
+  let(:incoming_request) { double("Request", request_attributes) }
+  let(:request_attributes) do
+    {
+      :parameters => request_parameters,
+      :session    => double("Session", :data => {}),
+      :protocol   => "http://",
+      :host       => "example.com",
+      :fullpath   => "http://example.com/test"
+    }
+  end
+  let(:request_parameters) do
+    {
+      :user_id  => 1,
+      :ssn      => "999-99-9999"
+    }
+  end
+  let(:controller) { FilteredTestRails2Controller.new }
+
+  before { allow(controller).to receive(:request).and_return(incoming_request) }
+
+  subject { filtered_request }
+
+  shared_examples_for "other request attributes are delegated" do
+    [:session, :protocol, :host, :fullpath].each do |attr|
+      it { is_expected.to respond_to attr }
+      its(attr) { is_expected.to eq request_attributes[attr] }
+    end
+  end
+
+  its(:parameters) { is_expected.to eq(request_parameters.merge(:ssn => '[FILTERED]')) }
+  it_behaves_like "other request attributes are delegated"
+
+  context "when the controller has no filtering" do
+    let(:controller) { UnfilteredTestRails2Controller.new }
+
+    its(:parameters) { is_expected.to eq(request_parameters) }
+    it_behaves_like "other request attributes are delegated"
+  end
+
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,4 @@
+require 'rspec/its'
 require 'bugsnag'
 
 class BugsnagTestException < RuntimeError; end


### PR DESCRIPTION
Rails 2 does parameter filtering via [a dynamically-defined method on the controller](https://github.com/rails/rails/blob/2-3-stable/actionpack/lib/action_controller/base.rb#L486). For this reason, these parameters are not accessible to the Bugsnag configuration and the filtering must be done while we still have the controller object.

I ran into this issue because I have an old Rails 2 project with custom filtered parameters and I noticed they were being sent to Bugsnag without being filtered out.

This change introduces a `FilteredRequest` class that wraps the request object. When its `#parameters` method is called, it calls the dynamically-generated `#filter_parameters` method on the controller if it exists.
