### PR TITLE
Don't verify if MetaData module is included at class level

### DIFF
--- a/lib/bugsnag/notification.rb
+++ b/lib/bugsnag/notification.rb
@@ -309,7 +309,7 @@ module Bugsnag
       meta_data = @meta_data.dup
 
       exceptions.each do |exception|
-        if exception.respond_to?(:bugsnag_meta_data)
+        if exception.respond_to?(:bugsnag_meta_data) && exception.bugsnag_meta_data
           exception.bugsnag_meta_data.each do |key, value|
             add_to_meta_data key, value, meta_data
           end

--- a/lib/bugsnag/notification.rb
+++ b/lib/bugsnag/notification.rb
@@ -309,7 +309,7 @@ module Bugsnag
       meta_data = @meta_data.dup
 
       exceptions.each do |exception|
-        if exception.class.include?(Bugsnag::MetaData) && exception.bugsnag_meta_data
+        if exception.respond_to?(:bugsnag_meta_data)
           exception.bugsnag_meta_data.each do |key, value|
             add_to_meta_data key, value, meta_data
           end


### PR DESCRIPTION
This allows decorating exception instances with metadata without
extending their class with the Bugsnag::MetaData module