### PR TITLE
Include name of job class in context for Sidekiq and Resque errors.

### DIFF
--- a/lib/bugsnag/resque.rb
+++ b/lib/bugsnag/resque.rb
@@ -26,7 +26,7 @@ module Bugsnag
     end
 
     def save
-      Bugsnag.auto_notify(exception, {:context => "resque##{queue}", :payload => payload, :delivery_method => :synchronous})
+      Bugsnag.auto_notify(exception, {:context => "#{payload['class']} on #{queue}", :payload => payload, :delivery_method => :synchronous})
     end
   end
 end

--- a/lib/bugsnag/sidekiq.rb
+++ b/lib/bugsnag/sidekiq.rb
@@ -29,7 +29,7 @@ if ::Sidekiq::VERSION < '3'
 else
   ::Sidekiq.configure_server do |config|
     config.error_handlers << lambda do |ex, ctx|
-      Bugsnag.auto_notify(ex, :sidekiq => ctx, :context => "sidekiq##{ctx['queue']}")
+      Bugsnag.auto_notify(ex, :sidekiq => ctx, :context => "#{ctx['class']} on #{ctx['queue']}")
     end
   end
 end


### PR DESCRIPTION
Fixes https://github.com/bugsnag/bugsnag-ruby/issues/258

I thought making context consistent was a good idea. I have **not** tested the change for Resque. I copied my code from the [existing failure handler for Airbrake](https://github.com/resque/resque/blob/master/lib/resque/failure/airbrake.rb#L26), so I think it should work. (I did not understand the code for delayed_job - it doesn't seem like it's setting `context`).

### Examples:

* NSQPoster on default
* SendEmailToCustomer on emails

### Screenshot

![runtimeerror_in_rutilus__fishbrain__-_bugsnag](https://cloud.githubusercontent.com/assets/22144/14881572/d6fc0986-0d34-11e6-9268-2211fef2382b.png)

What do you think?