### PR TITLE
Ensured default user_id set correctly in rack and rails3 middlewares

### DIFF
--- a/lib/bugsnag/middleware/rack_request.rb
+++ b/lib/bugsnag/middleware/rack_request.rb
@@ -18,7 +18,7 @@ module Bugsnag::Middleware
         report.context = "#{request.request_method} #{request.path}"
 
         # Set a sensible default for user_id
-        report.user_id = request.ip
+        report.user["id"] = request.ip
 
         # Build the clean url (hide the port if it is obvious)
         url = "#{request.scheme}://#{request.host}"

--- a/lib/bugsnag/middleware/rails3_request.rb
+++ b/lib/bugsnag/middleware/rails3_request.rb
@@ -26,7 +26,7 @@ module Bugsnag::Middleware
           :requestId => env["action_dispatch.request_id"]
         })
 
-        report.user_id = env["action_dispatch.remote_ip"]
+        report.user["id"] = env["action_dispatch.remote_ip"]
 
         # Add the rails version
         if report.configuration.send_environment


### PR DESCRIPTION
Currently the `user_id` doesn't exist on report and has no impact even if an accessor is provided.
This ensures the user id field is set to the user's Id in both rails3 and rack.