### PR TITLE
Disable sending code by default

### DIFF
--- a/lib/bugsnag/configuration.rb
+++ b/lib/bugsnag/configuration.rb
@@ -66,7 +66,7 @@ module Bugsnag
       self.auto_notify = true
       self.use_ssl = true
       self.send_environment = false
-      self.send_code = true
+      self.send_code = false
       self.params_filters = Set.new(DEFAULT_PARAMS_FILTERS)
       self.ignore_classes = Set.new(DEFAULT_IGNORE_CLASSES)
       self.ignore_user_agents = Set.new(DEFAULT_IGNORE_USER_AGENTS)

--- a/spec/code_spec.rb
+++ b/spec/code_spec.rb
@@ -2,6 +2,8 @@ require 'spec_helper'
 
 describe Bugsnag::Notification do
   it "includes code in the stack trace" do
+    Bugsnag.configuration.send_code = true
+
     _a = 1
     _b = 2
     _c = 3
@@ -25,9 +27,7 @@ describe Bugsnag::Notification do
     }
   end
 
-  it "allows you to disable sending code" do
-    Bugsnag.configuration.send_code = false
-
+  it "does not send code by default" do
     notify_test_exception
 
     expect(Bugsnag).to have_sent_notification{ |payload|
@@ -37,6 +37,8 @@ describe Bugsnag::Notification do
   end
 
   it 'should send the first 7 lines of the file for exceptions near the top' do
+    Bugsnag.configuration.send_code = true
+
     load 'spec/fixtures/crashes/start_of_file.rb' rescue Bugsnag.notify $!
 
     expect(Bugsnag).to have_sent_notification{ |payload|
@@ -55,6 +57,8 @@ describe Bugsnag::Notification do
   end
 
   it 'should send the last 7 lines of the file for exceptions near the bottom' do
+    Bugsnag.configuration.send_code = true
+
     load 'spec/fixtures/crashes/end_of_file.rb' rescue Bugsnag.notify $!
 
     expect(Bugsnag).to have_sent_notification{ |payload|
@@ -73,6 +77,8 @@ describe Bugsnag::Notification do
   end
 
   it 'should send the last 7 lines of the file for exceptions near the bottom' do
+    Bugsnag.configuration.send_code = true
+
     load 'spec/fixtures/crashes/short_file.rb' rescue Bugsnag.notify $!
 
     expect(Bugsnag).to have_sent_notification{ |payload|


### PR DESCRIPTION
While the feature to send code by default is pretty cool, it causes terrible performance problems. We saw the time to send an exception go from ~1,000ms to ~200ms on a test case of:

```ruby
begin
  fail "Test"
rescue => ex
  Bugsnag.notify_or_ignore(ex)
end
```

On a lot of exceptions (such as IO), they tend to have a lot of lines because they are wrapped in a couple of exceptions, which Bugsnag unwinds and tries to load code for. It can end up being that you're opening 50+ files and making the payload for an exception much larger.