### PR TITLE
Capistrano - allow for custom endpoint in cap task.

### DIFF
--- a/lib/bugsnag/tasks/bugsnag.cap
+++ b/lib/bugsnag/tasks/bugsnag.cap
@@ -32,7 +32,9 @@ namespace :bugsnag do
           :revision => fetch(:current_revision, ENV["BUGSNAG_REVISION"]),
           :repository => fetch(:repo_url, ENV["BUGSNAG_REPOSITORY"]),
           :branch => fetch(:branch, ENV["BUGSNAG_BRANCH"]),
-          :app_version => fetch(:app_version, ENV["BUGSNAG_APP_VERSION"])
+          :app_version => fetch(:app_version, ENV["BUGSNAG_APP_VERSION"]),
+          :endpoint => fetch(:bugsnag_endpoint, Bugsnag::Configuration::DEFAULT_ENDPOINT),
+          :use_ssl => fetch(:bugsnag_use_ssl, true)
         })
       rescue
         error "Bugsnag deploy notification failed, #{$!.inspect}"


### PR DESCRIPTION
This change allows users of the on-prem version of bugsnag to configure
the custom endpoint to connect to during a capistrano deployment.

The deploy class allows an override of the endpoint attribute [here](https://github.com/bugsnag/bugsnag-ruby/blob/ea2a431f5066ba5c5965da6c3178c778b86c0230/lib/bugsnag/deploy.rb#L11).

Please advise, if I should also bump the version of the gem.