### PR TITLE
Change before_filter to be before_action

### DIFF
--- a/lib/bugsnag/rails/controller_methods.rb
+++ b/lib/bugsnag/rails/controller_methods.rb
@@ -17,7 +17,7 @@ module Bugsnag::Rails
       def _add_bugsnag_notify_callback(callback_key, *methods, &block)
         options = methods.last.is_a?(Hash) ? methods.pop : {}
 
-        before_filter(options) do |controller|
+        before_action(options) do |controller|
           request_data = Bugsnag.configuration.request_data
           request_data[callback_key] ||= []
 


### PR DESCRIPTION
Fixes a deprecation warning for rails 5. Fixes https://github.com/bugsnag/bugsnag-ruby/issues/266.