### PR TITLE
Added unhandled functionality, updated tests and integrations

### DIFF
--- a/lib/bugsnag.rb
+++ b/lib/bugsnag.rb
@@ -86,7 +86,7 @@ module Bugsnag
         end
 
         # Test whether severity has been changed and ensure severity_reason is consistant in auto_notify case
-        if report.severity != before_callback_severity
+        if report.severity != initial_severity
           report.severity_reason = {
             :type => Bugsnag::Report::USER_CALLBACK_SET_SEVERITY
           }

--- a/lib/bugsnag.rb
+++ b/lib/bugsnag.rb
@@ -34,7 +34,7 @@ module Bugsnag
 
     # Explicitly notify of an exception
     def notify(exception, auto_notify=false, &block)
-      report = Report.new(exception, configuration)
+      report = Report.new(exception, configuration, auto_notify)
 
       if !configuration.auto_notify && auto_notify
         configuration.debug("Not notifying because auto_notify is disabled")

--- a/lib/bugsnag/configuration.rb
+++ b/lib/bugsnag/configuration.rb
@@ -5,6 +5,7 @@ require "bugsnag/middleware_stack"
 require "bugsnag/middleware/callbacks"
 require "bugsnag/middleware/exception_meta_data"
 require "bugsnag/middleware/ignore_error_class"
+require "bugsnag/middleware/classify_error"
 
 module Bugsnag
   class Configuration
@@ -73,6 +74,7 @@ module Bugsnag
       self.internal_middleware = Bugsnag::MiddlewareStack.new
       self.internal_middleware.use Bugsnag::Middleware::ExceptionMetaData
       self.internal_middleware.use Bugsnag::Middleware::IgnoreErrorClass
+      self.internal_middleware.use Bugsnag::Middleware::ClassifyError
 
       self.middleware = Bugsnag::MiddlewareStack.new
       self.middleware.use Bugsnag::Middleware::Callbacks

--- a/lib/bugsnag/integrations/delayed_job.rb
+++ b/lib/bugsnag/integrations/delayed_job.rb
@@ -9,6 +9,11 @@ unless defined? Delayed::Plugins::Bugsnag
   module Delayed
     module Plugins
       class Bugsnag < Plugin
