### PR TITLE
Added 'did you mean' suggestions middleware

### DIFF
--- a/lib/bugsnag/configuration.rb
+++ b/lib/bugsnag/configuration.rb
@@ -5,6 +5,7 @@ require "bugsnag/middleware_stack"
 require "bugsnag/middleware/callbacks"
 require "bugsnag/middleware/exception_meta_data"
 require "bugsnag/middleware/ignore_error_class"
+require "bugsnag/middleware/suggestion_data"
 
 module Bugsnag
   class Configuration
@@ -73,6 +74,7 @@ module Bugsnag
       self.internal_middleware = Bugsnag::MiddlewareStack.new
       self.internal_middleware.use Bugsnag::Middleware::ExceptionMetaData
       self.internal_middleware.use Bugsnag::Middleware::IgnoreErrorClass
+      self.internal_middleware.use Bugsnag::Middleware::SuggestionData
 
       self.middleware = Bugsnag::MiddlewareStack.new
       self.middleware.use Bugsnag::Middleware::Callbacks

--- a/lib/bugsnag/middleware/suggestion_data.rb
+++ b/lib/bugsnag/middleware/suggestion_data.rb
@@ -2,7 +2,7 @@ module Bugsnag::Middleware
   class SuggestionData
 
     CAPTURE_REGEX = /Did you mean\?([\s\S]+)$/
-    DELIMITTER = "\n"
+    DELIMITER = "\n"
 
     def initialize(bugsnag)
       @bugsnag = bugsnag
@@ -14,12 +14,12 @@ module Bugsnag::Middleware
         match = CAPTURE_REGEX.match(exception.message)
         next unless match
         
-        suggestions = match.captures[0].split(DELIMITTER).each { |suggestion|
+        suggestions = match.captures[0].split(DELIMITER).each { |suggestion|
           matches[matches.size] = suggestion.strip
         }
       end
 
-      report.add_tab(:"did you mean", matches) if matches.size > 0
+      report.add_tab(:suggestion, matches) if matches.size > 0
       
       @bugsnag.call(report)
     end

--- a/lib/bugsnag/middleware/suggestion_data.rb
+++ b/lib/bugsnag/middleware/suggestion_data.rb
@@ -1,0 +1,27 @@
+module Bugsnag::Middleware
+  class SuggestionData
+
+    CAPTURE_REGEX = /Did you mean\?([\s\S]+)$/
+    DELIMITTER = "\n"
+
+    def initialize(bugsnag)
+      @bugsnag = bugsnag
+    end
+
+    def call(report)
+      matches = {}
+      report.raw_exceptions.each do |exception| 
+        match = CAPTURE_REGEX.match(exception.message)
+        next unless match
+        
+        suggestions = match.captures[0].split(DELIMITTER).each { |suggestion|
+          matches[matches.size] = suggestion.strip
+        }
+      end
+
+      report.add_tab(:"did you mean", matches) if matches.size > 0
+      
+      @bugsnag.call(report)
+    end
+  end
+end

--- a/lib/bugsnag/middleware/suggestion_data.rb
+++ b/lib/bugsnag/middleware/suggestion_data.rb
@@ -10,18 +10,18 @@ module Bugsnag::Middleware
 
     def call(report)
       matches = []
-      report.raw_exceptions.each do |exception| 
+      report.raw_exceptions.each do |exception|
         match = CAPTURE_REGEX.match(exception.message)
         next unless match
-        
+
         suggestions = match.captures[0].split(DELIMITER)
         matches.concat suggestions.map{ |suggestion| suggestion.strip }
       end
 
       if matches.size == 1
-        report.add_tab(:"did you mean", {:suggestion => matches.first})
+        report.add_tab(:error, {:suggestion => matches.first})
       elsif matches.size > 1
-        report.add_tab(:"did you mean", {:suggestions => matches})
+        report.add_tab(:error, {:suggestions => matches})
       end
 
       @bugsnag.call(report)

--- a/spec/middleware_spec.rb
+++ b/spec/middleware_spec.rb
@@ -178,4 +178,38 @@ describe Bugsnag::MiddlewareStack do
     }
   end
 
+  if ruby_version_greater_equal?("2.3.0")
+    context "with a ruby version >= 2.3.0" do
+      it "attaches did you mean metadata when necessary" do
+        begin
+          "Test".starts_with? "T"
+        rescue Exception => e
+          Bugsnag.notify(e)
+        end
+
+        expect(Bugsnag).to have_sent_notification{ |payload|
+          event = get_event_from_payload(payload)
+          expect(event["metaData"]["did you mean"]).to_not be_nil
+          expect(event["metaData"]["did you mean"]).to eq({"0" => "start_with?"})
+        }
+      end
+    end
+  end
+
+  context "with a ruby version < 2.3.0" do
+    if !ruby_version_greater_equal?("2.3.0")
+      it "doesn't attach did you mean metadata" do
+        begin
+          "Test".starts_with? "T"
+        rescue Exception => e
+          Bugsnag.notify(e)
+        end
+
+        expect(Bugsnag).to have_sent_notification{ |payload|
+          event = get_event_from_payload(payload)
+          expect(event["metaData"]["did you mean"]).to be_nil
+        }
+      end
+    end
+  end
 end

--- a/spec/middleware_spec.rb
+++ b/spec/middleware_spec.rb
@@ -189,8 +189,8 @@ describe Bugsnag::MiddlewareStack do
 
         expect(Bugsnag).to have_sent_notification{ |payload|
           event = get_event_from_payload(payload)
-          expect(event["metaData"]["did you mean"]).to_not be_nil
-          expect(event["metaData"]["did you mean"]).to eq({"suggestion" => "start_with?"})
+          expect(event["metaData"]["error"]).to_not be_nil
+          expect(event["metaData"]["error"]).to eq({"suggestion" => "start_with?"})
         }
       end
     end
@@ -207,7 +207,7 @@ describe Bugsnag::MiddlewareStack do
 
         expect(Bugsnag).to have_sent_notification{ |payload|
           event = get_event_from_payload(payload)
-          expect(event["metaData"]["did you mean"]).to be_nil
+          expect(event["metaData"]["error"]).to be_nil
         }
       end
     end

--- a/spec/middleware_spec.rb
+++ b/spec/middleware_spec.rb
@@ -190,7 +190,7 @@ describe Bugsnag::MiddlewareStack do
         expect(Bugsnag).to have_sent_notification{ |payload|
           event = get_event_from_payload(payload)
           expect(event["metaData"]["did you mean"]).to_not be_nil
-          expect(event["metaData"]["did you mean"]).to eq({"0" => "start_with?"})
+          expect(event["metaData"]["did you mean"]).to eq({"suggestion" => "start_with?"})
         }
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -30,6 +30,14 @@ def notify_test_exception(*args)
   Bugsnag.notify(RuntimeError.new("test message"), *args)
 end
 
+def ruby_version_greater_equal?(version)
+  current_version = RUBY_VERSION.split "."
+  target_version = version.split "."
+  (Integer(current_version[0]) >= Integer(target_version[0])) &&
+    (Integer(current_version[1]) >= Integer(target_version[1])) &&
+    (Integer(current_version[2]) >= Integer(target_version[2]))
+end
+
 RSpec.configure do |config|
   config.order = "random"
 


### PR DESCRIPTION
- Adds middleware to capture 'did you mean' suggestions and append them to meta-data in ruby version > 2.3.0
- Uses string matching to not break earlier versions
- Includes tests to ensure early ruby version run correctly