### PR TITLE
Update internal before_bugsnag_notify reference

### DIFF
--- a/docs/Notification Options.md
+++ b/docs/Notification Options.md
@@ -15,7 +15,7 @@ exceptions, to help debug problems.
 
 ## Notification Object
 
-The notification object is passed to all [before bugsnag notify](#sending-custom-data-with-exceptions)
+The notification object is passed to all [before bugsnag notify](#framework-specific-configuration)
 callbacks and is used to manipulate the error report before it is transmitted.
 
 ### Instance Methods


### PR DESCRIPTION
#### Problem

Existing link referencing `before_bugsnag_notify` details had been orphaned.

#### Solution

Link to the Framework-specific Configuration section.