### PR TITLE
Don't override Rails 5 belongs_to association behavior

### DIFF
--- a/lib/bugsnag/railtie.rb
+++ b/lib/bugsnag/railtie.rb
@@ -47,8 +47,11 @@ module Bugsnag
         ActionController::API.send(:include, Bugsnag::Rails::ControllerMethods)
       end
       if defined?(ActiveRecord::Base)
-        require "bugsnag/rails/active_record_rescue"
-        ActiveRecord::Base.send(:include, Bugsnag::Rails::ActiveRecordRescue)
+        ActiveSupport.on_load(:active_record) do
+          require 'bugsnag/rails/active_record_rescue'
+
+          send(:include, Bugsnag::Rails::ActiveRecordRescue)
+        end
       end
 
       Bugsnag.configuration.app_type = "rails" unless Bugsnag::Railtie.running_as_dependency


### PR DESCRIPTION
Hi!
I've found a problem with default behavior of `belongs_to` association.
In Rails 5 ["belongs_to" association is required by default](https://github.com/rails/rails/pull/18937).

Example scenario:

```
class CustomModel < ApplicationRecord
  belongs_to :association
  # validates :association, presence: true is not necessary anymore
end
```

After adding your gem I've noticed that this change is not working anymore:

```
m = CustomModel.new
m.valid? #=> true but should return false
m.errors.full_messages #=> [] but should include proper error message
```

My PR should fix this problem.
