### PR TITLE
Adding handled/unhandled payload population

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,4 +10,7 @@ rvm:
 - jruby-19mode
 
 before_install:
+- gem install bundler -v 1.12
+- gem update --system
+- bundle --version
 - gem --version

--- a/lib/bugsnag.rb
+++ b/lib/bugsnag.rb
@@ -80,7 +80,7 @@ module Bugsnag
     # error class
     def auto_notify(exception, overrides=nil, request_data=nil, &block)
       overrides ||= {}
-      overrides.merge!({:severity => "error"})
+      overrides.merge!({:severity => "error", :unhandled => true})
       notify_or_ignore(exception, overrides, request_data, &block) if configuration.auto_notify
     end
 

--- a/lib/bugsnag.rb
+++ b/lib/bugsnag.rb
@@ -24,6 +24,7 @@ require "bugsnag/middleware/sidekiq"
 require "bugsnag/middleware/mailman"
 require "bugsnag/middleware/rake"
 require "bugsnag/middleware/callbacks"
+require "bugsnag/middleware/classify_error"
 
 module Bugsnag
   LOG_PREFIX = "** [Bugsnag] "
@@ -42,6 +43,9 @@ module Bugsnag
 
       # Use resque for asynchronous notification if required
       require "bugsnag/delay/resque" if configuration.delay_with_resque && defined?(Resque)
+
+      # Add info error classifier to internal middleware
+      configuration.internal_middleware.use(Bugsnag::Middleware::ClassifyError)
 
       # Warn if an api_key hasn't been set
       @key_warning = false unless defined?(@key_warning)

--- a/lib/bugsnag/configuration.rb
+++ b/lib/bugsnag/configuration.rb
@@ -45,20 +45,6 @@ module Bugsnag
       "rack.request.form_vars"
     ].freeze
 
-    DEFAULT_IGNORE_CLASSES = [
-      "AbstractController::ActionNotFound",
-      "ActionController::InvalidAuthenticityToken",
-      "ActionController::ParameterMissing",
-      "ActionController::UnknownAction",
-      "ActionController::UnknownFormat",
-      "ActionController::UnknownHttpMethod",
-      "ActiveRecord::RecordNotFound",
-      "CGI::Session::CookieStore::TamperedWithCookie",
-      "Mongoid::Errors::DocumentNotFound",
-      "SignalException",
-      "SystemExit",
-    ].freeze
-
     DEFAULT_IGNORE_USER_AGENTS = [].freeze
 
     DEFAULT_DELIVERY_METHOD = :thread_queue
@@ -72,7 +58,7 @@ module Bugsnag
       self.send_environment = false
       self.send_code = true
       self.params_filters = Set.new(DEFAULT_PARAMS_FILTERS)
-      self.ignore_classes = Set.new(DEFAULT_IGNORE_CLASSES)
+      self.ignore_classes = Set.new()
       self.ignore_user_agents = Set.new(DEFAULT_IGNORE_USER_AGENTS)
       self.endpoint = DEFAULT_ENDPOINT
       self.hostname = default_hostname

--- a/lib/bugsnag/delayed_job.rb
+++ b/lib/bugsnag/delayed_job.rb
@@ -19,9 +19,9 @@ unless defined? Delayed::Plugins::Bugsnag
                 :id => job.id,
               },
               :severity_reason => {
-                :type => "middleware_handler",
+                :type => Bugsnag::Notification::UNHANDLED_EXCEPTION_MIDDLEWARE,
                 :attributes => {
-                  :name => "delayed_job"
+                  :framework => "DelayedJob"
                 }
               }
             }

--- a/lib/bugsnag/delayed_job.rb
+++ b/lib/bugsnag/delayed_job.rb
@@ -17,6 +17,12 @@ unless defined? Delayed::Plugins::Bugsnag
               :job => {
                 :class => job.class.name,
                 :id => job.id,
+              },
+              :severity_reason => {
+                :type => "middleware_handler",
+                :attributes => {
+                  :name => "delayed_job"
+                }
               }
             }
             if job.respond_to?(:queue) && (queue = job.queue)

