### PR TITLE
Move the Sidekiq reporter to after the logging middleware

### DIFF
--- a/lib/bugsnag/sidekiq.rb
+++ b/lib/bugsnag/sidekiq.rb
@@ -27,6 +27,6 @@ end
 
 ::Sidekiq.configure_server do |config|
   config.server_middleware do |chain|
-    chain.add ::Bugsnag::Sidekiq
+    chain.insert_after ::Sidekiq::Middleware::Server::Logging, ::Bugsnag::Sidekiq
   end
 end


### PR DESCRIPTION
The Server::Logging middleware is the outermost middleware that Sidekiq provides by default.
This is a very safe place to put error reporting middleware, because any custom code implemented
by users of Bugsnag will probably not cause erroneous reports.

Specifically, we use a class that prevents error logging for certain error types `Sidekiq::Retry` unless it's the final retry. This helps reduce noise greatly. Bugsnag will report these errors even if we catch them ourselves, because it runs before our middleware. However, this middleware must execute after RetryJobs middleware.

We have a fix for this in our code (manually removing / adding Bugsnag back in), but wanted to also provide this insight for the Bugsnag team.
