### PR TITLE
Require json instead of multi_json in capistrano.rb

### DIFF
--- a/lib/bugsnag/capistrano.rb
+++ b/lib/bugsnag/capistrano.rb
@@ -1,4 +1,4 @@
-require "multi_json"
+require "json"
 require "bugsnag/deploy"
 
 if defined?(Capistrano::VERSION) && Gem::Version.new(Capistrano::VERSION).release >= Gem::Version.new('3.0.0')


### PR DESCRIPTION
`multi_json` was dropped in v2.8.9, but `capistrano.rb` was still requiring it.

Fix it by requiring `json` instead.