--- a/lib/bugsnag/mailman.rb
+++ b/lib/bugsnag/mailman.rb
@@ -17,9 +17,9 @@ module Bugsnag
         raise ex if [Interrupt, SystemExit, SignalException].include? ex.class
         Bugsnag.auto_notify(ex, {
           :severity_reason => {
-            :type => "middleware_handler",
+            :type => Bugsnag::Notification::UNHANDLED_EXCEPTION_MIDDLEWARE,
             :attributes => {
-              :name => "mailman"
+              :framework => "Mailman"
             }
           }
         })

--- a/lib/bugsnag/mailman.rb
+++ b/lib/bugsnag/mailman.rb
@@ -15,7 +15,14 @@ module Bugsnag
         yield
       rescue Exception => ex
         raise ex if [Interrupt, SystemExit, SignalException].include? ex.class
-        Bugsnag.auto_notify(ex)
+        Bugsnag.auto_notify(ex, {
+          :severity_reason => {
+            :type => "middleware_handler",
+            :attributes => {
+              :name => "mailman"
+            }
+          }
+        })
         raise
       ensure
         Bugsnag.clear_request_data

--- a/lib/bugsnag/middleware/classify_error.rb
+++ b/lib/bugsnag/middleware/classify_error.rb
@@ -30,7 +30,7 @@ module Bugsnag::Middleware
         }
 
         INFO_CLASSES.each do |info_class|
-          if ancestor_chain.include?(info_class) 
+          if ancestor_chain.include?(info_class)
             notification.severity_reason = {
               :type => Bugsnag::Notification::ERROR_CLASS,
               :attributes => {
@@ -46,7 +46,7 @@ module Bugsnag::Middleware
         break if outer_break
       end
 
-      @bugsnag.call(report)
+      @bugsnag.call(notification)
     end
   end
 end

--- a/lib/bugsnag/middleware/classify_error.rb
+++ b/lib/bugsnag/middleware/classify_error.rb
@@ -1,0 +1,53 @@
+module Bugsnag::Middleware
+  class ClassifyError
+    INFO_CLASSES = [
+        "AbstractController::ActionNotFound",
+        "ActionController::InvalidAuthenticityToken",
+        "ActionController::ParameterMissing",
+        "ActionController::UnknownAction",
+        "ActionController::UnknownFormat",
+        "ActionController::UnknownHttpMethod",
+        "ActiveRecord::RecordNotFound",
+        "CGI::Session::CookieStore::TamperedWithCookie",
+        "Mongoid::Errors::DocumentNotFound",
+        "SignalException",
+        "SystemExit"
+    ]
+
+    def initialize(bugsnag)
+      @bugsnag = bugsnag
+    end
+
+    def call(notification)
+      notification.exceptions.each do |ex|
+
+        outer_break = false
+
+        ancestor_chain = ex.class.ancestors.select {
+          |ancestor| ancestor.is_a?(Class) 
+        }.map {
+          |ancestor| ancestor.to_s
+        }
+
+        INFO_CLASSES.each do |info_class|
+          if ancestor_chain.include?(info_class) 
+            notification.severity_reason = {
+              :type => Bugsnag::Notification::ERROR_CLASS,
+              :attributes => {
+                :errorClass => info_class
+              }
+            }
+            notification.severity = 'info'
+            outer_break = true
+            break
+          end
+        end
+
+        break if outer_break
+      end
+
+      @bugsnag.call(report)
+    end
+  end
+end
+    

--- a/lib/bugsnag/notification.rb
+++ b/lib/bugsnag/notification.rb
@@ -19,7 +19,7 @@ module Bugsnag
     UNHANDLED_EXCEPTION = "unhandledException"
     UNHANDLED_EXCEPTION_MIDDLEWARE = "unhandledExceptionMiddleware"
     ERROR_CLASS = "errorClass"
-    USER_SPECFIEID_SEVERITY = "userSpecifiedSeverity"
+    USER_SPECIFIED_SEVERITY = "userSpecifiedSeverity"
     USER_CALLBACK_SET_SEVERITY = "userCallbackSetSeverity"
 
     API_KEY_REGEX = /[0-9a-f]{32}/i
@@ -78,7 +78,7 @@ module Bugsnag
       elsif valid_severity
         @severity = @overrides[:severity]
         @severity_reason = {
-          :type => USER_SPECFIEID_SEVERITY
+          :type => USER_SPECIFIED_SEVERITY
         }
       elsif has_reason
         @severity_reason = @overrides[:severity_reason]

--- a/lib/bugsnag/notification.rb
+++ b/lib/bugsnag/notification.rb
@@ -60,21 +60,21 @@ module Bugsnag
       @initial_severity = nil
 
       if @overrides.key? :unhandled
-        self.unhandled = @overrides[:unhandled]
+        @unhandled = @overrides[:unhandled]
         @overrides.delete :unhandled
       end
       
       if @overrides.key? :severity_reason
-        self.severity_reason = @overrides[:severity_reason]
+        @severity_reason = @overrides[:severity_reason]
         @overrides.delete :severity_reason 
       end
 
-      if !self.unhandled && (@overrides.key? :severity)
-        self.default_severity = false
+      if !@unhandled && (@overrides.key? :severity)
+        @default_severity = false
       end
 
       self.severity = @overrides[:severity]
-      self.initial_severity = self.severity
+      @initial_severity = self.severity
       @overrides.delete :severity
 
       if @overrides.key? :grouping_hash
@@ -242,7 +242,7 @@ module Bugsnag
         return if @should_ignore
 
         # Check to see if the severity has been changed
-        if @initial_severity != @severity
+        if @initial_severity != self.severity
           @default_severity = false
         end
 
@@ -265,17 +265,17 @@ module Bugsnag
           :type => @configuration.app_type
         },
         :context => self.context,
-        :defaultSeverity => self.default_severity,
+        :defaultSeverity => @default_severity,
         :user => @user,
         :payloadVersion => payload_version,
         :exceptions => exception_list,
         :severity => self.severity,
-        :unhandled => self.unhandled,
+        :unhandled => @unhandled,
         :groupingHash => self.grouping_hash,
       }
 
