### PR TITLE
Prevent nil from being cleaned in arrays and sets

### DIFF
--- a/lib/bugsnag/cleaner.rb
+++ b/lib/bugsnag/cleaner.rb
@@ -37,7 +37,7 @@ module Bugsnag
         end
         clean_hash
       when Array, Set
-        obj.map { |el| traverse_object(el, seen, scope) }.compact
+        obj.map { |el| traverse_object(el, seen, scope) }
       when Numeric, TrueClass, FalseClass
         obj
       when String

--- a/spec/cleaner_spec.rb
+++ b/spec/cleaner_spec.rb
@@ -19,6 +19,11 @@ describe Bugsnag::Cleaner do
       expect(subject.clean_object(a)).to eq(["[RECURSION]", "hello"])
     end
 
+    it "doesn't remove nil from arrays" do
+      a = ["b", nil, "c"]
+      expect(subject.clean_object(a)).to eq(["b", nil, "c"])
+    end
+
     it "allows multiple copies of the same string" do
       a = {:name => "bugsnag"}
       a[:second] = a[:name]


### PR DESCRIPTION
Currently arrays and sets are 'cleaned' before being reported to Bugsnag.

This has the effect of removing `nil`s which can be meaningful.

For example it is confusing to not show all the args metadata for a Sidekiq job, even if some are nil:
```
“args”: [
  nil,
  "arg2
]
```
