### PR TITLE
Ignore additional exceptions by default

### DIFF
--- a/lib/bugsnag/configuration.rb
+++ b/lib/bugsnag/configuration.rb
@@ -46,15 +46,18 @@ module Bugsnag
     ].freeze
 
     DEFAULT_IGNORE_CLASSES = [
-      "ActiveRecord::RecordNotFound",
-      "ActionController::RoutingError",
-      "ActionController::InvalidAuthenticityToken",
-      "CGI::Session::CookieStore::TamperedWithCookie",
-      "ActionController::UnknownAction",
       "AbstractController::ActionNotFound",
+      "ActionController::InvalidAuthenticityToken",
+      "ActionController::ParameterMissing",
+      "ActionController::RoutingError",
+      "ActionController::UnknownAction",
+      "ActionController::UnknownFormat",
+      "ActionController::UnknownHttpMethod",
+      "ActiveRecord::RecordNotFound",
+      "CGI::Session::CookieStore::TamperedWithCookie",
       "Mongoid::Errors::DocumentNotFound",
+      "SignalException",
       "SystemExit",
-      "SignalException"
     ].freeze
 
     DEFAULT_IGNORE_USER_AGENTS = [].freeze


### PR DESCRIPTION
The following exceptions are irrelevant and harmless in production, since they are already handled by rails and will return an appropriate response. They have been causing unnecessary noise for us in Bugsnag.

* `ActionController::ParameterMissing`
* `ActionController::UnknownFormat`
* `ActionController::UnknownHttpMethod`

I also sorted the exception list alphabetically to keep sanity if more ignored exceptions are added in future.

I realize these can be easily configured to be ignored in the bugsnag interface (which we have already done), but I believe they should also be included as default ignore list.

Fixes #230