-      if self.unhandled
-        payload_event[:severity_reason] = self.severity_reason
+      if @unhandled
+        payload_event[:severityReason] = @severity_reason
       end
 
       payload_event[:device] = {:hostname => @configuration.hostname} if @configuration.hostname

--- a/lib/bugsnag/que.rb
+++ b/lib/bugsnag/que.rb
@@ -5,9 +5,9 @@ if defined?(::Que)
 
       Bugsnag.auto_notify(error, {
         :severity_reason => {
-          :type => "middleware_handler",
+          :type => Bugsnag::Notification::UNHANDLED_EXCEPTION_MIDDLEWARE,
           :attributes => {
-            :name => "que"
+            :framework => "Que"
           }
         }
       }) do |notification|

--- a/lib/bugsnag/que.rb
+++ b/lib/bugsnag/que.rb
@@ -3,7 +3,14 @@ if defined?(::Que)
     begin
       job = job.dup # Make sure the original job object is not mutated.
 
-      Bugsnag.auto_notify(error) do |notification|
+      Bugsnag.auto_notify(error, {
+        :severity_reason => {
+          :type => "middleware_handler",
+          :attributes => {
+            :name => "que"
+          }
+        }
+      }) do |notification|
         job[:error_count] += 1
 
         # If the job was scheduled using ActiveJob then unwrap the job details for clarity:

--- a/lib/bugsnag/rack.rb
+++ b/lib/bugsnag/rack.rb
@@ -30,11 +30,20 @@ module Bugsnag
       # Set the request data for bugsnag middleware to use
       Bugsnag.set_request_data(:rack_env, env)
 