+
+        FRAMEWORK_ATTRIBUTES = {
+          :framework => "DelayedJob"
+        }
+
         module Notify
           def error(job, error)
             overrides = {
@@ -36,12 +41,10 @@ unless defined? Delayed::Plugins::Bugsnag
 
             ::Bugsnag.notify(error, true) do |report|
               report.severity = "error"
-              report.set_handled_state({
-                :type => "unhandledExceptionMiddleware",
-                :attributes => {
-                  :framework => "DelayedJob"
-                }
-              })
+              report.severity_reason = {
+                :type => Bugsnag::Report::UNHANDLED_EXCEPTION_MIDDLEWARE,
+                :attributes => FRAMEWORK_ATTRIBUTES
+              }
               report.meta_data.merge! overrides
             end
 

--- a/lib/bugsnag/integrations/delayed_job.rb
+++ b/lib/bugsnag/integrations/delayed_job.rb
@@ -36,6 +36,12 @@ unless defined? Delayed::Plugins::Bugsnag
 
             ::Bugsnag.notify(error, true) do |report|
               report.severity = "error"
+              report.set_handled_state({
+                :type => "unhandledExceptionMiddleware",
+                :attributes => {
+                  :framework => "DelayedJob"
+                }
+              })
               report.meta_data.merge! overrides
             end
 

--- a/lib/bugsnag/integrations/delayed_job.rb
+++ b/lib/bugsnag/integrations/delayed_job.rb
@@ -42,7 +42,7 @@ unless defined? Delayed::Plugins::Bugsnag
             ::Bugsnag.notify(error, true) do |report|
               report.severity = "error"
               report.severity_reason = {
-                :type => Bugsnag::Report::UNHANDLED_EXCEPTION_MIDDLEWARE,
+                :type => ::Bugsnag::Report::UNHANDLED_EXCEPTION_MIDDLEWARE,
                 :attributes => FRAMEWORK_ATTRIBUTES
               }
               report.meta_data.merge! overrides

--- a/lib/bugsnag/integrations/mailman.rb
+++ b/lib/bugsnag/integrations/mailman.rb
@@ -16,9 +16,9 @@ module Bugsnag
         Bugsnag.notify(ex, true) do |report|
           report.severity = "error"
           report.set_handled_state({
-            :type => "middleware_handler",
+            :type => "unhandledExceptionMiddleware",
             :attributes => {
-              :name => "mailman"
+              :framework => "Mailman"
             }
           })
         end

--- a/lib/bugsnag/integrations/mailman.rb
+++ b/lib/bugsnag/integrations/mailman.rb
@@ -2,6 +2,11 @@ require 'mailman'
 
 module Bugsnag
   class Mailman
+
+    FRAMEWORK_ATTRIBUTES = {
+      :framework => "Mailman"
+    }
+
     def initialize
       Bugsnag.configuration.internal_middleware.use(Bugsnag::Middleware::Mailman)
       Bugsnag.configuration.app_type = "mailman"
@@ -15,12 +20,10 @@ module Bugsnag
         raise ex if [Interrupt, SystemExit, SignalException].include? ex.class
         Bugsnag.notify(ex, true) do |report|
           report.severity = "error"
-          report.set_handled_state({
-            :type => "unhandledExceptionMiddleware",
-            :attributes => {
-              :framework => "Mailman"
-            }
-          })
+          report.severity_reason = {
+            :type => Bugsnag::Report::UNHANDLED_EXCEPTION_MIDDLEWARE,
+            :attributes => FRAMEWORK_ATTRIBUTES
+          }
         end
         raise
       ensure

--- a/lib/bugsnag/integrations/mailman.rb
+++ b/lib/bugsnag/integrations/mailman.rb
@@ -13,7 +13,12 @@ module Bugsnag
         yield
       rescue Exception => ex
         raise ex if [Interrupt, SystemExit, SignalException].include? ex.class
-        Bugsnag.notify(ex, true) do |report|
+        Bugsnag.auto_notify(ex, {
+            :type => "middleware",
+            :attributes => {
+              :name => "mailman"
+            }
+          }) do |report|
           report.severity = "error"
         end
         raise

--- a/lib/bugsnag/integrations/mailman.rb
+++ b/lib/bugsnag/integrations/mailman.rb
@@ -13,13 +13,14 @@ module Bugsnag
         yield
       rescue Exception => ex
         raise ex if [Interrupt, SystemExit, SignalException].include? ex.class
-        Bugsnag.auto_notify(ex, {
-            :type => "middleware",
+        Bugsnag.notify(ex, true) do |report|
+          report.severity = "error"
+          report.set_handled_state({
+            :type => "middleware_handler",
             :attributes => {
               :name => "mailman"
             }
-          }) do |report|
-          report.severity = "error"
+          })
         end
         raise
       ensure

--- a/lib/bugsnag/integrations/rack.rb
+++ b/lib/bugsnag/integrations/rack.rb
@@ -33,13 +33,14 @@ module Bugsnag
         response = @app.call(env)
       rescue Exception => raised
         # Notify bugsnag of rack exceptions
-        Bugsnag.auto_notify(raised, {
-          :type => "middleware_handler",
-          :attirbutes => {
-            :name => "rack"
-          }
-        }) do |report|
+        Bugsnag.notify(raised, true) do |report|
           report.severity = "error"
+          report.set_handled_state({
+            :type => "middleware_handler",
+            :attirbutes => {
+              :name => "rack"
+            }
+          })
         end
 
         # Re-raise the exception
@@ -48,13 +49,14 @@ module Bugsnag
 
       # Notify bugsnag of rack exceptions
       if env["rack.exception"]
-        Bugsnag.auto_notify(env["rack.exception"], {
-          :type => "middleware",
-          :attributes => {
-            :name => "rack"
-          }
-        }) do |report|
+        Bugsnag.notify(env["rack.exception"], true) do |report|
           report.severity = "error"
+          report.set_handled_state({
+            :type => "middleware_handler",
+            :attributes => {
+              :name => "rack"
+            }
+          })
         end
       end
 

--- a/lib/bugsnag/integrations/rack.rb
+++ b/lib/bugsnag/integrations/rack.rb
@@ -36,9 +36,9 @@ module Bugsnag
         Bugsnag.notify(raised, true) do |report|
           report.severity = "error"
           report.set_handled_state({
-            :type => "middleware_handler",
+            :type => "unhandledExceptionMiddleware",
             :attirbutes => {
-              :name => "rack"
+              :framework => "Rack"
             }
           })
         end

--- a/lib/bugsnag/integrations/rack.rb
+++ b/lib/bugsnag/integrations/rack.rb
@@ -1,5 +1,10 @@
 module Bugsnag
   class Rack
+
+    FRAMEWORK_ATTRIBUTES = {
+      :framework => "Rack"
+    }
+
     def initialize(app)
       @app = app
 
@@ -35,12 +40,10 @@ module Bugsnag
         # Notify bugsnag of rack exceptions
         Bugsnag.notify(raised, true) do |report|
           report.severity = "error"
-          report.set_handled_state({
-            :type => "unhandledExceptionMiddleware",
-            :attirbutes => {
-              :framework => "Rack"
-            }
-          })
+          report.severity_reason = {
+            :type => Bugsnag::Report::UNHANDLED_EXCEPTION_MIDDLEWARE,
+            :attributes => Bugsnag::Rack::FRAMEWORK_ATTRIBUTES
+          }
         end
 
         # Re-raise the exception
@@ -51,12 +54,10 @@ module Bugsnag
       if env["rack.exception"]
         Bugsnag.notify(env["rack.exception"], true) do |report|
           report.severity = "error"
-          report.set_handled_state({
-            :type => "middleware_handler",
-            :attributes => {
-              :name => "rack"
-            }
-          })
+          report.severity_reason = {
+            :type => Bugsnag::Report::UNHANDLED_EXCEPTION_MIDDLEWARE,
+            :attributes => FRAMEWORK_ATTRIBUTES
+          }
         end
       end
 

--- a/lib/bugsnag/integrations/rack.rb
+++ b/lib/bugsnag/integrations/rack.rb
@@ -33,7 +33,12 @@ module Bugsnag
         response = @app.call(env)
       rescue Exception => raised
         # Notify bugsnag of rack exceptions
-        Bugsnag.notify(raised, true) do |report|
+        Bugsnag.auto_notify(raised, {
+          :type => "middleware_handler",
+          :attirbutes => {
+            :name => "rack"
+          }
+        }) do |report|
           report.severity = "error"
         end
 
@@ -43,7 +48,12 @@ module Bugsnag
 
       # Notify bugsnag of rack exceptions
       if env["rack.exception"]
-        Bugsnag.notify(env["rack.exception"], true) do |report|
+        Bugsnag.auto_notify(env["rack.exception"], {
+          :type => "middleware",
+          :attributes => {
+            :name => "rack"
+          }
+        }) do |report|
           report.severity = "error"
         end
       end

--- a/lib/bugsnag/integrations/rails/active_record_rescue.rb
+++ b/lib/bugsnag/integrations/rails/active_record_rescue.rb
@@ -8,7 +8,12 @@ module Bugsnag::Rails
           super
         rescue StandardError => exception
           # This exception will NOT be escalated, so notify it here.
-          Bugsnag.notify(exception, true) do |report|
+          Bugsnag.auto_notify(exception, {
+            :type => "middleware",
+            :attributes => {
+              :name => "active record"
+            }
+          }) do |report|
             report.severity = "error"
           end
           raise

--- a/lib/bugsnag/integrations/rails/active_record_rescue.rb
+++ b/lib/bugsnag/integrations/rails/active_record_rescue.rb
@@ -8,13 +8,14 @@ module Bugsnag::Rails
           super
         rescue StandardError => exception
           # This exception will NOT be escalated, so notify it here.
-          Bugsnag.auto_notify(exception, {
-            :type => "middleware",
-            :attributes => {
-              :name => "active record"
-            }
-          }) do |report|
+          Bugsnag.notify(exception, true) do |report|
             report.severity = "error"
+            report.set_handled_state({
+              :type => "middleware_handler",
+              :attributes => {
+                :name => "active record"
+              }
+            })
           end
           raise
         end

--- a/lib/bugsnag/integrations/rails/active_record_rescue.rb
+++ b/lib/bugsnag/integrations/rails/active_record_rescue.rb
@@ -11,9 +11,9 @@ module Bugsnag::Rails
           Bugsnag.notify(exception, true) do |report|
             report.severity = "error"
             report.set_handled_state({
-              :type => "middleware_handler",
+              :type => "unhandledExceptionMiddleware",
               :attributes => {
-                :name => "active record"
+                :framework => "Rails"
               }
             })
           end

--- a/lib/bugsnag/integrations/rails/active_record_rescue.rb
+++ b/lib/bugsnag/integrations/rails/active_record_rescue.rb
@@ -1,6 +1,9 @@
 module Bugsnag::Rails
   module ActiveRecordRescue
     KINDS = [:commit, :rollback].freeze
+    FRAMEWORK_ATTRIBUTES = {
+      :framework => "Rails"
+    }
 
     def run_callbacks(kind, *args, &block)
       if KINDS.include?(kind)
@@ -10,12 +13,10 @@ module Bugsnag::Rails
           # This exception will NOT be escalated, so notify it here.
           Bugsnag.notify(exception, true) do |report|
             report.severity = "error"
-            report.set_handled_state({
-              :type => "unhandledExceptionMiddleware",
-              :attributes => {
-                :framework => "Rails"
-              }
-            })
+            report.severity_reason = {
+              :type => Bugsnag::Report::UNHANDLED_EXCEPTION_MIDDLEWARE,
+              :attributes => FRAMEWORK_ATTRIBUTES
+            }
           end
           raise
         end

--- a/lib/bugsnag/integrations/railtie.rb
+++ b/lib/bugsnag/integrations/railtie.rb
@@ -20,9 +20,9 @@ module Bugsnag
             Bugsnag.notify($!, true) do |report|
               report.severity = "error"
               report.set_handled_state({
-                :type => "middleware_handler",
+                :type => "unhandledExceptionMiddleware",
                 :attributes => {
-                  :name => "railtie"
+                  :framework => "Rails"
                 }
               })
             end

--- a/lib/bugsnag/integrations/railtie.rb
+++ b/lib/bugsnag/integrations/railtie.rb
@@ -7,6 +7,11 @@ require "bugsnag/middleware/rack_request"
 
 module Bugsnag
   class Railtie < Rails::Railtie
+
+    FRAMEWORK_ATTRIBUTES = {
+      :framework => "Rails"
+    }
+
     rake_tasks do
       require "bugsnag/integrations/rake"
       load "bugsnag/tasks/bugsnag.rake"
@@ -19,12 +24,10 @@ module Bugsnag
           if $!
             Bugsnag.notify($!, true) do |report|
               report.severity = "error"
-              report.set_handled_state({
-                :type => "unhandledExceptionMiddleware",
-                :attributes => {
-                  :framework => "Rails"
-                }
-              })
+              report.severity_reason = {
+                :type => Bugsnag::Report::UNHANDLED_EXCEPTION_MIDDLEWARE,
+                :attributes => FRAMEWORK_ATTRIBUTES
+              }
             end
           end
         end

--- a/lib/bugsnag/integrations/railtie.rb
+++ b/lib/bugsnag/integrations/railtie.rb
@@ -17,7 +17,12 @@ module Bugsnag
       runner do
         at_exit do
           if $!
-            Bugsnag.notify($!, true) do |report|
+            Bugsnag.auto_notify($!, {
+              :type => "middleware",
+              :attributes => {
+                :name => "railtie"
+              }
+            }) do |report|
               report.severity = "error"
             end
           end

--- a/lib/bugsnag/integrations/railtie.rb
+++ b/lib/bugsnag/integrations/railtie.rb
@@ -17,13 +17,14 @@ module Bugsnag
       runner do
         at_exit do
           if $!
-            Bugsnag.auto_notify($!, {
-              :type => "middleware",
-              :attributes => {
-                :name => "railtie"
-              }
-            }) do |report|
+            Bugsnag.notify($!, true) do |report|
               report.severity = "error"
+              report.set_handled_state({
+                :type => "middleware_handler",
+                :attributes => {
+                  :name => "railtie"
+                }
+              })
             end
           end
         end

--- a/lib/bugsnag/integrations/rake.rb
+++ b/lib/bugsnag/integrations/rake.rb
@@ -15,9 +15,9 @@ class Rake::Task
     Bugsnag.notify(ex, true) do |report|
       report.severity = "error"
       report.set_handled_state({
-        :type => "middleware_handler",
+        :type => "unhandledExceptionMiddleware",
         :attributes => {
-          :name => "rake"
+          :framework => "Rake"
         }
       })
     end

--- a/lib/bugsnag/integrations/rake.rb
+++ b/lib/bugsnag/integrations/rake.rb
@@ -12,13 +12,14 @@ class Rake::Task
     execute_without_bugsnag(args)
 
   rescue Exception => ex
-    Bugsnag.auto_notify(ex, {
-      :type => "middleware",
-      :attributes => {
-        :name => "rake"
-      }
-    }) do |report|
+    Bugsnag.notify(ex, true) do |report|
       report.severity = "error"
+      report.set_handled_state({
+        :type => "middleware_handler",
+        :attributes => {
+          :name => "rake"
+        }
+      })
     end
     raise
   ensure

--- a/lib/bugsnag/integrations/rake.rb
+++ b/lib/bugsnag/integrations/rake.rb
@@ -12,7 +12,12 @@ class Rake::Task
     execute_without_bugsnag(args)
 
   rescue Exception => ex
-    Bugsnag.notify(ex, true) do |report|
+    Bugsnag.auto_notify(ex, {
+      :type => "middleware",
+      :attributes => {
+        :name => "rake"
+      }
+    }) do |report|
       report.severity = "error"
     end
     raise

--- a/lib/bugsnag/integrations/rake.rb
+++ b/lib/bugsnag/integrations/rake.rb
@@ -4,6 +4,10 @@ Rake::TaskManager.record_task_metadata = true
 
 class Rake::Task
 
+  FRAMEWORK_ATTRIBUTES = {
+    :framework => "Rake"
+  }
+
   def execute_with_bugsnag(args=nil)
     Bugsnag.configuration.app_type = "rake"
     old_task = Bugsnag.configuration.request_data[:bugsnag_running_task]
@@ -14,12 +18,10 @@ class Rake::Task
   rescue Exception => ex
     Bugsnag.notify(ex, true) do |report|
       report.severity = "error"
-      report.set_handled_state({
-        :type => "unhandledExceptionMiddleware",
-        :attributes => {
-          :framework => "Rake"
-        }
-      })
+      report.severity_reason = {
+        :type => Bugsnag::Report::UNHANDLED_EXCEPTION_MIDDLEWARE,
+        :attributes => FRAMEWORK_ATTRIBUTES
+      }
     end
     raise
   ensure

--- a/lib/bugsnag/integrations/resque.rb
+++ b/lib/bugsnag/integrations/resque.rb
@@ -29,9 +29,9 @@ module Bugsnag
       Bugsnag.notify(exception, true) do |report|
         report.severity = "error"
         report.set_handled_state({
-          :type => "middleware_handler",
+          :type => "unhandledExceptionMiddleware",
           :attributes => {
-            :name => "mailman"
+            :framework => "Resque"
           }
         })
         report.meta_data.merge!({:context => "#{payload['class']}@#{queue}", :payload => payload, :delivery_method => :synchronous})

--- a/lib/bugsnag/integrations/resque.rb
+++ b/lib/bugsnag/integrations/resque.rb
@@ -26,7 +26,12 @@ module Bugsnag
     end
 
     def save
-      Bugsnag.notify(exception, true) do |report|
+      Bugsnag.auto_notify(exception, {
+        :type => "middleware",
+        :attributes => {
+          :name => "mailman"
+        }
+      }) do |report|
         report.severity = "error"
         report.meta_data.merge!({:context => "#{payload['class']}@#{queue}", :payload => payload, :delivery_method => :synchronous})
       end

--- a/lib/bugsnag/integrations/resque.rb
+++ b/lib/bugsnag/integrations/resque.rb
@@ -26,13 +26,14 @@ module Bugsnag
     end
 
     def save
-      Bugsnag.auto_notify(exception, {
-        :type => "middleware",
-        :attributes => {
-          :name => "mailman"
-        }
-      }) do |report|
+      Bugsnag.notify(exception, true) do |report|
         report.severity = "error"
+        report.set_handled_state({
+          :type => "middleware_handler",
+          :attributes => {
+            :name => "mailman"
+          }
+        })
         report.meta_data.merge!({:context => "#{payload['class']}@#{queue}", :payload => payload, :delivery_method => :synchronous})
       end
     end

--- a/lib/bugsnag/integrations/resque.rb
+++ b/lib/bugsnag/integrations/resque.rb
@@ -3,6 +3,11 @@ require "resque/failure/multiple"
 
 module Bugsnag
   class Resque < ::Resque::Failure::Base
+
+    FRAMEWORK_ATTRIBUTES = {
+      :framework => "Resque"
+    }
+
     def self.configure(&block)
       add_failure_backend
       Bugsnag.configure(&block)
@@ -28,12 +33,10 @@ module Bugsnag
     def save
       Bugsnag.notify(exception, true) do |report|
         report.severity = "error"
-        report.set_handled_state({
-          :type => "unhandledExceptionMiddleware",
-          :attributes => {
-            :framework => "Resque"
-          }
-        })
+        report.severity_reason = {
+          :type => Bugsnag::Report::UNHANDLED_EXCEPTION_MIDDLEWARE,
+          :attributes => FRAMEWORK_ATTRIBUTES
+        }
         report.meta_data.merge!({:context => "#{payload['class']}@#{queue}", :payload => payload, :delivery_method => :synchronous})
       end
     end

--- a/lib/bugsnag/integrations/sidekiq.rb
+++ b/lib/bugsnag/integrations/sidekiq.rb
@@ -24,7 +24,7 @@ module Bugsnag
         Bugsnag.notify(ex, true) do |report|
           report.severity = "error"
           report.severity_reason = {
-            :type => Bugsnag::Report::UNHANDLED_MIDDLEWARE_EXCEPTION,
+            :type => Bugsnag::Report::UNHANDLED_EXCEPTION_MIDDLEWARE,
             :attributes => FRAMEWORK_ATTRIBUTES
           }
         end

--- a/lib/bugsnag/integrations/sidekiq.rb
+++ b/lib/bugsnag/integrations/sidekiq.rb
@@ -19,9 +19,9 @@ module Bugsnag
         Bugsnag.notify(ex, true) do |report|
           report.severity = "error"
           report.set_handled_states({
-            :type => 'middleware_handler',
+            :type => 'unhandledExceptionMiddleware',
             :attributes => {
-              :name => "sidekiq"
+              :framework => "Sidekiq"
             }
           })
         end

--- a/lib/bugsnag/integrations/sidekiq.rb
+++ b/lib/bugsnag/integrations/sidekiq.rb
@@ -2,6 +2,11 @@ require 'sidekiq'
 
 module Bugsnag
   class Sidekiq
+
+    FRAMEWORK_ATTRIBUTES = {
+      :framework => "Sidekiq"
+    }
+
     def initialize
       Bugsnag.configuration.internal_middleware.use(Bugsnag::Middleware::Sidekiq)
       Bugsnag.configuration.app_type = "sidekiq"
@@ -18,12 +23,10 @@ module Bugsnag
         raise ex if [Interrupt, SystemExit, SignalException].include? ex.class
         Bugsnag.notify(ex, true) do |report|
           report.severity = "error"
-          report.set_handled_states({
-            :type => 'unhandledExceptionMiddleware',
-            :attributes => {
-              :framework => "Sidekiq"
-            }
-          })
+          report.severity_reason = {
+            :type => Bugsnag::Report::UNHANDLED_MIDDLEWARE_EXCEPTION,
+            :attributes => FRAMEWORK_ATTRIBUTES
+          }
         end
         raise
       ensure

--- a/lib/bugsnag/integrations/sidekiq.rb
+++ b/lib/bugsnag/integrations/sidekiq.rb
@@ -16,16 +16,14 @@ module Bugsnag
         yield
       rescue Exception => ex
         raise ex if [Interrupt, SystemExit, SignalException].include? ex.class
-        Bugsnag.auto_notify(
-          ex,
-          {
+        Bugsnag.notify(ex, true) do |report|
+          report.severity = "error"
+          report.set_handled_states({
             :type => 'middleware_handler',
             :attributes => {
               :name => "sidekiq"
             }
-          }
-        ) do |report|
-          report.severity = "error"
+          })
         end
         raise
       ensure

--- a/lib/bugsnag/integrations/sidekiq.rb
+++ b/lib/bugsnag/integrations/sidekiq.rb
@@ -16,7 +16,15 @@ module Bugsnag
         yield
       rescue Exception => ex
         raise ex if [Interrupt, SystemExit, SignalException].include? ex.class
-        Bugsnag.notify(ex, true) do |report|
+        Bugsnag.auto_notify(
+          ex,
+          {
+            :type => 'middleware_handler',
+            :attributes => {
+              :name => "sidekiq"
+            }
+          }
+        ) do |report|
           report.severity = "error"
         end
         raise

--- a/lib/bugsnag/middleware/classify_error.rb
+++ b/lib/bugsnag/middleware/classify_error.rb
@@ -1,0 +1,45 @@
+module Bugsnag::Middleware
+  class ClassifyError
+    INFO_CLASSES = [
+        "AbstractController::ActionNotFound",
+        "ActionController::InvalidAuthenticityToken",
+        "ActionController::ParameterMissing",
+        "ActionController::UnknownAction",
+        "ActionController::UnknownFormat",
+        "ActionController::UnknownHttpMethod",
+        "ActiveRecord::RecordNotFound",
+        "CGI::Session::CookieStore::TamperedWithCookie",
+        "Mongoid::Errors::DocumentNotFound",
+        "SignalException",
+        "SystemExit"
+    ]
+
+    def initialize(bugsnag)
+      @bugsnag = bugsnag
+    end
+
+    def call(report)
+      report.raw_exceptions.each do |ex|
+        ancestor_chain = ex.class.ancestors.select { |ancestor| ancestor.is_a?(Class) }.map { |ancestor| ancestor.to_s }
+
+        INFO_CLASSES.each do |info_class|
+          if ancestor_chain.include?(info_class) 
+            report.set_handled_state(
+              {
+                :type => "error_class",
+                :attributes => {
+                  :errorClass => info_class
+                }
+              }
+            )
+            report.severity = 'info'
+            break;
+          end
+        end
+      end
+
+      @bugsnag.call(report)
+    end
+  end
+end
+  

--- a/lib/bugsnag/middleware/classify_error.rb
+++ b/lib/bugsnag/middleware/classify_error.rb
@@ -20,20 +20,23 @@ module Bugsnag::Middleware
 
     def call(report)
       report.raw_exceptions.each do |ex|
-        ancestor_chain = ex.class.ancestors.select { |ancestor| ancestor.is_a?(Class) }.map { |ancestor| ancestor.to_s }
+
+        ancestor_chain = ex.class.ancestors.select {
+          |ancestor| ancestor.is_a?(Class) 
+        }.map {
+          |ancestor| ancestor.to_s
+        }
 
         INFO_CLASSES.each do |info_class|
           if ancestor_chain.include?(info_class) 
-            report.set_handled_state(
-              {
-                :type => "error_class",
-                :attributes => {
-                  :errorClass => info_class
-                }
+            report.severity_reason = {
+              :type => Bugsnag::Report::ERROR_CLASS,
+              :attributes => {
+                :errorClass => info_class
               }
-            )
+            }
             report.severity = 'info'
-            break;
+            break
           end
         end
       end

--- a/lib/bugsnag/report.rb
+++ b/lib/bugsnag/report.rb
@@ -51,10 +51,8 @@ module Bugsnag
       self.hostname = configuration.hostname
       self.meta_data = {}
       self.release_stage = configuration.release_stage
-      self.severity = "warning"
-      self.severity_reason = {
-        :type => HANDLED_EXCEPTION
-      }
+      self.severity = auto_notify ? "error" : "warning"
+      self.severity_reason = auto_notify ? {:type => UNHANDLED_EXCEPTION} : {:type => HANDLED_EXCEPTION}
       self.user = {}
     end
 

--- a/lib/bugsnag/report.rb
+++ b/lib/bugsnag/report.rb
@@ -8,6 +8,13 @@ module Bugsnag
     NOTIFIER_VERSION = Bugsnag::VERSION
     NOTIFIER_URL = "http://www.bugsnag.com"
 
+    UNHANDLED_EXCEPTION = "unhandledException"
+    UNHANDLED_EXCEPTION_MIDDLEWARE = "unhandledExceptionMiddleware"
+    ERROR_CLASS = "errorClass"
+    HANDLED_EXCEPTION = "handledException"
+    USER_SPECIFIED_SEVERITY = "userSpecifiedSeverity"
+    USER_CALLBACK_SET_SEVERITY = "userCallbackSetSeverity"
+
     MAX_EXCEPTIONS_TO_UNWRAP = 5
 
     CURRENT_PAYLOAD_VERSION = "2"
@@ -46,7 +53,7 @@ module Bugsnag
       self.release_stage = configuration.release_stage
       self.severity = "warning"
       self.severity_reason = {
-        :type => "handledException"
+        :type => HANDLED_EXCEPTION
       }
       self.user = {}
     end

--- a/lib/bugsnag/report.rb
+++ b/lib/bugsnag/report.rb
@@ -28,8 +28,9 @@ module Bugsnag
     attr_accessor :severity
     attr_accessor :user
 
-    def initialize(exception, passed_configuration)
+    def initialize(exception, passed_configuration, auto_notify=false)
       @should_ignore = false
+      @auto_notify = auto_notify
       @unhandled = false
 
       self.configuration = passed_configuration
@@ -117,7 +118,7 @@ module Bugsnag
     end
 
     def set_handled_state(handled_state)
-      if !@unhandled
+      if @auto_notify
         @unhandled = true
         @severity_reason = handled_state
       end

--- a/lib/bugsnag/report.rb
+++ b/lib/bugsnag/report.rb
@@ -118,7 +118,7 @@ module Bugsnag
     end
 
     def set_handled_state(handled_state)
-      if @auto_notify
+      if @auto_notify && !@unhandled
         @unhandled = true
         @severity_reason = handled_state
       end

--- a/lib/bugsnag/report.rb
+++ b/lib/bugsnag/report.rb
@@ -28,10 +28,9 @@ module Bugsnag
     attr_accessor :severity
     attr_accessor :user
 
-    def initialize(exception, passed_configuration, unhandled=false, severity_reason=nil)
+    def initialize(exception, passed_configuration)
       @should_ignore = false
-      @unhandled = unhandled
-      @severity_reason = severity_reason
+      @unhandled = false
 
       self.configuration = passed_configuration
 
@@ -115,6 +114,13 @@ module Bugsnag
         },
         :events => [payload_event]
       }
