### PR TITLE
Reference classes instead of using strings

### DIFF
--- a/lib/bugsnag/railtie.rb
+++ b/lib/bugsnag/railtie.rb
@@ -69,9 +69,9 @@ module Bugsnag
 
     initializer "bugsnag.use_rack_middleware" do |app|
       begin
-        app.config.middleware.insert_after ActionDispatch::DebugExceptions, "Bugsnag::Rack"
+        app.config.middleware.insert_after ActionDispatch::DebugExceptions, Bugsnag::Rack
       rescue
-        app.config.middleware.use "Bugsnag::Rack"
+        app.config.middleware.use Bugsnag::Rack
       end
     end
   end


### PR DESCRIPTION
This fixes the Rails 5 deprecation warning:

```
DEPRECATION WARNING: Passing strings or symbols to the middleware builder is deprecated, please change
them to actual class references.  For example:

  "Bugsnag::Rack" => Bugsnag::Rack
```