### PR TITLE
Exception backtrace could be empty

### DIFF
--- a/lib/bugsnag/notification.rb
+++ b/lib/bugsnag/notification.rb
@@ -343,7 +343,7 @@ module Bugsnag
         {
           :errorClass => error_class(exception),
           :message => exception.message,
-          :stacktrace => stacktrace(exception)
+          :stacktrace => stacktrace(exception.backtrace)
         }
       end
     end
@@ -354,9 +354,9 @@ module Bugsnag
       (exception.is_a? Class) ? exception.name : exception.class.name
     end
 
-    def stacktrace(exception)
-      (exception.backtrace || caller).map do |trace|
-
+    def stacktrace(backtrace)
+      backtrace = caller if !backtrace || backtrace.empty?
+      backtrace.map do |trace|
         if trace.match(BACKTRACE_LINE_REGEX)
           file, line_str, method = [$1, $2, $3]
         elsif trace.match(JAVA_BACKTRACE_REGEX)

--- a/spec/notification_spec.rb
+++ b/spec/notification_spec.rb
@@ -857,6 +857,21 @@ describe Bugsnag::Notification do
     }
   end
 
+  it 'should handle exceptions with empty backtrace' do
+    begin
+      err = RuntimeError.new
+      err.set_backtrace([])
+      raise err
+    rescue
+      Bugsnag.notify $!
+    end
+
+    expect(Bugsnag).to have_sent_notification { |payload|
+      exception = get_exception_from_payload(payload)
+      expect(exception['stacktrace'].size).to be > 0
+    }
+  end
+
   if defined?(JRUBY_VERSION)
 
     it "should work with java.lang.Throwables" do


### PR DESCRIPTION
I faced an issue when exception that had happen in my app don't show in Bugsnag UI.
I found that bugsnag backend silently swallow notification if there is empty stacktrace in any of exceptions.

```
:exceptions => [
  {:errorClass=>"Oxblood::Connection::TimeoutError", :message=>"Oxblood::Connection::TimeoutError", :stacktrace => <STACKTRACE>},
  {:errorClass=>"IO::EAGAINWaitReadable", :message=>"Resource temporarily unavailable - errno backtraces disabled; run with -Xerrno.backtrace=true to enable", :stacktrace=>[]}
]
```

Possibly it should be fixed in backend itself, but I can't do this. This is workaround for such issue.

P.S. Why don't you use `202 Accepted` instead of `200 OK`? It will cause much less confusion for such users (like me) who haven't looked in API documentation yet.
P.P.S. Possibly returning something like `task_id` that could be later used for checking processing status (using `/status/:task_id`) could be helpful for debugging such situations. This won't cause huge overhead if it will be made with, for example, 1 hour auto-expiration.