+    end
+
+    def set_handled_state(handled_state)
+      if !@unhandled
+        @unhandled = true
+        @severity_reason = handled_state
+      end
     end
 
     def ignore?

--- a/lib/bugsnag/tasks/bugsnag.rake
+++ b/lib/bugsnag/tasks/bugsnag.rake
@@ -6,7 +6,14 @@ namespace :bugsnag do
     begin
       raise RuntimeError.new("Bugsnag test exception")
     rescue => e
-      Bugsnag.notify(e, {:context => "rake#test_exception"})
+      Bugsnag.auto_notify(e, {
+        :type => "middleware",
+        :attributes => {
+          :name => "rake"
+        }
+      }) do |report|
+        report.context = "rake#test_exception"
+      end
     end
   end
 end

--- a/lib/bugsnag/tasks/bugsnag.rake
+++ b/lib/bugsnag/tasks/bugsnag.rake
@@ -6,12 +6,7 @@ namespace :bugsnag do
     begin
       raise RuntimeError.new("Bugsnag test exception")
     rescue => e
-      Bugsnag.auto_notify(e, {
-        :type => "middleware",
-        :attributes => {
-          :name => "rake"
-        }
-      }) do |report|
+      Bugsnag.notify(e) do |report|
         report.context = "rake#test_exception"
       end
     end

