### PR TITLE
Add back a default timeout of 15 seconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -534,7 +534,7 @@ config.proxy_password = "proxy_secret_password_here"
 ```
 
 ###timeout
-By default the timeout for posting errors to Bugsnag is 5 seconds, to change this
+By default the timeout for posting errors to Bugsnag is 15 seconds, to change this
 you can set the `timeout`:
 
 ```ruby

--- a/lib/bugsnag/configuration.rb
+++ b/lib/bugsnag/configuration.rb
@@ -78,6 +78,7 @@ module Bugsnag
       self.endpoint = DEFAULT_ENDPOINT
       self.hostname = default_hostname
       self.delivery_method = DEFAULT_DELIVERY_METHOD
+      self.timeout = 15
 
       # Read the API key from the environment
       self.api_key = ENV["BUGSNAG_API_KEY"]


### PR DESCRIPTION
At some point the default configuration for timeouts got removed. This adds back a default of 15 seconds which should be plenty for most exceptions.

Our last 24 hours of notifications had a max p95 of 10 seconds for requests, which gives a 5 second runway on open/read.