### PR TITLE
Mutating @ignore_classes is not threadsafe

### DIFF
--- a/lib/bugsnag/configuration.rb
+++ b/lib/bugsnag/configuration.rb
@@ -31,7 +31,7 @@ module Bugsnag
     attr_accessor :timeout
     attr_accessor :hostname
     attr_accessor :delivery_method
-
+    private_attr_reader :mutex
     attr_writer :ignore_classes
 
     THREAD_LOCAL_NAME = "bugsnag_req_data"
@@ -63,6 +63,8 @@ module Bugsnag
     DEFAULT_DELIVERY_METHOD = :thread_queue
 
     def initialize
+      @mutex = Mutex.new
+
       # Set up the defaults
       self.auto_notify = true
       self.use_ssl = true
@@ -91,7 +93,7 @@ module Bugsnag
 
     # Accept both String and Class instances as an ignored class
     def ignore_classes
-      @ignore_classes.map! { |klass| klass.is_a?(Class) ? klass.name : klass }
+      mutex.synchronize { @ignore_classes.map! { |klass| klass.is_a?(Class) ? klass.name : klass } }
     end
 
     def should_notify?

--- a/lib/bugsnag/configuration.rb
+++ b/lib/bugsnag/configuration.rb
@@ -31,7 +31,6 @@ module Bugsnag
     attr_accessor :timeout
     attr_accessor :hostname
     attr_accessor :delivery_method
-    private_attr_reader :mutex
     attr_writer :ignore_classes
 
     THREAD_LOCAL_NAME = "bugsnag_req_data"
@@ -93,7 +92,7 @@ module Bugsnag
 
     # Accept both String and Class instances as an ignored class
     def ignore_classes
-      mutex.synchronize { @ignore_classes.map! { |klass| klass.is_a?(Class) ? klass.name : klass } }
+      @mutex.synchronize { @ignore_classes.map! { |klass| klass.is_a?(Class) ? klass.name : klass } }
     end
 
     def should_notify?


### PR DESCRIPTION
Under heavy load on puma we sometimes see ignored exceptions reported to bugsnag.  I believe this is resolved by synchronizing changes to @ignored_classes.