--- a/spec/middleware_spec.rb
+++ b/spec/middleware_spec.rb
@@ -185,9 +185,9 @@ describe Bugsnag::MiddlewareStack do
       end
 
       def call(report)
-        report.set_handled_state({
+        report.severity_reason = {
           :test => "test"
-        })
+        }
         @bugsnag.call(report)
       end
     end
@@ -197,12 +197,12 @@ describe Bugsnag::MiddlewareStack do
     end
 
     Bugsnag.notify(BugsnagTestException.new("It crashed"), true) do |report|
-      report.set_handled_state({
+      report.severity_reason = {
         :type => "middleware_handler",
         :attributes => {
           :name => "middleware_test"
         }
-      })
+      }
     end
 
     expect(Bugsnag).to have_sent_notification{ |payload|
@@ -214,31 +214,6 @@ describe Bugsnag::MiddlewareStack do
           "name" => "middleware_test"
         }
       })
-    }
-  end
-
-  it "sets defaultSeverity to false if changed in middleware" do
-    SeverityChanger = Class.new do
-      def initialize(bugsnag)
-        @bugsnag = bugsnag
-      end
-
-      def call(report)
-        report.severity = "info"
-        @bugsnag.call(report)
-      end
-    end
-
-    Bugsnag.configure do |c|
-      c.middleware.use SeverityChanger
-    end
-
-    Bugsnag.notify(BugsnagTestException.new("It crashed"))
-
-    expect(Bugsnag).to have_sent_notification{ |payload|
-      event = get_event_from_payload(payload)
-      expect(event["severity"]).to eq("info")
-      expect(event["defaultSeverity"]).to be false
     }
   end
 

