### PR TITLE
Allow for a delivery failure hook

### DIFF
--- a/lib/bugsnag/configuration.rb
+++ b/lib/bugsnag/configuration.rb
@@ -29,6 +29,7 @@ module Bugsnag
     attr_accessor :timeout
     attr_accessor :hostname
     attr_accessor :delivery_method
+    attr_accessor :delivery_failure_proc
 
     attr_writer :ignore_classes
 

--- a/lib/bugsnag/delivery/synchronous.rb
+++ b/lib/bugsnag/delivery/synchronous.rb
@@ -12,6 +12,8 @@ module Bugsnag
             response = request(url, body, configuration)
             Bugsnag.debug("Notification to #{url} finished, response was #{response.code}, payload was #{body}")
           rescue StandardError => e
+            configuration.delivery_failure_proc.call(e) if configuration.delivery_failure_proc
+
             # KLUDGE: Since we don't re-raise http exceptions, this breaks rspec
             raise if e.class.to_s == "RSpec::Expectations::ExpectationNotMetError"
 

--- a/spec/notification_spec.rb
+++ b/spec/notification_spec.rb
@@ -113,6 +113,21 @@ describe Bugsnag::Notification do
     }
   end
 
+  it "triggers failure delivery proc if delivery errors out" do
+    error = StandardError.new
+    allow(Bugsnag).to receive(:debug).and_raise(error)
+
+    calls = []
+    Bugsnag.configure do |config|
+      config.delivery_method = :synchronous
+      config.delivery_failure_proc = ->(e) { calls << e }
+    end
+
+    Bugsnag.notify(BugsnagTestException.new("It crashed"))
+
+    expect(calls).to eq([error])
+  end
+
   # TODO: nested context
 
   it "accepts tabs in overrides and adds them to metaData" do


### PR DESCRIPTION
We want to hook into when synchronous delivery fails