### PR TITLE
Prepend Bugsnag in the Sidekiq middleware chain

### DIFF
--- a/lib/bugsnag/sidekiq.rb
+++ b/lib/bugsnag/sidekiq.rb
@@ -27,6 +27,10 @@ end
 
 ::Sidekiq.configure_server do |config|
   config.server_middleware do |chain|
-    chain.add ::Bugsnag::Sidekiq
+    if Gem::Version.new(Sidekiq::VERSION) >= Gem::Version.new('3.3.0')
+      chain.prepend ::Bugsnag::Sidekiq
+    else
+      chain.add ::Bugsnag::Sidekiq
+    end
   end
 end


### PR DESCRIPTION
Starting in version 3.3.0, Sidekiq introduced the ability to prepend to the middleware chain. We should prepend when we can so that we can catch any exceptions that occur in the middleware chain.