### PR TITLE
Fix ThreadQueue for Ruby 1.8

### DIFF
--- a/lib/bugsnag/delivery/thread_queue.rb
+++ b/lib/bugsnag/delivery/thread_queue.rb
@@ -14,7 +14,7 @@ module Bugsnag
           end
 
           # Add delivery to the worker thread
-          queue.push proc { super }
+          queue.push proc { super(url, body) }
 
           # Make sure the worker thread is started
           ensure_worker_thread_started


### PR DESCRIPTION
Implicit argument passing by `super` inside a `proc` doesn't work in Ruby 1.8.

Test case: https://gist.github.com/korny/4f6ea67986d3d5efa462
