### PR TITLE
Add logging of Rails request ID

### DIFF
--- a/lib/bugsnag/middleware/rails3_request.rb
+++ b/lib/bugsnag/middleware/rails3_request.rb
@@ -15,6 +15,7 @@ module Bugsnag::Middleware
 
           # Augment the request tab
           notification.add_tab(:request, {
+            :requestId => env["action_dispatch.request_id"],
             :railsAction => "#{params[:controller]}##{params[:action]}",
             :params => params
           })


### PR DESCRIPTION
The request ID was introduced in Rails 3.2 to enable easy tracking of
individual requests in logs. This adds it to the Request tab in bugsnag,
to make tracking down logs for a particular error easier.

The ID is generated by ActionDispatch::RequestId (using either the
`X-Request-Id` header, or `SecureRandom.uuid`).

Note that this is already available on the Environment tab, but it's buried along with everything else, and I believe it deserves to be promoted to the Request tab.