+      overrides = {
+        :severity_reason => {
+          :type => "middleware_handler",
+          :attributes => {
+            :name => "rack"
+          }
+        }
+      }
+
       begin
         response = @app.call(env)
       rescue Exception => raised
         # Notify bugsnag of rack exceptions
-        Bugsnag.auto_notify(raised)
+        Bugsnag.auto_notify(raised, overrides)
 
         # Re-raise the exception
         raise
@@ -42,7 +51,7 @@ module Bugsnag
 
       # Notify bugsnag of rack exceptions
       if env["rack.exception"]
-        Bugsnag.auto_notify(env["rack.exception"])
+        Bugsnag.auto_notify(env["rack.exception"], overrides)
       end
 
       response

--- a/lib/bugsnag/rack.rb
+++ b/lib/bugsnag/rack.rb
@@ -1,5 +1,13 @@
 module Bugsnag
   class Rack
+
+    SEVERITY_REASON = {
+      :type => "middleware_handler",
+      :attributes => {
+        :name => "rack"
+      }
+    }
+
     def initialize(app)
       @app = app
 
@@ -30,20 +38,13 @@ module Bugsnag
       # Set the request data for bugsnag middleware to use
       Bugsnag.set_request_data(:rack_env, env)
 
-      overrides = {
-        :severity_reason => {
-          :type => "middleware_handler",
-          :attributes => {
-            :name => "rack"
-          }
-        }
-      }
-
       begin
         response = @app.call(env)
       rescue Exception => raised
         # Notify bugsnag of rack exceptions
-        Bugsnag.auto_notify(raised, overrides)
+        Bugsnag.auto_notify(raised, {
+          :severity_reason => SEVERITY_REASON
+        })
 
         # Re-raise the exception
         raise
@@ -51,7 +52,9 @@ module Bugsnag
 
       # Notify bugsnag of rack exceptions
       if env["rack.exception"]
-        Bugsnag.auto_notify(env["rack.exception"], overrides)
+        Bugsnag.auto_notify(env["rack.exception"], {
+          :severity_reason => SEVERITY_REASON
+        })
       end
 
       response

--- a/lib/bugsnag/rack.rb
+++ b/lib/bugsnag/rack.rb
@@ -2,9 +2,9 @@ module Bugsnag
   class Rack
 
     SEVERITY_REASON = {
-      :type => "middleware_handler",
+      :type => Bugsnag::Notification::UNHANDLED_EXCEPTION_MIDDLEWARE,
       :attributes => {
-        :name => "rack"
+        :framework => "Rack"
       }
     }
 

--- a/lib/bugsnag/rails/action_controller_rescue.rb
+++ b/lib/bugsnag/rails/action_controller_rescue.rb
@@ -1,6 +1,14 @@
 # Rails 2.x only
 module Bugsnag::Rails
   module ActionControllerRescue
+
+    SEVERITY_REASON = {
+      :type => "middleware_handler",
+      :attributes => {
+        :name => "rails"
+      }
+    }
+
     def self.included(base)
       base.extend(ClassMethods)
 
@@ -22,13 +30,17 @@ module Bugsnag::Rails
     end
 
     def rescue_action_in_public_with_bugsnag(exception)
-      Bugsnag.auto_notify(exception)
+      Bugsnag.auto_notify(exception, {
+        :severity_reason => SEVERITY_REASON
+      })
 
       rescue_action_in_public_without_bugsnag(exception)
     end
 
     def rescue_action_locally_with_bugsnag(exception)
-      Bugsnag.auto_notify(exception)
+      Bugsnag.auto_notify(exception, {
+        :severity_reason => SEVERITY_REASON
+      })
 
       rescue_action_locally_without_bugsnag(exception)
     end

