### PR TITLE
Alias notify_or_ignore to notify

### DIFF
--- a/lib/bugsnag.rb
+++ b/lib/bugsnag.rb
@@ -58,16 +58,6 @@ module Bugsnag
 
       yield(notification) if block_given?
 
-      notification.deliver
-      notification
-    end
-
-    # Notify of an exception unless it should be ignored
-    def notify_or_ignore(exception, overrides=nil, request_data=nil, &block)
-      notification = Notification.new(exception, configuration, overrides, request_data)
-
-      yield(notification) if block_given?
-
       unless notification.ignore?
         notification.deliver
         notification
@@ -75,6 +65,7 @@ module Bugsnag
         false
       end
     end
+    alias_method :notify_or_ignore, :notify
 
     # Auto notify of an exception, called from rails and rack exception
     # rescuers, unless auto notification is disabled, or we should ignore this


### PR DESCRIPTION
`notify` and `notify_or_ignore` causes confusion with getting ignore classes to work.

I propose that we release this as is as it lines up with the documentation (we dont actually document `notify_or_ignore`) and then in a larger v5 rewrite I have going we clean this up and break the interface.

Thoughts?
