### PR TITLE
Require the bugsnag top level lib when notifying of a deploy

### DIFF
--- a/lib/bugsnag/capistrano.rb
+++ b/lib/bugsnag/capistrano.rb
@@ -1,4 +1,4 @@
-require "bugsnag/deploy"
+require "bugsnag"
 
 if defined?(Capistrano::VERSION) && Gem::Version.new(Capistrano::VERSION).release >= Gem::Version.new('3.0.0')
   load File.expand_path('../tasks/bugsnag.cap', __FILE__)


### PR DESCRIPTION
This fixes #274 and #272.