### PR TITLE
Fix parameter filtering in Rails 2.

### DIFF
--- a/lib/bugsnag/rails/action_controller_rescue.rb
+++ b/lib/bugsnag/rails/action_controller_rescue.rb
@@ -2,6 +2,8 @@
 module Bugsnag::Rails
   module ActionControllerRescue
     def self.included(base)
+      base.extend(ClassMethods)
+
       # Hook into rails exception rescue stack
       base.send(:alias_method, :rescue_action_in_public_without_bugsnag, :rescue_action_in_public)
       base.send(:alias_method, :rescue_action_in_public, :rescue_action_in_public_with_bugsnag)
@@ -30,5 +32,31 @@ module Bugsnag::Rails
 
       rescue_action_locally_without_bugsnag(exception)
     end
+
+    module ClassMethods
+
+      def self.extended(base)
+        base.singleton_class.class_eval do
+          alias_method_chain :filter_parameter_logging, :bugsnag
+        end
+      end
+
+      # Rails 2 does parameter filtering via a controller configuration method
+      # that dynamically defines a method on the controller, so the configured
+      # parameters aren't easily accessible. Intercept these parameters as
+      # they're configured so that the Bugsnag configuration can take them
+      # into account.
+      #
+      def filter_parameter_logging_with_bugsnag(*filter_words, &block)
+        if filter_words.length > 0
+          Bugsnag.configure do |config|
+            # Use the same regular expression that Rails parameter filtering uses.
+            config.params_filters << Regexp.new(filter_words.collect{ |s| s.to_s }.join('|'), true)
+          end
+        end
+        filter_parameter_logging_without_bugsnag(*filter_words, &block)
+      end
+    end
+
   end
 end


### PR DESCRIPTION
Rails 2 does parameter filtering via a controller configuration method that [dynamically defines a method](https://github.com/rails/rails/blob/2-3-stable/actionpack/lib/action_controller/base.rb#L486) on the controller, so the configured parameters aren't easily accessible. Intercept these parameters as they're configured so that the Bugsnag configuration can take them into account.

I ran into this issue because I have an old Rails 2 project with custom filtered parameters and I noticed they were being sent to Bugsnag without being filtered out.

I originally opened #171 to fix this issue but then realized that that fix can be made much simpler. This is the simplified fix.
