### PR TITLE
Add more to delayed job notifications

### DIFF
--- a/lib/bugsnag/delayed_job.rb
+++ b/lib/bugsnag/delayed_job.rb
@@ -19,6 +19,12 @@ unless defined? Delayed::Plugins::Bugsnag
                 :id => job.id,
               }
             }
+            if job.respond_to?(:queue) && (queue = job.queue)
+              overrides[:job][:queue] = queue
+            end
+            if job.respond_to?(:attempts)
+              overrides[:job][:attempts] = "#{job.attempts} / #{Delayed::Worker.max_attempts}"
+            end
             if payload = job.payload_object
               p = {
                 :class => payload.class.name,
@@ -44,7 +50,7 @@ unless defined? Delayed::Plugins::Bugsnag
 
           def add_active_job_details(p, payload)
             if payload.respond_to?(:job_data) && payload.job_data.respond_to?(:[])
-              [:job_class, :job_id, :arguments].each do |key|
+              [:job_class, :arguments, :queue_name, :job_id].each do |key|
                 if (value = payload.job_data[key.to_s])
                   p[key] = value
                 end

--- a/lib/bugsnag/delayed_job.rb
+++ b/lib/bugsnag/delayed_job.rb
@@ -33,12 +33,23 @@ unless defined? Delayed::Plugins::Bugsnag
                 }
                 p[:object][:id] = object.id if object.respond_to?(:id)
               end
+              add_active_job_details(p, payload)
               overrides[:job][:payload] = p
             end
 
             ::Bugsnag.auto_notify(error, overrides)
 
             super if defined?(super)
+          end
+
+          def add_active_job_details(p, payload)
+            if payload.respond_to?(:job_data) && payload.job_data.respond_to?(:[])
+              [:job_class, :job_id, :arguments].each do |key|
+                if (value = payload.job_data[key.to_s])
+                  p[key] = value
+                end
+              end
+            end
           end
         end
 

--- a/lib/bugsnag/delayed_job.rb
+++ b/lib/bugsnag/delayed_job.rb
@@ -23,7 +23,8 @@ unless defined? Delayed::Plugins::Bugsnag
               overrides[:job][:queue] = queue
             end
             if job.respond_to?(:attempts)
-              overrides[:job][:attempts] = "#{job.attempts} / #{Delayed::Worker.max_attempts}"
+              overrides[:job][:attempts] = "#{job.attempts + 1} / #{Delayed::Worker.max_attempts}"
+              # +1 as "attempts" is really previous attempts AFAICT, certainly it starts at 0.
             end
             if payload = job.payload_object
               p = {


### PR DESCRIPTION
Currently the Bugnsag DelayedJob Plugin / DelayedJob notifier doesn't show ActiveJob data. This PR addresses that.

It also adds the queue (if present) for the DJ job and the #attempts

![runtimeerror_in_fnc_backend_webapp](https://cloud.githubusercontent.com/assets/18395/19525776/f9454372-9619-11e6-9c45-611ac39bf9b6.png)

PS: Hard to work out how to get any specs for this to run (I did try...), as DelayedJob isn't actually a dependency for this gem (and there are no existing specs for the DJ plugin code), but if you can give some guidance on this bit of set up I could write them.
