### PR TITLE
Don't log API key

### DIFF
--- a/lib/bugsnag/notification.rb
+++ b/lib/bugsnag/notification.rb
@@ -219,7 +219,7 @@ module Bugsnag
 
         # Build the endpoint url
         endpoint = (@configuration.use_ssl ? "https://" : "http://") + @configuration.endpoint
-        Bugsnag.log("Notifying #{endpoint} of #{@exceptions.last.class} from api_key #{api_key}")
+        Bugsnag.log("Notifying #{endpoint} of #{@exceptions.last.class}")
 
         # Deliver the payload
         self.class.deliver_exception_payload(endpoint, build_exception_payload, @configuration, @delivery_method)


### PR DESCRIPTION
[This PR](https://github.com/bugsnag/bugsnag-ruby/commit/5eaddd862ea6b0c39ac9ecef070a8a94befd6e56) was a good start but there was more.

Used to find where more changes were needed
```bash
~/src/bugsnag-ruby (master)$ grep -r "#{api_key}" .
./lib/bugsnag/notification.rb:        Bugsnag.warn "Your API key (#{api_key}) is not valid, couldn't notify"
./lib/bugsnag/notification.rb:        Bugsnag.log("Notifying #{endpoint} of #{@exceptions.last.class} from api_key #{api_key}")
```

Should not log API key since logs are not necessarily kept as secret a
environment variables. The log steam should be keeping track of which
service/box is doing the logging in order to identify which client of
the API is having issues.

Result of running spec:
```
Finished in 3.78 seconds (files took 0.86747 seconds to load)
130 examples, 0 failures
```