### PR TITLE
[Resque] Do not leak config in parent process

### DIFF
--- a/lib/bugsnag/resque.rb
+++ b/lib/bugsnag/resque.rb
@@ -37,7 +37,7 @@ Resque::Failure::Bugsnag = Bugsnag::Resque
 # Auto-load the failure backend
 Bugsnag::Resque.add_failure_backend
 
-Resque.before_first_fork do
+Resque.after_fork do
   Bugsnag.configuration.app_type = "resque"
   Bugsnag.configuration.delivery_method = :synchronous
 end


### PR DESCRIPTION
Mutating `Bugsnag.configuration` in `before_first_fork` means that it will also affect the parent process. But in this case, we only want to mutate configuration for the new forked Resque process.

@keeganlow

cc @casperisfine @fw42