### PR TITLE
Add ActiveRecord information

### DIFF
--- a/lib/bugsnag/notification.rb
+++ b/lib/bugsnag/notification.rb
@@ -301,6 +301,9 @@ module Bugsnag
             add_to_meta_data key, value, meta_data
           end
         end
+        if exception.respond_to?(:record) && exception.record.respond_to?(:attributes)
+          add_to_meta_data :active_record, exception.record.attributes, meta_data
+        end
       end
 
       overrides.each do |key, value|


### PR DESCRIPTION
Although we can use `Bugsnag::MetaData`, it is useful if bugsnag automatically detect ActiveRecord related error such as `ActiveRecord::RecordNotSaved` and report the attributes.
https://github.com/rails/rails/blob/5142d5411481c893f817c1431b0869be3745060f/activerecord/lib/active_record/errors.rb#L55
