### PR TITLE
Fix warnings

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,3 +1,4 @@
 --backtrace
 --color
 --format doc
+--warnings

--- a/lib/bugsnag.rb
+++ b/lib/bugsnag.rb
@@ -43,6 +43,7 @@ module Bugsnag
       require "bugsnag/delay/resque" if configuration.delay_with_resque && defined?(Resque)
 
       # Log that we are ready to rock
+      @logged_ready = nil unless defined?(@logged_ready)
       if configuration.api_key && !@logged_ready
         log "Bugsnag exception handler #{VERSION} ready, api_key=#{configuration.api_key}"
         @logged_ready = true
@@ -94,7 +95,8 @@ module Bugsnag
 
     # Configuration getters
     def configuration
-      @configuration || LOCK.synchronize { @configuration ||= Bugsnag::Configuration.new }
+      return @configuration if defined?(@configuration)
+      LOCK.synchronize { @configuration = Bugsnag::Configuration.new }
     end
 
     # Set "per-request" data, temporal data for use in bugsnag middleware

--- a/lib/bugsnag/configuration.rb
+++ b/lib/bugsnag/configuration.rb
@@ -102,6 +102,7 @@ module Bugsnag
     end
 
     def should_notify?
+      @notify_release_stages = nil unless defined?(@notify_release_stages)
       @release_stage.nil? || @notify_release_stages.nil? || @notify_release_stages.include?(@release_stage)
     end
 

--- a/lib/bugsnag/delivery/thread_queue.rb
+++ b/lib/bugsnag/delivery/thread_queue.rb
@@ -26,6 +26,7 @@ module Bugsnag
 
         def start_once!
           MUTEX.synchronize do
+            @started = nil unless defined?(@started)
             return if @started
             @started = true
 

--- a/lib/bugsnag/delivery/thread_queue.rb
+++ b/lib/bugsnag/delivery/thread_queue.rb
@@ -11,18 +11,16 @@ module Bugsnag
         def deliver(url, body, configuration)
           start_once!
 
-          if queue.length > MAX_OUTSTANDING_REQUESTS
-            Bugsnag.warn("Dropping notification, #{queue.length} outstanding requests")
+          if @queue.length > MAX_OUTSTANDING_REQUESTS
+            Bugsnag.warn("Dropping notification, #{@queue.length} outstanding requests")
             return
           end
 
           # Add delivery to the worker thread
-          queue.push proc { super(url, body, configuration) }
+          @queue.push proc { super(url, body, configuration) }
         end
 
         private
-
-        attr_reader :queue
 
         def start_once!
           MUTEX.synchronize do
@@ -33,15 +31,15 @@ module Bugsnag
             @queue = Queue.new
 
             worker_thread = Thread.new do
-              while x = queue.pop
+              while x = @queue.pop
                 break if x == STOP
                 x.call
               end
             end
 
             at_exit do
-              Bugsnag.warn("Waiting for #{queue.length} outstanding request(s)") unless queue.empty?
-              queue.push STOP
+              Bugsnag.warn("Waiting for #{@queue.length} outstanding request(s)") unless @queue.empty?
+              @queue.push STOP
               worker_thread.join
             end
           end

--- a/lib/bugsnag/deploy.rb
+++ b/lib/bugsnag/deploy.rb
@@ -1,4 +1,3 @@
-require "bugsnag"
 require "json"
 
 module Bugsnag

--- a/lib/bugsnag/notification.rb
+++ b/lib/bugsnag/notification.rb
@@ -30,7 +30,7 @@ module Bugsnag
     CURRENT_PAYLOAD_VERSION = "2"
 
     attr_accessor :context
-    attr_accessor :user
+    attr_reader :user
     attr_accessor :configuration
     attr_accessor :meta_data
 

--- a/lib/bugsnag/notification.rb
+++ b/lib/bugsnag/notification.rb
@@ -153,6 +153,7 @@ module Bugsnag
     end
 
     def severity
+      @severity = nil unless defined?(@severity)
       @severity || "warning"
     end
 
@@ -165,6 +166,7 @@ module Bugsnag
     end
 
     def grouping_hash
+      @grouping_hash = nil unless defined?(@grouping_hash)
       @grouping_hash || nil
     end
 
@@ -226,6 +228,7 @@ module Bugsnag
         Bugsnag.log("Notifying #{endpoint} of #{@exceptions.last.class} from api_key #{api_key}")
 
         # Deliver the payload
+        @delivery_method = nil unless defined?(@delivery_method)
         self.class.deliver_exception_payload(endpoint, build_exception_payload, @configuration, @delivery_method)
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -27,12 +27,12 @@ RSpec.configure do |config|
     WebMock.stub_request(:post, "https://notify.bugsnag.com/")
 
     Bugsnag.instance_variable_set(:@configuration, Bugsnag::Configuration.new)
-    Bugsnag.configure do |config|
-      config.api_key = "c9d60ae4c7e70c4b6c4ebd3e8056d2b8"
-      config.release_stage = "production"
-      config.delivery_method = :synchronous
+    Bugsnag.configure do |bugsnag|
+      bugsnag.api_key = "c9d60ae4c7e70c4b6c4ebd3e8056d2b8"
+      bugsnag.release_stage = "production"
+      bugsnag.delivery_method = :synchronous
       # silence logger in tests
-      config.logger = Logger.new(StringIO.new)
+      bugsnag.logger = Logger.new(StringIO.new)
     end
   end
 


### PR DESCRIPTION
I encountered some warnings in this gem while reviewing orgsync/stoplight#78. This pull request fixes those warnings. I chose the path of least resistance for most of these fixes. Since I don't know this library, there may be better ways to fix them. 

Ultimately I think the only commit I really care about is 5647d23f5f03f953d789f1be66d0de61ab09caa5. I think it's causing my JRuby build to fail. 