--- a/lib/bugsnag/rails/action_controller_rescue.rb
+++ b/lib/bugsnag/rails/action_controller_rescue.rb
@@ -3,9 +3,9 @@ module Bugsnag::Rails
   module ActionControllerRescue
 
     SEVERITY_REASON = {
-      :type => "middleware_handler",
+      :type => Bugsnag::Notification::UNHANDLED_EXCEPTION_MIDDLEWARE,
       :attributes => {
-        :name => "rails"
+        :framework => "Rails"
       }
     }
 

--- a/lib/bugsnag/rails/active_record_rescue.rb
+++ b/lib/bugsnag/rails/active_record_rescue.rb
@@ -10,9 +10,9 @@ module Bugsnag::Rails
           # This exception will NOT be escalated, so notify it here.
           Bugsnag.auto_notify(exception, {
             :severity_reason => {
-              :type => "middleware_handler",
+              :type => Bugsnag::Notification::UNHANDLED_EXCEPTION_MIDDLEWARE,
               :attributes => {
-                :name => "rails"
+                :framework => "Rails"
               }
             }
           })

--- a/lib/bugsnag/rails/active_record_rescue.rb
+++ b/lib/bugsnag/rails/active_record_rescue.rb
@@ -8,7 +8,14 @@ module Bugsnag::Rails
           super
         rescue StandardError => exception
           # This exception will NOT be escalated, so notify it here.
-          Bugsnag.auto_notify(exception)
+          Bugsnag.auto_notify(exception, {
+            :severity_reason => {
+              :type => "middleware_handler",
+              :attributes => {
+                :name => "rails"
+              }
+            }
+          })
           raise
         end
       else

--- a/lib/bugsnag/railtie.rb
+++ b/lib/bugsnag/railtie.rb
@@ -19,9 +19,9 @@ module Bugsnag
           if $!
             Bugsnag.auto_notify($!, {
               :severity_reason => {
-                :type => "middleware_handler",
+                :type => Bugsnag::Notification::UNHANDLED_EXCEPTION_MIDDLEWARE,
                 :attributes => {
-                  :name => "railtie"
+                  :framework => "Rails"
                 }
               }
             })

--- a/lib/bugsnag/railtie.rb
+++ b/lib/bugsnag/railtie.rb
@@ -17,7 +17,14 @@ module Bugsnag
       runner do
         at_exit do
           if $!
-            Bugsnag.auto_notify($!)
+            Bugsnag.auto_notify($!, {
+              :severity_reason => {
+                :type => "middleware_handler",
+                :attributes => {
+                  :name => "railtie"
+                }
+              }
+            })
           end
         end
       end

--- a/lib/bugsnag/rake.rb
+++ b/lib/bugsnag/rake.rb
@@ -14,9 +14,9 @@ class Rake::Task
   rescue Exception => ex
     Bugsnag.auto_notify(ex, {
       :severity_reason => {
-        :type => "middleware_handler",
+        :type => Bugsnag::Notification::UNHANDLED_EXCEPTION_MIDDLEWARE,
         :attributes => {
-          :name => "rake"
+          :framework => "Rake"
         }
       }
     })

--- a/lib/bugsnag/rake.rb
+++ b/lib/bugsnag/rake.rb
@@ -12,7 +12,14 @@ class Rake::Task
     execute_without_bugsnag(args)
 
   rescue Exception => ex
-    Bugsnag.auto_notify(ex)
+    Bugsnag.auto_notify(ex, {
+      :severity_reason => {
+        :type => "middleware_handler",
+        :attributes => {
+          :name => "rake"
+        }
+      }
+    })
     raise
   ensure
     Bugsnag.set_request_data :bugsnag_running_task, old_task

--- a/lib/bugsnag/resque.rb
+++ b/lib/bugsnag/resque.rb
@@ -26,7 +26,16 @@ module Bugsnag
     end
 
     def save
-      Bugsnag.auto_notify(exception, {:context => "#{payload['class']}@#{queue}", :payload => payload})
+      Bugsnag.auto_notify(exception, {
+        :context => "#{payload['class']}@#{queue}",
+        :payload => payload,
+        :severity_reason => {
+          :type => "middleware_handler",
+          :attributes => {
+            :name => "resque"
+          }
+        }
+      })
     end
   end
 end

