### PR TITLE
Correctly hook on Action Controller

### DIFF
--- a/lib/bugsnag/railtie.rb
+++ b/lib/bugsnag/railtie.rb
@@ -37,12 +37,9 @@ module Bugsnag
       config = YAML.load_file(config_file) if File.exist?(config_file)
       Bugsnag.configure(config[::Rails.env] ? config[::Rails.env] : config) if config
 
-      if defined?(::ActionController::Base)
+      ActiveSupport.on_load(:action_controller) do
         require "bugsnag/rails/controller_methods"
-        ::ActionController::Base.send(:include, Bugsnag::Rails::ControllerMethods)
-      end
-      if defined?(ActionController::API)
-        ActionController::API.send(:include, Bugsnag::Rails::ControllerMethods)
+        include Bugsnag::Rails::ControllerMethods
       end
       if defined?(ActiveRecord::Base)
         require "bugsnag/rails/active_record_rescue"


### PR DESCRIPTION
When an initializer load the `ActionController::Base` constant all the on_load triggers for `:action_controller` are executed. This cause a lot of load order issues.

Gems should always use `ActiveSupport.on_load` to extent behavior of the Rails frameworks.

Also using `ActiveSupport.on_load(:action_controller)` we can make sure that both `ActionController::Base` and `ActionController::Api` are extended.

This is related with #337 and #314.