### PR TITLE
Re-init delivery thread if current PID does not match the one it was created with

### DIFF
--- a/lib/bugsnag/delivery/thread_queue.rb
+++ b/lib/bugsnag/delivery/thread_queue.rb
@@ -26,8 +26,8 @@ module Bugsnag
 
         def start_once!
           MUTEX.synchronize do
-            return if @started
-            @started = true
+            return if @started == Process.pid
+            @started = Process.pid
 
             @queue = Queue.new
 

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -70,21 +70,24 @@ describe 'Bugsnag' do
   end
 
   it 'should work with threadpool delivery after fork' do
-    Bugsnag.configure do |config|
-      config.endpoint = "localhost:#{server.config[:Port]}"
-      config.use_ssl = false
-      config.delivery_method = :thread_queue
+    is_jruby = defined?(RUBY_ENGINE) && RUBY_ENGINE == 'jruby'
+    unless is_jruby #jruby doesn't support fork, so this test doesn't apply
+      Bugsnag.configure do |config|
+        config.endpoint = "localhost:#{server.config[:Port]}"
+        config.use_ssl = false
+        config.delivery_method = :thread_queue
+      end
+      WebMock.allow_net_connect!
+
+      Bugsnag.notify 'yo'
+
+      Process.fork do
+        Bugsnag.notify 'yo too'
+      end
+      Process.wait
+
+      expect(queue.length).to eq(2)
     end
-    WebMock.allow_net_connect!
-
-    Bugsnag.notify 'yo'
-
-    Process.fork do
-      Bugsnag.notify 'yo too'
-    end
-    Process.wait
-
-    expect(queue.length).to eq(2)
   end
 
   describe 'with a proxy' do


### PR DESCRIPTION

Currently, a delivery thread is started one time per process using the
start_once! method.

However, this causes problems in forking code.  If a process encounters
an exception and notifies, then forks, deliveries in the child process
will not be delivered since it will not be given a delivery thread since @started
will be true (inherited from parent process).

This commit modifies the start_once! method to store the PID of the
process in @started.  Then, instead of just checking if @started is set,
it checks if it matched the current PID.  If it doesn't match, the
current process doesn't have a delivery thread so we create one.