### PR TITLE
Support ActiveJob wrapped delayed jobs

### DIFF
--- a/lib/bugsnag/delayed_job.rb
+++ b/lib/bugsnag/delayed_job.rb
@@ -20,20 +20,25 @@ unless defined? Delayed::Plugins::Bugsnag
               }
             }
             if payload = job.payload_object
-              p = {
-                :class => payload.class.name,
-              }
-              p[:id]           = payload.id           if payload.respond_to?(:id)
-              p[:display_name] = payload.display_name if payload.respond_to?(:display_name)
-              p[:method_name]  = payload.method_name  if payload.respond_to?(:method_name)
-              p[:args]         = payload.args         if payload.respond_to?(:args)
-              if payload.is_a?(::Delayed::PerformableMethod) && (object = payload.object)
-                p[:object] = {
-                  :class => object.class.name,
+              if payload.class.name == "ActiveJob::QueueAdapters::DelayedJobAdapter::JobWrapper"
+                overrides[:job][:payload] = payload.job_data
+              else
+                p = {
+                  :class => payload.class.name
                 }
-                p[:object][:id] = object.id if object.respond_to?(:id)
+
+                p[:id]           = payload.id           if payload.respond_to?(:id)
+                p[:display_name] = payload.display_name if payload.respond_to?(:display_name)
+                p[:method_name]  = payload.method_name  if payload.respond_to?(:method_name)
+                p[:args]         = payload.args         if payload.respond_to?(:args)
+                if payload.is_a?(::Delayed::PerformableMethod) && (object = payload.object)
+                  p[:object] = {
+                    :class => object.class.name,
+                  }
+                  p[:object][:id] = object.id if object.respond_to?(:id)
+                end
+                overrides[:job][:payload] = p
               end
-              overrides[:job][:payload] = p
             end
 
             ::Bugsnag.auto_notify(error, overrides)


### PR DESCRIPTION
![screen shot 2016-08-29 at 4 04 32 pm](https://cloud.githubusercontent.com/assets/10610335/18042131/5528b10a-6e02-11e6-9914-6c21bb858ff1.png)

Better support for ActiveJob wrapped delayed jobs. The payload details like `job_class` and `arguments` are now shown in the "Job" tab in bugsnag
