### PR TITLE
Add support for 'block syntax' on Bugsnag.notify calls

### DIFF
--- a/lib/bugsnag.rb
+++ b/lib/bugsnag.rb
@@ -53,15 +53,20 @@ module Bugsnag
     end
 
     # Explicitly notify of an exception
-    def notify(exception, overrides=nil, request_data=nil)
+    def notify(exception, overrides=nil, request_data=nil, &block)
       notification = Notification.new(exception, configuration, overrides, request_data)
+
+      yield(notification) if block_given?
+
       notification.deliver
       notification
     end
 
     # Notify of an exception unless it should be ignored
-    def notify_or_ignore(exception, overrides=nil, request_data=nil)
+    def notify_or_ignore(exception, overrides=nil, request_data=nil, &block)
       notification = Notification.new(exception, configuration, overrides, request_data)
+
+      yield(notification) if block_given?
 
       unless notification.ignore?
         notification.deliver
@@ -74,10 +79,10 @@ module Bugsnag
     # Auto notify of an exception, called from rails and rack exception
     # rescuers, unless auto notification is disabled, or we should ignore this
     # error class
-    def auto_notify(exception, overrides=nil, request_data=nil)
+    def auto_notify(exception, overrides=nil, request_data=nil, &block)
       overrides ||= {}
       overrides.merge!({:severity => "error"})
-      notify_or_ignore(exception, overrides, request_data) if configuration.auto_notify
+      notify_or_ignore(exception, overrides, request_data, &block) if configuration.auto_notify
     end
 
     # Log wrapper

--- a/spec/notification_spec.rb
+++ b/spec/notification_spec.rb
@@ -335,6 +335,17 @@ describe Bugsnag::Notification do
     }
   end
 
+  it "lets you override severity using block syntax" do
+    Bugsnag.notify(BugsnagTestException.new("It crashed")) do |notification|
+      notification.severity = "info"
+    end
+
+    expect(Bugsnag).to have_sent_notification{ |payload|
+      event = get_event_from_payload(payload)
+      expect(event["severity"]).to eq("info")
+    }
+  end
+
   it "autonotifies errors" do
     Bugsnag.auto_notify(BugsnagTestException.new("It crashed"))
 


### PR DESCRIPTION
This allows users to customize the error report sent to Bugsnag using ruby block syntax on each `Bugsnag.notify` call as follows:

```ruby
Bugsnag.notify(ex) do |notification|
  notification.severity = "info"
end
```

As well as being an arguably cleaner syntax than before, this also exposes the full power of accessing the `Notification` object to every `Bugsnag.notify` call - provideing a single interface to error report customization. This means `Bugsnag.notify` report customization and `before_notify_callbacks` can all share a single documentation.

This PR is the super un-opinionated version, which does not break existing APIs.

I actually propose we **remove** all the slightly hacky `overrides` logic and replace with this, which would be an api-incompatible change requiring a major version bump - any thoughts?