### PR TITLE
Fix all warnings

### DIFF
--- a/lib/bugsnag.rb
+++ b/lib/bugsnag.rb
@@ -44,6 +44,8 @@ module Bugsnag
       require "bugsnag/delay/resque" if configuration.delay_with_resque && defined?(Resque)
 
       # Log that we are ready to rock
+      @logged_ready = false unless defined?(@logged_ready)
+
       if configuration.api_key && !@logged_ready
         log "Bugsnag exception handler #{VERSION} ready, api_key=#{configuration.api_key}"
         @logged_ready = true
@@ -95,6 +97,7 @@ module Bugsnag
 
     # Configuration getters
     def configuration
+      @configuration = nil unless defined?(@configuration)
       @configuration || LOCK.synchronize { @configuration ||= Bugsnag::Configuration.new }
     end
 

--- a/lib/bugsnag/configuration.rb
+++ b/lib/bugsnag/configuration.rb
@@ -81,6 +81,7 @@ module Bugsnag
       self.delivery_method = DEFAULT_DELIVERY_METHOD
       self.timeout = 15
       self.vendor_paths = [%r{vendor/}]
+      self.notify_release_stages = nil
 
       # Read the API key from the environment
       self.api_key = ENV["BUGSNAG_API_KEY"]

--- a/lib/bugsnag/delivery/thread_queue.rb
+++ b/lib/bugsnag/delivery/thread_queue.rb
@@ -24,6 +24,7 @@ module Bugsnag
 
         def start_once!
           MUTEX.synchronize do
+            @started = nil unless defined?(@started)
             return if @started == Process.pid
             @started = Process.pid
 

--- a/lib/bugsnag/notification.rb
+++ b/lib/bugsnag/notification.rb
@@ -56,6 +56,9 @@ module Bugsnag
       @meta_data = {}
       @user = {}
       @should_ignore = false
+      @severity = nil
+      @grouping_hash = nil
+      @delivery_method = nil
 
       self.severity = @overrides[:severity]
       @overrides.delete :severity


### PR DESCRIPTION
Fixes #257

However I was unable to see the warnings in the snippet in that ticket, so I just fixed the ones I could see. I used `RUBYOPT=-w rspec` to see the warnings.