--- a/lib/bugsnag/resque.rb
+++ b/lib/bugsnag/resque.rb
@@ -30,9 +30,9 @@ module Bugsnag
         :context => "#{payload['class']}@#{queue}",
         :payload => payload,
         :severity_reason => {
-          :type => "middleware_handler",
+          :type => Bugsnag::Notification::UNHANDLED_EXCEPTION_MIDDLEWARE,
           :attributes => {
-            :name => "resque"
+            :framework => "Resque"
           }
         }
       })

--- a/lib/bugsnag/shoryuken.rb
+++ b/lib/bugsnag/shoryuken.rb
@@ -18,7 +18,14 @@ module Bugsnag
 
         yield
       rescue Exception => ex
-        Bugsnag.auto_notify(ex) unless [Interrupt, SystemExit, SignalException].include?(ex.class)
+        Bugsnag.auto_notify(ex, {
+          :severity_reason => {
+            :type => "middleware_handler",
+            :attributes => {
+              :name => "shoryuken"
+            }
+          }
+        }) unless [Interrupt, SystemExit, SignalException].include?(ex.class)
         raise
       ensure
         Bugsnag.clear_request_data

--- a/lib/bugsnag/shoryuken.rb
+++ b/lib/bugsnag/shoryuken.rb
@@ -20,9 +20,9 @@ module Bugsnag
       rescue Exception => ex
         Bugsnag.auto_notify(ex, {
           :severity_reason => {
-            :type => "middleware_handler",
+            :type => Bugsnag::Notification::UNHANDLED_EXCEPTION_MIDDLEWARE,
             :attributes => {
-              :name => "shoryuken"
+              :framework => "Shoryuken"
             }
           }
         }) unless [Interrupt, SystemExit, SignalException].include?(ex.class)

--- a/lib/bugsnag/sidekiq.rb
+++ b/lib/bugsnag/sidekiq.rb
@@ -18,9 +18,9 @@ module Bugsnag
         raise ex if [Interrupt, SystemExit, SignalException].include? ex.class
         Bugsnag.auto_notify(ex, {
           :severity_reason => {
-            :type => "middleware_handler",
+            :type => Bugsnag::Notification::UNHANDLED_EXCEPTION_MIDDLEWARE,
             :attributes => {
-              :name => "sidekiq"
+              :framework => "Sidekiq"
             }
           }
         })

--- a/lib/bugsnag/sidekiq.rb
+++ b/lib/bugsnag/sidekiq.rb
@@ -16,7 +16,14 @@ module Bugsnag
         yield
       rescue Exception => ex
         raise ex if [Interrupt, SystemExit, SignalException].include? ex.class
-        Bugsnag.auto_notify(ex)
+        Bugsnag.auto_notify(ex, {
+          :severity_reason => {
+            :type => "middleware_handler",
+            :attributes => {
+              :name => "sidekiq"
+            }
+          }
+        })
         raise
       ensure
         Bugsnag.clear_request_data

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -28,8 +28,8 @@ describe 'Bugsnag' do
     Dir.chdir(task_fixtures_path) do
       system("bundle exec rake test:crash > /dev/null 2>&1")
     end
-    #expect(request["events"][0]["metaData"]["rake_task"]).not_to be_nil
-    #expect(request["events"][0]["metaData"]["rake_task"]["name"]).to eq("test:crash")
+    expect(request["events"][0]["metaData"]["rake_task"]).not_to be_nil
+    expect(request["events"][0]["metaData"]["rake_task"]["name"]).to eq("test:crash")
   end
 
   it 'should send notifications over the wire' do

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -28,8 +28,8 @@ describe 'Bugsnag' do
     Dir.chdir(task_fixtures_path) do
       system("bundle exec rake test:crash > /dev/null 2>&1")
     end
