### PR TITLE
Support whitespace in Heroku config vars

### DIFF
--- a/lib/bugsnag/tasks/bugsnag.rake
+++ b/lib/bugsnag/tasks/bugsnag.rake
@@ -47,7 +47,7 @@ namespace :bugsnag do
       # Fetch heroku config settings
       config_command = "heroku config --shell"
       config_command += " --app #{ENV["HEROKU_APP"]}" if ENV["HEROKU_APP"]
-      heroku_env = run_command.call(config_command).split.each_with_object({}) do |c, obj|
+      heroku_env = run_command.call(config_command).split(/[\n\r]/).each_with_object({}) do |c, obj|
         k,v = c.split("=")
         obj[k] = v.strip.empty? ? nil : v
       end


### PR DESCRIPTION
A config var like "VAR=with space" incorrectly yields two lines:
"VAR=with" and "space". Because the latter doesn't contain an equal
sign v in the block equals nil. This results in NoMethodError raised by
v.strip.