### PR TITLE
Optimize exception cleanup

### DIFF
--- a/lib/bugsnag/helpers.rb
+++ b/lib/bugsnag/helpers.rb
@@ -18,7 +18,7 @@ module Bugsnag
         clean_hash = {}
         obj.each do |k,v|
           if filters_match?(k, filters)
-            clean_hash[k] = "[FILTERED]"
+            clean_hash[k] = '[FILTERED]'.freeze
           else
             clean_obj = cleanup_obj(v, filters, seen)
             clean_hash[k] = clean_obj
@@ -35,7 +35,7 @@ module Bugsnag
         str = obj.to_s
         # avoid leaking potentially sensitive data from objects' #inspect output
         if str =~ /#<.*>/
-          '[OBJECT]'
+          '[OBJECT]'.freeze
         else
           cleanup_string(str)
         end

--- a/lib/bugsnag/helpers.rb
+++ b/lib/bugsnag/helpers.rb
@@ -3,6 +3,7 @@ require 'uri'
 module Bugsnag
   module Helpers
     MAX_STRING_LENGTH = 4096
+    ENCODING_OPTIONS = {:invalid => :replace, :undef => :replace}.freeze
 
     def self.cleanup_obj(obj, filters = nil, seen = {})
       return nil unless obj
@@ -48,9 +49,9 @@ module Bugsnag
     def self.cleanup_string(str)
       if defined?(str.encoding) && defined?(Encoding::UTF_8)
         if str.encoding == Encoding::UTF_8
-          str.valid_encoding? ? str : str.encode('utf-16', {:invalid => :replace, :undef => :replace}).encode('utf-8')
+          str.valid_encoding? ? str : str.encode('utf-16', ENCODING_OPTIONS).encode('utf-8')
         else
-          str.encode('utf-8', {:invalid => :replace, :undef => :replace})
+          str.encode('utf-8', ENCODING_OPTIONS)
         end
       elsif defined?(Iconv)
         Iconv.conv('UTF-8//IGNORE', 'UTF-8', str) || str


### PR DESCRIPTION
Hey everyone, we found that compiling an exception (everything before `Notification#deliver_exception_payload`) takes around ~340ms on your typical Rails exception. If you just test something like

```ruby
begin
  raise ArgumentError, "Test"
rescue => ex
  Bugsnag.notify(ex)
end
```

It will be fast because the stack trace is tiny. In your Rails app, it's more common to see 40-60 lines in a stack trace. In your worst case such as IO errors, they can get 3 layers deep of `cause` so you're really cleaning up 160 lines of exceptions which includes an additional ~4 arrays to clean.

It turns out that duping a `Set` is a major time sink. Removing the dups gets it down to 340ms to 40ms. We also call `freeze` on the strings which causes Rails to do some magic and treat them as constants. As well as moving the encoding options to a constant to reduce unnecessary garbage.

https://github.com/zanker/bugsnag_benchmark has an example of the performance of the old code vs the new. I also included a micro optimization one which further improves performance.

This code alone is a ~50% improvement in the benchmark, and in our real world test it's about 90%, as the 340ms -> 40ms change includes the entirety of `Bugsnag.notify`.