### PR TITLE
Clean up strings returned from #to_s.

### DIFF
--- a/lib/bugsnag/helpers.rb
+++ b/lib/bugsnag/helpers.rb
@@ -41,7 +41,7 @@ module Bugsnag
         if str =~ /#<.*>/
           '[OBJECT]'
         else
-          str
+          cleanup_string(str)
         end
       end
     end

--- a/spec/helper_spec.rb
+++ b/spec/helper_spec.rb
@@ -44,6 +44,17 @@ describe Bugsnag::Helpers do
     end
   end
 
+  it "cleans up strings returned from #to_s properly" do
+    if RUBY_VERSION > "1.9"
+      str = "Andr\xc7\xff"
+      if str.respond_to? :force_encoding
+        str = str.force_encoding('BINARY')
+      end
+      obj = RuntimeError.new(str)
+      expect(Bugsnag::Helpers.cleanup_obj(obj)).to eq("Andr��")
+    end
+  end
+
   it "filters by string inclusion" do
     expect(Bugsnag::Helpers.cleanup_obj({ :foo => 'bar' }, ['f'])).to eq({ :foo => '[FILTERED]' })
     expect(Bugsnag::Helpers.cleanup_obj({ :foo => 'bar' }, ['b'])).to eq({ :foo => 'bar' })


### PR DESCRIPTION
When an arbitrary object included in `meta_data` hash returns a badly encoded string from its `#to_s` method, the string won't get cleaned up properly, which in turn breaks the whole notification sending.

A real life problem example is Sinatra, which stores currently thrown exception in Rack environment under `"sinatra.error"`. When that exception message contains badly encoded characters, the exception won't be reported to Bugsnag because serializing the message in `@meta_data[:environment]['sinatra_error']` fails.

The solution is to clean up all strings returned from `#to_s` methods in `Bugsnag::Helpers.cleanup_obj`.