### PR TITLE
Dont log txn callback errors on 4.2+

### DIFF
--- a/lib/bugsnag/rails.rb
+++ b/lib/bugsnag/rails.rb
@@ -15,8 +15,10 @@ module Bugsnag
         ActionController::Base.send(:include, Bugsnag::Rails::ActionControllerRescue)
         ActionController::Base.send(:include, Bugsnag::Rails::ControllerMethods)
       end
-      if defined?(ActiveRecord::Base)
-        ActiveRecord::Base.send(:include, Bugsnag::Rails::ActiveRecordRescue)
+      if defined?(ActiveRecord::Base) && Gem::Version.new(ActiveRecord::VERSION::STRING) < Gem::Version.new("4.3")
+        unless ActiveRecord::Base.respond_to?(:raise_in_transactional_callbacks) && ActiveRecord::Base.raise_in_transactional_callbacks
+          ActiveRecord::Base.send(:include, Bugsnag::Rails::ActiveRecordRescue)
+        end
       end
 
       Bugsnag.configure do |config|


### PR DESCRIPTION
On Active Record 4.2+ we start no swallowing the errors on
commit/rollback callbacks, so we dont need to handle them specially on
bugsnag.
Note: on 4.2 there is a option that needs to be +true+ for bring the new behaviour:
`ActiveRecord::Base.raise_in_transactional_callbacks`

see on Rails 5:
https://github.com/rails/rails/blob/0d76ab9c6f01e6390ba8878a296ff9d3ac6b9aa8/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb#L82-L94

and 4.2:
https://github.com/rails/rails/blob/ab104ff869e3a713e403705cdf58f2978d993609/activerecord/lib/active_record/connection_adapters/abstract/transaction.rb#L85-L99

review @ConradIrwin @snmaynard @loopj 