### PR TITLE
Make the list of vendor paths configurable

### DIFF
--- a/lib/bugsnag/configuration.rb
+++ b/lib/bugsnag/configuration.rb
@@ -14,6 +14,7 @@ module Bugsnag
     attr_accessor :send_environment
     attr_accessor :send_code
     attr_accessor :project_root
+    attr_accessor :vendor_paths
     attr_accessor :app_version
     attr_accessor :app_type
     attr_accessor :params_filters
@@ -79,6 +80,7 @@ module Bugsnag
       self.hostname = default_hostname
       self.delivery_method = DEFAULT_DELIVERY_METHOD
       self.timeout = 15
+      self.vendor_paths = [%r{vendor/}]
 
       # Read the API key from the environment
       self.api_key = ENV["BUGSNAG_API_KEY"]

--- a/lib/bugsnag/notification.rb
+++ b/lib/bugsnag/notification.rb
@@ -380,7 +380,7 @@ module Bugsnag
 
         # Generate the stacktrace line hash
         trace_hash = {}
-        trace_hash[:inProject] = true if @configuration.project_root && file.match(/^#{@configuration.project_root}/) && !file.match(/vendor\//)
+        trace_hash[:inProject] = true if in_project?(file)
         trace_hash[:lineNumber] = line_str.to_i
 
         if @configuration.send_code
@@ -408,6 +408,17 @@ module Bugsnag
           nil
         end
       end.compact
+    end
+
+    def in_project?(line)
+      return false if @configuration.vendor_paths && @configuration.vendor_paths.any? do |vendor_path|
+        if vendor_path.is_a?(String)
+          line.include?(vendor_path)
+        else
+          line =~ vendor_path
+        end
+      end
+      @configuration.project_root && line.start_with?(@configuration.project_root.to_s)
     end
 
     def code(file, line_number, num_lines = 7)

--- a/spec/notification_spec.rb
+++ b/spec/notification_spec.rb
@@ -417,6 +417,19 @@ describe Bugsnag::Notification do
     }
   end
 
+  it "does not mark the top-most stacktrace line as inProject if it matches a vendor path" do
+    Bugsnag.configuration.project_root = File.expand_path('../../', __FILE__)
+    Bugsnag.configuration.vendor_paths = [File.expand_path('../', __FILE__)]
+
+    Bugsnag.notify(BugsnagTestException.new("It crashed"))
+
+    expect(Bugsnag).to have_sent_notification{ |payload|
+      exception = get_exception_from_payload(payload)
+      expect(exception["stacktrace"].size).to be >= 1
+      expect(exception["stacktrace"].first["inProject"]).to be_nil
+    }
+  end
+
   it "marks the top-most stacktrace line as inProject if necessary" do
     Bugsnag.configuration.project_root = File.expand_path File.dirname(__FILE__)
     Bugsnag.notify(BugsnagTestException.new("It crashed"))


### PR DESCRIPTION
I guess the title explains it all. It allow to mark some part of the application as "framework", that shouldn't be used for grouping, nor title.

@loopj @snmaynard what do you think?