### PR TITLE
Pass temporary queue to check resque worker fork_per_job?

### DIFF
--- a/lib/bugsnag/resque.rb
+++ b/lib/bugsnag/resque.rb
@@ -37,7 +37,7 @@ Resque::Failure::Bugsnag = Bugsnag::Resque
 # Auto-load the failure backend
 Bugsnag::Resque.add_failure_backend
 
-if Resque::Worker.new.fork_per_job?
+if Resque::Worker.new(:bugsnag_fork_check).fork_per_job?
   Resque.after_fork do
     Bugsnag.configuration.app_type = "resque"
     Bugsnag.configuration.default_delivery_method = :synchronous


### PR DESCRIPTION
Quick fix to use a queue name when initializing a worker.
Use the queue name `:bugsnag_fork_check` for the initialized worker that is used to call `.fork_per_job?`
fixes #354 