### PR TITLE
Support for configurable exclusion patters in stack traces

### DIFF
--- a/lib/bugsnag/configuration.rb
+++ b/lib/bugsnag/configuration.rb
@@ -33,6 +33,7 @@ module Bugsnag
     attr_accessor :hostname
     attr_accessor :delivery_method
     attr_writer :ignore_classes
+    attr_accessor :stacktrace_exclusion_patterns
 
     THREAD_LOCAL_NAME = "bugsnag_req_data"
 
@@ -85,6 +86,7 @@ module Bugsnag
       # Read the API key from the environment
       self.api_key = ENV["BUGSNAG_API_KEY"]
 
+      self.stacktrace_exclusion_patterns = [ %r{lib/bugsnag(/|\.rb)}.freeze ]
       # Set up logging
       self.logger = Logger.new(STDOUT)
       self.logger.level = Logger::WARN

--- a/lib/bugsnag/notification.rb
+++ b/lib/bugsnag/notification.rb
@@ -52,6 +52,7 @@ module Bugsnag
       @severity = nil
       @grouping_hash = nil
       @delivery_method = nil
+      @stacktrace_exclusions =  Regexp.union( @configuration.stacktrace_exclusion_patterns )
 
       self.severity = @overrides[:severity]
       @overrides.delete :severity
@@ -369,7 +370,7 @@ module Bugsnag
         # Parse the stacktrace line
 
         # Skip stacktrace lines inside lib/bugsnag
-        next(nil) if file.nil? || file =~ %r{lib/bugsnag(/|\.rb)}
+        next(nil) if file.nil? || file =~ @stacktrace_exclusions
 
         # Expand relative paths
         p = Pathname.new(file)

--- a/spec/notification_spec.rb
+++ b/spec/notification_spec.rb
@@ -347,7 +347,6 @@ describe Bugsnag::Notification do
         expect(exception_event["stacktrace"].size).to eq(2)
       }
     end
-
   end
 
   it "accepts a severity in overrides" do


### PR DESCRIPTION
Adds support for configurable exclusion patterns in reported stacktrace lines.
- Added new configuration key: `stacktrace_exclusion_patterns`. This key will contain an array of Regex patterns which when matched, will exclude said lines from the reported the stack trace in the exceptions.
  - By default the exclusion pattern will contain the original regexp (`%r{lib/bugsnag(/|\.rb)}`
  - Usage example: `Bugsnag.configuration.stacktrace_exclusion_patterns << /mypat/`
