### PR TITLE
Remove multi_json dependency, use 'json' gem for old rubies

### DIFF
--- a/bugsnag.gemspec
+++ b/bugsnag.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   ]
   s.require_paths = ["lib"]
 
-  s.add_runtime_dependency 'multi_json', ["~> 1.0"]
+  s.add_dependency 'json', '~> 1.7', '>= 1.7.7'
 
   if RUBY_VERSION < "1.9"
     s.add_development_dependency "rake", "~> 10.1.1"

--- a/lib/bugsnag/deploy.rb
+++ b/lib/bugsnag/deploy.rb
@@ -27,7 +27,7 @@ module Bugsnag
 
       raise RuntimeError.new("No API key found when notifying of deploy") if !parameters["apiKey"] || parameters["apiKey"].empty?
 
-      payload_string = Bugsnag::Helpers.dump_json(parameters)
+      payload_string = ::JSON.dump(parameters)
       Bugsnag::Delivery::Synchronous.deliver(endpoint, payload_string, configuration)
     end
   end

--- a/lib/bugsnag/helpers.rb
+++ b/lib/bugsnag/helpers.rb
@@ -123,22 +123,5 @@ module Bugsnag
         overrides
       end
     end
-
-    # Helper functions to work around MultiJson changes in 1.3+
-    def self.dump_json(object, options={})
-      if MultiJson.respond_to?(:adapter)
-        MultiJson.dump(object, options)
-      else
-        MultiJson.encode(object, options)
-      end
-    end
-
-    def self.load_json(json, options={})
-      if MultiJson.respond_to?(:adapter)
-        MultiJson.load(json, options)
-      else
-        MultiJson.decode(json, options)
-      end
-    end
   end
 end

--- a/lib/bugsnag/notification.rb
+++ b/lib/bugsnag/notification.rb
@@ -1,4 +1,4 @@
-require "multi_json"
+require "json"
 
 if RUBY_VERSION =~ /^1\.8/
   begin
@@ -39,10 +39,10 @@ module Bugsnag
 
         # If the payload is going to be too long, we trim the hashes to send
         # a minimal payload instead
-        payload_string = Bugsnag::Helpers.dump_json(payload)
+        payload_string = ::JSON.dump(payload)
         if payload_string.length > 128000
           payload[:events].each {|e| e[:metaData] = Bugsnag::Helpers.reduce_hash_size(e[:metaData])}
-          payload_string = Bugsnag::Helpers.dump_json(payload)
+          payload_string = ::JSON.dump(payload)
         end
 
         Bugsnag::Delivery[delivery_method || configuration.delivery_method].deliver(url, payload_string, configuration)

--- a/spec/notification_spec.rb
+++ b/spec/notification_spec.rb
@@ -268,7 +268,7 @@ describe Bugsnag::Notification do
     expect(Bugsnag).to have_sent_notification{ |payload|
       # Truncated body should be no bigger than
       # 2 truncated hashes (4096*2) + rest of payload (20000)
-      expect(Bugsnag::Helpers.dump_json(payload).length).to be < 4096*2 + 20000
+      expect(::JSON.dump(payload).length).to be < 4096*2 + 20000
     }
   end
 


### PR DESCRIPTION
Takes the exact same approach as `active_support` did when removing `multi_json` here:
https://github.com/rails/rails/pull/10576