### PR TITLE
Make sending cookies opt-in

### DIFF
--- a/lib/bugsnag/configuration.rb
+++ b/lib/bugsnag/configuration.rb
@@ -12,6 +12,7 @@ module Bugsnag
     attr_accessor :use_ssl
     attr_accessor :send_environment
     attr_accessor :send_code
+    attr_accessor :send_cookies
     attr_accessor :project_root
     attr_accessor :app_version
     attr_accessor :app_type
@@ -67,6 +68,7 @@ module Bugsnag
       self.use_ssl = true
       self.send_environment = false
       self.send_code = true
+      self.send_cookies = false
       self.params_filters = Set.new(DEFAULT_PARAMS_FILTERS)
       self.ignore_classes = Set.new(DEFAULT_IGNORE_CLASSES)
       self.ignore_user_agents = Set.new(DEFAULT_IGNORE_USER_AGENTS)

--- a/lib/bugsnag/middleware/rack_request.rb
+++ b/lib/bugsnag/middleware/rack_request.rb
@@ -67,7 +67,7 @@ module Bugsnag::Middleware
 
         # Add a cookies tab
         cookies = request.cookies
-        notification.add_tab(:cookies, cookies) if cookies
+        notification.add_tab(:cookies, cookies) if cookies && notification.configuration.send_cookies
       end
 
       @bugsnag.call(notification)

--- a/lib/bugsnag/middleware/rails2_request.rb
+++ b/lib/bugsnag/middleware/rails2_request.rb
@@ -38,7 +38,7 @@ module Bugsnag::Middleware
         notification.add_tab(:session, session_data) if session_data
 
         # Add a cookies tab
-        notification.add_tab(:cookies, request.cookies) if request.cookies
+        notification.add_tab(:cookies, request.cookies) if request.cookies && notification.configuration.send_cookies
 
         # Add the rails version
         notification.add_tab(:environment, {


### PR DESCRIPTION
For us, cookies often contain fairly sensitive data. In our use case, opting in to cookies makes the most sense but for backwards compatibility I totally understand if you guys want to make cookies opt-out.

cc @nealharris