### PR TITLE
Default delivery method

### DIFF
--- a/lib/bugsnag/configuration.rb
+++ b/lib/bugsnag/configuration.rb
@@ -31,7 +31,6 @@ module Bugsnag
     attr_accessor :proxy_password
     attr_accessor :timeout
     attr_accessor :hostname
-    attr_accessor :delivery_method
     attr_writer :ignore_classes
 
     THREAD_LOCAL_NAME = "bugsnag_req_data"
@@ -77,7 +76,6 @@ module Bugsnag
       self.ignore_user_agents = Set.new(DEFAULT_IGNORE_USER_AGENTS)
       self.endpoint = DEFAULT_ENDPOINT
       self.hostname = default_hostname
-      self.delivery_method = DEFAULT_DELIVERY_METHOD
       self.timeout = 15
       self.vendor_paths = [%r{vendor/}]
       self.notify_release_stages = nil
@@ -94,6 +92,30 @@ module Bugsnag
 
       self.middleware = Bugsnag::MiddlewareStack.new
       self.middleware.use Bugsnag::Middleware::Callbacks
+    end
+
+    ##
+    # Gets the delivery_method that Bugsnag will use to communicate with the
+    # notification endpoint.
+    #
+    def delivery_method
+      @delivery_method || @default_delivery_method || DEFAULT_DELIVERY_METHOD
+    end
+
+    ##
+    # Sets the delivery_method that Bugsnag will use to communicate with the
+    # notification endpoint.
+    #
+    def delivery_method=(delivery_method)
+      @delivery_method = delivery_method
+    end
+
+    ##
+    # Used to set a new default delivery method that will be used if one is not
+    # set with #delivery_method.
+    #
+    def default_delivery_method=(delivery_method)
+      @default_delivery_method = delivery_method
     end
 
     # Accept both String and Class instances as an ignored class

--- a/lib/bugsnag/resque.rb
+++ b/lib/bugsnag/resque.rb
@@ -26,7 +26,7 @@ module Bugsnag
     end
 
     def save
-      Bugsnag.auto_notify(exception, {:context => "#{payload['class']}@#{queue}", :payload => payload, :delivery_method => :synchronous})
+      Bugsnag.auto_notify(exception, {:context => "#{payload['class']}@#{queue}", :payload => payload})
     end
   end
 end

--- a/lib/bugsnag/resque.rb
+++ b/lib/bugsnag/resque.rb
@@ -39,5 +39,5 @@ Bugsnag::Resque.add_failure_backend
 
 Resque.before_first_fork do
   Bugsnag.configuration.app_type = "resque"
-  Bugsnag.configuration.delivery_method = :synchronous
+  Bugsnag.configuration.default_delivery_method = :synchronous
 end

--- a/lib/bugsnag/shoryuken.rb
+++ b/lib/bugsnag/shoryuken.rb
@@ -4,7 +4,7 @@ module Bugsnag
   class Shoryuken
     def initialize
       Bugsnag.configuration.app_type = "shoryuken"
-      Bugsnag.configuration.delivery_method = :synchronous
+      Bugsnag.configuration.default_delivery_method = :synchronous
     end
 
     def call(_, queue, _, body)

--- a/lib/bugsnag/sidekiq.rb
+++ b/lib/bugsnag/sidekiq.rb
@@ -5,7 +5,7 @@ module Bugsnag
     def initialize
       Bugsnag.configuration.internal_middleware.use(Bugsnag::Middleware::Sidekiq)
       Bugsnag.configuration.app_type = "sidekiq"
-      Bugsnag.configuration.delivery_method = :synchronous
+      Bugsnag.configuration.default_delivery_method = :synchronous
     end
 
     def call(worker, msg, queue)

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -1,0 +1,26 @@
+# encoding: utf-8
+require 'spec_helper'
+
+describe Bugsnag::Configuration do
+  describe "delivery_method" do
+    it "should have the default delivery method" do
+      expect(subject.delivery_method).to eq(Bugsnag::Configuration::DEFAULT_DELIVERY_METHOD)
+    end
+
+    it "should have the defined delivery_method" do
+      subject.delivery_method = :test
+      expect(subject.delivery_method).to eq(:test)
+    end
+
+    it "should allow a new default delivery_method to be set" do
+      subject.default_delivery_method = :test
+      expect(subject.delivery_method).to eq(:test)
+    end
+
+    it "should allow the delivery_method to be set over a default" do
+      subject.default_delivery_method = :test
+      subject.delivery_method = :wow
+      expect(subject.delivery_method).to eq(:wow)
+    end
+  end
+end


### PR DESCRIPTION
Resolves issues raised in #317 and #335 by @rafaelfranca.

Removed setting the `delivery_method` to `:synchronous` when notifying errors in resque, which allows any user set `delivery_method` to be used.

Now when the gem sets a default due to detecting it is running as a certain app type it will only set a new default `delivery_method` which can be overridden.