### PR TITLE
Use File.exist? instead of File.exists?

### DIFF
--- a/example/rails-32/config/boot.rb
+++ b/example/rails-32/config/boot.rb
@@ -3,4 +3,4 @@ require 'rubygems'
 # Set up gems listed in the Gemfile.
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
 
-require 'bundler/setup' if File.exists?(ENV['BUNDLE_GEMFILE'])
+require 'bundler/setup' if File.exist?(ENV['BUNDLE_GEMFILE'])

--- a/lib/bugsnag/rails.rb
+++ b/lib/bugsnag/rails.rb
@@ -31,7 +31,7 @@ module Bugsnag
 
       # Auto-load configuration settings from config/bugsnag.yml if it exists
       config_file = File.join(rails_root, "config", "bugsnag.yml")
-      config = YAML.load_file(config_file) if File.exists?(config_file)
+      config = YAML.load_file(config_file) if File.exist?(config_file)
       Bugsnag.configure(config[rails_env] ? config[rails_env] : config) if config
 
       Bugsnag.configuration.app_type = "rails"

--- a/lib/bugsnag/railtie.rb
+++ b/lib/bugsnag/railtie.rb
@@ -34,7 +34,7 @@ module Bugsnag
 
       # Auto-load configuration settings from config/bugsnag.yml if it exists
       config_file = ::Rails.root.join("config", "bugsnag.yml")
-      config = YAML.load_file(config_file) if File.exists?(config_file)
+      config = YAML.load_file(config_file) if File.exist?(config_file)
       Bugsnag.configure(config[::Rails.env] ? config[::Rails.env] : config) if config
 
       if defined?(::ActionController::Base)


### PR DESCRIPTION
In newer versions of Ruby using File.exists? will warn about deprecation. The File.exist? method has been around forever so this will not introduce any backwards compatibility problems.