### PR TITLE
Ensure Sidekiq app_type is not overwritten when rails is a dependency

### DIFF
--- a/lib/bugsnag/railtie.rb
+++ b/lib/bugsnag/railtie.rb
@@ -7,6 +7,8 @@ require "bugsnag/middleware/rack_request"
 
 module Bugsnag
   class Railtie < Rails::Railtie
+    cattr_accessor :running_as_dependency
+
     rake_tasks do
       require "bugsnag/rake"
       load "bugsnag/tasks/bugsnag.rake"
@@ -49,7 +51,7 @@ module Bugsnag
         ActiveRecord::Base.send(:include, Bugsnag::Rails::ActiveRecordRescue)
       end
 
-      Bugsnag.configuration.app_type = "rails"
+      Bugsnag.configuration.app_type = "rails" unless Bugsnag::Railtie.running_as_dependency
     end
 
     # Configure params_filters after initialization, so that rails initializers

--- a/lib/bugsnag/sidekiq.rb
+++ b/lib/bugsnag/sidekiq.rb
@@ -36,3 +36,7 @@ end
 
 Bugsnag.configuration.internal_middleware.use(Bugsnag::Middleware::Sidekiq)
 Bugsnag.configuration.app_type = "sidekiq"
+
+if defined?(::Sidekiq::CLI) && defined?(Bugsnag::Railtie)
+  Bugsnag::Railtie.running_as_dependency = true
+end


### PR DESCRIPTION
This is a fix for #285. It's possible this same bug happens with other integrations, but I only use Sidekiq and didn't verify that.