### PR TITLE
send notifications automatically if 'rails runner' call fails

### DIFF
--- a/lib/bugsnag/railtie.rb
+++ b/lib/bugsnag/railtie.rb
@@ -12,6 +12,15 @@ module Bugsnag
       load "bugsnag/tasks/bugsnag.rake"
     end
 
+    # send notifications if a command fails in a 'rails runner' call
+    runner do
+      at_exit do
+        if $!
+          Bugsnag.notify($!)
+        end
+      end
+    end
+
     config.before_initialize do
       # Configure bugsnag rails defaults
       Bugsnag.configure do |config|


### PR DESCRIPTION
this change adds the suggested notification code from the 'Standard Ruby Script' section automatically to code run via ```rails runner```. 

you don't currently test for rails-specific stuff so i didn't add a spec but if it's ok to pull in all of those deps i'd  be happy to add it. 