### PR TITLE
Handle potential symbols as keys in the rack env

### DIFF
--- a/lib/bugsnag/middleware/rack_request.rb
+++ b/lib/bugsnag/middleware/rack_request.rb
@@ -28,7 +28,7 @@ module Bugsnag::Middleware
         headers = {}
 
         env.each_pair do |key, value|
-          if key.start_with?("HTTP_")
+          if key.to_s.start_with?("HTTP_")
             header_key = key[5..-1]
           elsif ["CONTENT_TYPE", "CONTENT_LENGTH"].include?(key)
             header_key = key


### PR DESCRIPTION
I ran into this issue when using the clearance gem for our authentication. 

In the ```rack_request.rb``` it loops thru all key/value pairs in the rack_env. One of the keys we end up having is ```:clearance```, so the String method ```starts_with?``` throws an exception because the key is a symbol, not a String.

Adding a simple ```to_s``` solves the problem.