-    expect(request["events"][0]["metaData"]["rake_task"]).not_to be_nil
-    expect(request["events"][0]["metaData"]["rake_task"]["name"]).to eq("test:crash")
+    #expect(request["events"][0]["metaData"]["rake_task"]).not_to be_nil
+    #expect(request["events"][0]["metaData"]["rake_task"]["name"]).to eq("test:crash")
   end
 
   it 'should send notifications over the wire' do

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -28,8 +28,10 @@ describe 'Bugsnag' do
     Dir.chdir(task_fixtures_path) do
       system("bundle exec rake test:crash > /dev/null 2>&1")
     end
-    expect(request["events"][0]["metaData"]["rake_task"]).not_to be_nil
-    expect(request["events"][0]["metaData"]["rake_task"]["name"]).to eq("test:crash")
+
+    result = request()
+    expect(result["events"][0]["metaData"]["rake_task"]).not_to be_nil
+    expect(result["events"][0]["metaData"]["rake_task"]["name"]).to eq("test:crash")
   end
 
   it 'should send notifications over the wire' do

--- a/spec/notification_spec.rb
+++ b/spec/notification_spec.rb
@@ -175,6 +175,21 @@ describe Bugsnag::Notification do
     }
   end
 
+  it "sets correct severity and reason for specific error classes" do
+    Bugsnag.notify(SignalException.new("TERM"))
+    expect(Bugsnag).to have_sent_notification{ |payload|
+      event = get_event_from_payload(payload)
+      expect(event["unhandled"]).to be false
+      expect(event["severity"]).to eq("info")
+      expect(event["severityReason"]).to eq({
+        "type" => "errorClass",
+        "attributes" => {
+          "errorClass" => "SignalException"
+        }
+      })
+    }
+  end
+
   # TODO: nested context
 
   it "accepts tabs in overrides and adds them to metaData" do
@@ -640,12 +655,6 @@ describe Bugsnag::Notification do
       expect(event["metaData"]["request"]["params"]).not_to be_nil
       expect(event["metaData"]["request"]["params"]).to have_key("nil_param")
     }
-  end
-
-  it "does not notify if the exception class is in the default ignore_classes list" do
-    Bugsnag.notify_or_ignore(ActiveRecord::RecordNotFound.new("It crashed"))
-
-    expect(Bugsnag).not_to have_sent_notification
   end
 
   it "does not notify if the non-default exception class is added to the ignore_classes" do

--- a/spec/rack_spec.rb
+++ b/spec/rack_spec.rb
@@ -32,6 +32,21 @@ describe Bugsnag::Rack do
 
     end
 
+    it "applies the correct severity reason" do
+      rack_stack.call(rack_env) rescue nil
+
+      expect(Bugsnag).to have_sent_notification{ |payload|
+        event = get_event_from_payload(payload)
+        expect(event["unhandled"]).to be true
+        expect(event["severityReason"]).to eq({
+          "type" => "middleware_handler",
+          "attributes" => {
+            "name" => "rack"
+          }
+        })
+      }
+    end
+
     it "does not deliver an exception if auto_notify is disabled" do
       Bugsnag.configure do |config|
         config.auto_notify = false

--- a/spec/rack_spec.rb
+++ b/spec/rack_spec.rb
@@ -39,9 +39,9 @@ describe Bugsnag::Rack do
         event = get_event_from_payload(payload)
         expect(event["unhandled"]).to be true
         expect(event["severityReason"]).to eq({
-          "type" => "middleware_handler",
+          "type" => "unhandledExceptionMiddleware",
           "attributes" => {
-            "name" => "rack"
+            "framework" => "Rack"
           }
         })
       }


### PR DESCRIPTION
- Adds `defaultSeverity`, `unhandled`, and `severityReasons` payload properties to support upcoming handled/unhandled functionality
- Allows properties to be set via `override` properties on notifications creation
- Middleware set up with correct severity reasons
_references [PLAT_207](https://bugsnag.atlassian.net/browse/PLAT-207)_