### PR TITLE
Trim nested arrays and drop metadata to save on payload size

### DIFF
--- a/lib/bugsnag/helpers.rb
+++ b/lib/bugsnag/helpers.rb
@@ -42,13 +42,11 @@ module Bugsnag
     TRUNCATION_INFO = '[TRUNCATED]'
 
     # Shorten array until it fits within the payload size limit when serialized
-    def self.truncate_arrays(array)
+    def self.truncate_array(array)
       return [] unless array.respond_to?(:slice)
-      array = array.slice(0, MAX_ARRAY_LENGTH)
-      while array.length > 0 and payload_too_long?(array)
-        array = array.slice(0, array.length - 1)
+      array.slice(0, MAX_ARRAY_LENGTH).map do |item|
+        truncate_arrays_in_value(item)
       end
-      array
     end
 
     # Trim all strings to be less than the maximum allowed string length
@@ -101,7 +99,7 @@ module Bugsnag
       when Hash
         truncate_arrays_in_hash(value)
       when Array, Set
-        truncate_arrays(value)
+        truncate_array(value)
       else
         value
       end

--- a/lib/bugsnag/helpers.rb
+++ b/lib/bugsnag/helpers.rb
@@ -7,7 +7,7 @@ module Bugsnag
   module Helpers
     MAX_STRING_LENGTH = 4096
     MAX_PAYLOAD_LENGTH = 128000
-    MAX_ARRAY_LENGTH = 400
+    MAX_ARRAY_LENGTH = 40
     RAW_DATA_TYPES = [Numeric, TrueClass, FalseClass]
 
     # Trim the size of value if the serialized JSON value is longer than is

--- a/spec/helper_spec.rb
+++ b/spec/helper_spec.rb
@@ -146,6 +146,17 @@ describe Bugsnag::Helpers do
 
           expect(::JSON.dump(trimmed_value).length).to be < Bugsnag::Helpers::MAX_PAYLOAD_LENGTH
         end
+
+        it "removes metadata from events" do
+          metadata = Hash[*20000.times.map {|i| [i,i+1]}.flatten]
+          frames = 100.times.map {|i| SecureRandom.hex(4096) }
+          value = {key:"abc", events:[{metaData: metadata, frames: frames, cake: "carrot"}]}
+          trimmed_value = Bugsnag::Helpers.trim_if_needed(value)
+          expect(::JSON.dump(trimmed_value).length).to be < Bugsnag::Helpers::MAX_PAYLOAD_LENGTH
+          expect(trimmed_value[:key]).to eq value[:key]
+          expect(trimmed_value[:events].first.keys.to_set).to eq [:frames, :cake].to_set
+          expect(trimmed_value[:events].first[:metaData]).to be_nil
+        end
       end
     end
   end

--- a/spec/helper_spec.rb
+++ b/spec/helper_spec.rb
@@ -135,10 +135,11 @@ describe Bugsnag::Helpers do
 
       context "and trimmed strings are not enough" do
         it "truncates long arrays" do
-          value = 100.times.map {|i| SecureRandom.hex(8192) }
+          value = [100.times.map {|i| SecureRandom.hex(8192) }, "a"]
           trimmed_value = Bugsnag::Helpers.trim_if_needed(value)
-          expect(trimmed_value.length).to be > 0
-          trimmed_value.each do |str|
+          expect(trimmed_value.length).to eq 2
+          expect(trimmed_value.first.length).to eq Bugsnag::Helpers::MAX_ARRAY_LENGTH
+          trimmed_value.first.each do |str|
             expect(str.match(/\[TRUNCATED\]$/)).to_not be_nil
             expect(str.length).to eq(Bugsnag::Helpers::MAX_STRING_LENGTH)
           end


### PR DESCRIPTION
When a payload is too large, the request is rejected by the Bugsnag API. This changeset adds a few more last resort adjustments to error reports to ensure at least something is sent.

If a payload is too large to be sent, the following steps are taken, and then only if the previous step did not put the payload size under the threshold:

1. **Trim strings.** All strings over 3kb are truncated. This still leaves enough room for the opening paragraphs of [War and Peace](http://www.gutenberg.org/files/2600/2600-h/2600-h.htm#link2HCH0001).
2. **Truncate arrays.** All arrays are truncated to having 40 items or less. If an array of 40 items has maximum length strings, ~5kb remains for the remainder of the payload
3. **Drop metadata.** Custom metadata attached to the report is dropped. This should ensure that a report is at least generated, even if there is less available to assist with debugging.