### PR TITLE
Resque fork

### DIFF
--- a/lib/bugsnag/resque.rb
+++ b/lib/bugsnag/resque.rb
@@ -37,7 +37,7 @@ Resque::Failure::Bugsnag = Bugsnag::Resque
 # Auto-load the failure backend
 Bugsnag::Resque.add_failure_backend
 
-Resque.before_first_fork do
+Resque.after_fork do
   Bugsnag.configuration.app_type = "resque"
   Bugsnag.configuration.default_delivery_method = :synchronous
 end

--- a/lib/bugsnag/resque.rb
+++ b/lib/bugsnag/resque.rb
@@ -37,7 +37,14 @@ Resque::Failure::Bugsnag = Bugsnag::Resque
 # Auto-load the failure backend
 Bugsnag::Resque.add_failure_backend
 
-Resque.after_fork do
-  Bugsnag.configuration.app_type = "resque"
-  Bugsnag.configuration.default_delivery_method = :synchronous
+if Resque::Worker.new.fork_per_job?
+  Resque.after_fork do
+    Bugsnag.configuration.app_type = "resque"
+    Bugsnag.configuration.default_delivery_method = :synchronous
+  end
+else
+  Resque.before_first_fork do
+    Bugsnag.configuration.app_type = "resque"
+    Bugsnag.configuration.default_delivery_method = :synchronous
+  end
 end


### PR DESCRIPTION
Suggestion for moving forward with #335.

Check if we are forking the worker and if so only perform the configuration after the fork has occurred. If not then retain the old behavior.
