### PR TITLE
Remove RoutingError from default ignore classes

### DIFF
--- a/lib/bugsnag/configuration.rb
+++ b/lib/bugsnag/configuration.rb
@@ -50,7 +50,6 @@ module Bugsnag
       "AbstractController::ActionNotFound",
       "ActionController::InvalidAuthenticityToken",
       "ActionController::ParameterMissing",
-      "ActionController::RoutingError",
       "ActionController::UnknownAction",
       "ActionController::UnknownFormat",
       "ActionController::UnknownHttpMethod",


### PR DESCRIPTION
ActionController::RoutingError is raised when calling a router function that doesnt exist and can generate a 500 page. I think not having this in defaults is safer