--- a/spec/report_spec.rb
+++ b/spec/report_spec.rb
@@ -882,19 +882,18 @@ describe Bugsnag::Report do
     expect(Bugsnag).to have_sent_notification{ |payload|
       event = payload["events"][0]
       expect(event["unhandled"]).to be false
-      expect(event["severityReason"].nil?).to be true
-      expect(event["defaultSeverity"]).to be true
+      expect(event["severityReason"]).to eq({"type" => "handledException"})
     }
   end
 
   it 'should attach severity reason through a block when auto_notify is true' do
     Bugsnag.notify(BugsnagTestException.new("It crashed"), true) do |report|
-      report.set_handled_state({
+      report.severity_reason = {
         :type => "middleware_handler",
         :attributes => {
           :name => "middleware_test"
         }
-      })
+      }
     end
 
     expect(Bugsnag).to have_sent_notification{ |payload|
@@ -911,30 +910,20 @@ describe Bugsnag::Report do
     }
   end
 
-  it 'should not attach severity reason when auto_notify is false' do
+  it 'should not attach severity reason from callback when auto_notify is false' do
     Bugsnag.notify(BugsnagTestException.new("It crashed")) do |report|
-      report.set_handled_state({
+      report.severity_reason = {
         :type => "middleware_handler",
         :attributes => {
           :name => "middleware_test"
         }
-      })
+      }
     end
 
     expect(Bugsnag).to have_sent_notification{ |payload|
       event = payload["events"][0]
       expect(event["unhandled"]).to be false
-      expect(event["severityReason"].nil?).to be true
-    }
-  end
-
-  it 'should set default_severity flag if severity is changed' do
-    Bugsnag.notify(BugsnagTestException.new("It crashed")) do |report|
-      report.severity = "info"
-    end
-
-    expect(Bugsnag).to have_sent_notification{ |payload|
-      expect(payload["events"][0]["defaultSeverity"]).to be false
+      expect(event["severityReason"]).to eq({"type" => "handledException"})
     }
   end
 


### PR DESCRIPTION
- Adds `defaultSeverity`, `unhandled`, and `severityReasons` payload properties to support upcoming handled/unhandled functionality
- Created separate notifier functions, `notify` for handled notifications and `auto_notify` for automated/middleware notifications
- Middleware set up with correct severity reasons
- Discussion needed around language-level ruby error handling, and how to allow the user to this up without delving into severity reasons
_references [PLAT_207](https://bugsnag.atlassian.net/browse/PLAT-207)_