### PR TITLE
Move building payloads, don't require a block for middleware run

### DIFF
--- a/lib/bugsnag/middleware_stack.rb
+++ b/lib/bugsnag/middleware_stack.rb
@@ -56,7 +56,7 @@ module Bugsnag
       lambda_has_run = false
       notify_lambda = lambda do |notif|
         lambda_has_run = true
-        yield
+        yield if block_given?
       end
 
       begin


### PR DESCRIPTION
This moves building a payload into a method for easier integration with other background queueing libraries. Also removes the requirement of a block to execute the middleware stack.