### PR TITLE
Add support for DelayedJob Custom Job arguments

### DIFF
--- a/lib/bugsnag/delayed_job.rb
+++ b/lib/bugsnag/delayed_job.rb
@@ -33,7 +33,12 @@ unless defined? Delayed::Plugins::Bugsnag
               p[:id]           = payload.id           if payload.respond_to?(:id)
               p[:display_name] = payload.display_name if payload.respond_to?(:display_name)
               p[:method_name]  = payload.method_name  if payload.respond_to?(:method_name)
-              p[:args]         = payload.respond_to?(:args) ? payload.args : payload.to_h
+
+              if payload.respond_to?(:args)
+                p[:args] = payload.args
+              elsif payload.respond_to?(:to_h)
+                p[:args] = payload.to_h
+              end
 
               if payload.is_a?(::Delayed::PerformableMethod) && (object = payload.object)
                 p[:object] = {

--- a/lib/bugsnag/delayed_job.rb
+++ b/lib/bugsnag/delayed_job.rb
@@ -33,7 +33,8 @@ unless defined? Delayed::Plugins::Bugsnag
               p[:id]           = payload.id           if payload.respond_to?(:id)
               p[:display_name] = payload.display_name if payload.respond_to?(:display_name)
               p[:method_name]  = payload.method_name  if payload.respond_to?(:method_name)
-              p[:args]         = payload.args         if payload.respond_to?(:args)
+              p[:args]         = payload.respond_to?(:args) ? payload.args : payload.to_h
+
               if payload.is_a?(::Delayed::PerformableMethod) && (object = payload.object)
                 p[:object] = {
                   :class => object.class.name,


### PR DESCRIPTION
This adds support for passing the arguments for [Custom Job objects](https://github.com/collectiveidea/delayed_job#custom-jobs) in the DelayedJob integration.

Please advise of the best way to handle writing any specs for this. I've tested it manually on various job types.