### PR TITLE
Adding a breadcrumb logger 

### DIFF
--- a/lib/bugsnag/loggers/bugsnag_logger.rb
+++ b/lib/bugsnag/loggers/bugsnag_logger.rb
@@ -1,0 +1,110 @@
+require "bugsnag"
+require "bugsnag/breadcrumbs/breadcrumb"
+
+module Bugsnag::Loggers
+
+  LEVELS = [
+    "debug",
+    "info",
+    "warn",
+    "error",
+    "fatal"
+  ]
+
+  class BugsnagLogger
+
+    attr_reader :level
+
+    def initialize(level="info")
+      @level = level
+    end
+
+    def add(severity, message = nil, progname = nil)
+      if supports_level?(severity)
+        Bugsnag.leave_breadcrumb(message, Bugsnag::Breadcrumbs::LOG_TYPE, {
+          :progname => progname,
+          :severity => severity
+        })
+      end
+    end
+
+    def <<(message)
+      add "unknown", message
+    end
+
+    alias :sev_threshold :level
+    def level(severity)
+      if Loggers::LEVELS.include? severity
+        @level = severity
+      end
+    end
+
+    def info(message)
+      add "info", message
+    end
+
+    def info(progname=nil, &block)
+      yield message="" if block_given?
+      add "info", message, progname
+    end
+
+    def info?
+      supports_level?("info")
+    end
+
+    def debug(progname=nil, &block)
+      yield message="" if block_given?
+      add "debug", message, progname
+    end
+
+    def debug?
+      supports_level?("debug")
+    end
+
+    def error(progname=nil, &block)
+      yield message="" if block_given?
+      add "error", message, progname
+    end
+
+    def error
+      supports_level?("error")
+    end
+
+    def fatal(progname=nil, &block)
+      yield message="" if block_given?
+      add "fatal", message, progname
+    end
+
+    def fatal?
+      supports_level?("fatal")
+    end
+
+    def warn(progname=nil, &block)
+      yield message="" if block_given?
+      add "warn", message, progname
+    end
+
+    def warn?
+      supports_level?("warn")
+    end
+
+    def unknown(progname = nil, &block)
+      yield message="" if block_given?
+      add "unknown", message, progname
+    end
+
+    def close
+      true
+    end
+
+    private
+    def supports_level?(level)
+      if level == "unknown"
+        true
+      else 
+        Loggers::LEVELS.index(level) >= Loggers::LEVELS.index(@level)
+      end
+    end
+
+  end
+end

--- a/lib/bugsnag/loggers/bugsnag_logger.rb
+++ b/lib/bugsnag/loggers/bugsnag_logger.rb
@@ -19,7 +19,7 @@ module Bugsnag::Loggers
       @level = level
     end
 
-    def add(severity, message = nil, progname = nil)
+    def add(severity, message = nil, progname = nil, &block)
       if supports_level?(severity)
         Bugsnag.leave_breadcrumb(message, Bugsnag::Breadcrumbs::LOG_TYPE, {
           :progname => progname,
@@ -27,23 +27,24 @@ module Bugsnag::Loggers
         })
       end
     end
+    alias :log :add
 
     def <<(message)
       add "unknown", message
     end
 
-    alias :sev_threshold :level
     def level(severity)
-      if Loggers::LEVELS.include? severity
+      if Bugsnag::Loggers::LEVELS.include? severity
         @level = severity
       end
     end
+    alias :sev_threshold :level
 
     def info(message)
       add "info", message
     end
 
-    def info(progname=nil, &block)
+    def info(progname = nil, &block)
       yield message="" if block_given?
       add "info", message, progname
     end
@@ -52,7 +53,7 @@ module Bugsnag::Loggers
       supports_level?("info")
     end
 
-    def debug(progname=nil, &block)
+    def debug(progname = nil, &block)
       yield message="" if block_given?
       add "debug", message, progname
     end
@@ -61,7 +62,7 @@ module Bugsnag::Loggers
       supports_level?("debug")
     end
 
-    def error(progname=nil, &block)
+    def error(progname = nil, &block)
       yield message="" if block_given?
       add "error", message, progname
     end
@@ -70,7 +71,7 @@ module Bugsnag::Loggers
       supports_level?("error")
     end
 
-    def fatal(progname=nil, &block)
+    def fatal(progname = nil, &block)
       yield message="" if block_given?
       add "fatal", message, progname
     end
@@ -79,7 +80,7 @@ module Bugsnag::Loggers
       supports_level?("fatal")
     end
 
-    def warn(progname=nil, &block)
+    def warn(progname = nil, &block)
       yield message="" if block_given?
       add "warn", message, progname
     end
@@ -102,7 +103,7 @@ module Bugsnag::Loggers
       if level == "unknown"
         true
       else 
-        Loggers::LEVELS.index(level) >= Loggers::LEVELS.index(@level)
+        Bugsnag::Loggers::LEVELS.index(level) >= Bugsnag::Loggers::LEVELS.index(@level)
       end
     end
 

--- a/lib/bugsnag/loggers/bugsnag_logger.rb
+++ b/lib/bugsnag/loggers/bugsnag_logger.rb
@@ -68,7 +68,7 @@ module Bugsnag::Loggers
       add "error", message, progname
     end
 
-    def error
+    def error?
       supports_level?("error")
     end
 

--- a/lib/bugsnag/loggers/bugsnag_logger.rb
+++ b/lib/bugsnag/loggers/bugsnag_logger.rb
@@ -34,12 +34,12 @@ module Bugsnag::Loggers
       add "unknown", message
     end
 
-    def level(severity)
+    def level=(severity)
       if Bugsnag::Loggers::LEVELS.include? severity
         @level = severity
       end
     end
-    alias :sev_threshold :level
+    alias :sev_threshold= :level=
 
     def info(message)
       add "info", message

--- a/lib/bugsnag/loggers/bugsnag_logger.rb
+++ b/lib/bugsnag/loggers/bugsnag_logger.rb
@@ -17,10 +17,11 @@ module Bugsnag::Loggers
 
     def initialize(level="info")
       @level = level
+      @open = true
     end
 
     def add(severity, message = nil, progname = nil, &block)
-      if supports_level?(severity)
+      if supports_level?(severity) && @open
         Bugsnag.leave_breadcrumb(message, Bugsnag::Breadcrumbs::LOG_TYPE, {
           :progname => progname,
           :severity => severity
@@ -95,6 +96,12 @@ module Bugsnag::Loggers
     end
 
     def close
+      @open = false
+      true
+    end
+
+    def reopen
+      @open = true
       true
     end
 

--- a/lib/bugsnag/loggers/multi_logger.rb
+++ b/lib/bugsnag/loggers/multi_logger.rb
@@ -1,0 +1,76 @@
+module Bugsnag::Loggers
+  class MultiLogger
+
+    def initialize(loggers = [])
+      @loggers = loggers
+    end
+
+    def call_loggers(method, *args)
+      @loggers.each do |logger|
+        logger.send(method, *args)
+      end
+    end
+
+    def <<(*args)
+      call_loggers(:<<, *args)
+    end
+
+    def add(*args)
+      call_loggers(:add, *args)
+    end
+    alias :log :add
+
+    def debug(*args)
+      call_loggers(:debug, *args)
+    end
+
+    def info(*args)
+      call_loggers(:info, *args)
+    end
+
+    def warn(*args)
+      call_loggers(:warn, *args)
+    end
+
+    def error(*args)
+      call_loggers(:error, *args)
+    end
+
+    def fatal(*args)
+      call_loggers(:fatal, *args)
+    end
+
+    def unknown(*args)
+      call_loggers(:unknown, *args)
+    end
+
+    def close
+      call_loggers(:close)
+    end
+
+    def debug?
+      supports_level?(:debug?)
+    end
+
+    def info?
+      supports_level?(:info?)
+    end
+
+    def warn?
+      supports_level?(:warn?)
+    end
+    
+    def error?
+      supports_level?(:error?)
+    end
+
+    def fatal?
+      supports_level?(:fatal?)
+    end
+
+    private
+    def supports_level?(level)
+      @loggers.any {|logger| logger.send(level)}
+    end
+  end
+end

--- a/lib/bugsnag/loggers/multi_logger.rb
+++ b/lib/bugsnag/loggers/multi_logger.rb
@@ -44,6 +44,10 @@ module Bugsnag::Loggers
       call_loggers(:unknown, *args)
     end
 
+    def reopen(*args)
+      call_loggers(:reopen, *args)
+    end
+
     def close
       call_loggers(:close)
     end

--- a/lib/bugsnag/loggers/multi_logger.rb
+++ b/lib/bugsnag/loggers/multi_logger.rb
@@ -5,12 +5,6 @@ module Bugsnag::Loggers
       @loggers = loggers
     end
 
-    def call_loggers(method, *args)
-      @loggers.each do |logger|
-        logger.send(method, *args)
-      end
-    end
-
     def <<(*args)
       call_loggers(:<<, *args)
     end
@@ -72,9 +66,20 @@ module Bugsnag::Loggers
       supports_level?(:fatal?)
     end
 
+    def level?
+      Bugsnag::Loggers::LEVELS.find { |level| supports_level? level + "?" }
+    end
+
     private
     def supports_level?(level)
       @loggers.any? {|logger| logger.send(level)}
+    end
+
+    private
+    def call_loggers(method, *args)
+      @loggers.each do |logger|
+        logger.send(method, *args)
+      end
     end
   end
 end

--- a/lib/bugsnag/loggers/multi_logger.rb
+++ b/lib/bugsnag/loggers/multi_logger.rb
@@ -70,7 +70,7 @@ module Bugsnag::Loggers
 
     private
     def supports_level?(level)
-      @loggers.any {|logger| logger.send(level)}
+      @loggers.any? {|logger| logger.send(level)}
     end
   end
 end

--- a/spec/loggers_spec.rb
+++ b/spec/loggers_spec.rb
@@ -1,0 +1,154 @@
+# encoding: utf-8
+
+require 'spec_helper'
+require 'bugsnag/loggers/bugsnag_logger'
+require 'bugsnag/loggers/multi_logger'
+
+describe Bugsnag::Loggers do
+  
+  context "a bugsnag logger" do
+
+    before do
+      @logger = Bugsnag::Loggers::BugsnagLogger.new
+    end
+
+    it "has a default level of info" do
+      expect(@logger.level).to eq("info")
+    end
+
+    it "allows the level to be changed" do
+      @logger.level = "warn"
+      expect(@logger.level).to eq("warn")
+      @logger.sev_threshold = "error"
+      expect(@logger.level).to eq("error")
+    end
+
+    it "logs when add is called" do
+      expect(Bugsnag).to receive(:leave_breadcrumb).with(
+        "message",
+        "log",
+        {
+          :progname => "progname",
+          :severity => "error"
+        }
+      )
+      @logger.add("error", "message", "progname")
+    end
+
+    it "doesn't log when the severity is too low" do
+      expect(Bugsnag).to_not receive(:leave_breadcrumb).with(
+        "message",
+        "log",
+        {
+          :progname => "progname",
+          :severity => "error"
+        }
+      )
+      @logger.level = "fatal"
+      @logger.add("error", "message", "progname")
+    end
+
+    it "won't log when closed" do
+      expect(Bugsnag).to_not receive(:leave_breadcrumb).with(
+        "message",
+        "log",
+        {
+          :progname => "progname",
+          :severity => "error"
+        }
+      )
+      expect(@logger.close).to be true
+      @logger.add("error", "message", "progname")
+    end
+
+    it "will log if reopened" do
+      expect(Bugsnag).to receive(:leave_breadcrumb).with(
+        "message",
+        "log",
+        {
+          :progname => "progname",
+          :severity => "error"
+        }
+      )
+
+      expect(@logger.close).to be true
+      expect(@logger.reopen).to be true
+      @logger.add("error", "message", "progname")
+    end
+
+    it "returns whether level is supported" do
+      expect(@logger.debug?).to be false
+      expect(@logger.info?).to be true
+      expect(@logger.warn?).to be true
+      expect(@logger.error?).to be true
+      expect(@logger.fatal?).to be true
+    end
+
+    it "always logs unknown level errors" do
+      expect(Bugsnag).to receive(:leave_breadcrumb).with(
+        "message",
+        "log",
+        {
+          :progname => "progname",
+          :severity => "unknown"
+        }
+      )
+      @logger.level = "fatal"
+      @logger.add("unknown", "message", "progname")
+    end
+
+    it "allows a message to be set via block in a severity call" do
+      expect(Bugsnag).to receive(:leave_breadcrumb).with(
+        "block message",
+        "log",
+        {
+          :progname => nil,
+          :severity => "warn"
+        }
+      )
+      @logger.warn {"block message"}
+    end
+
+    it "sets << messages as 'unknown" do
+      expect(Bugsnag).to receive(:leave_breadcrumb).with(
+        "message",
+        "log",
+        {
+          :progname => nil,
+          :severity => "unknown"
+        }
+      )
+      @logger << "message"
+    end
+  end
+
+  context "a multi-logger" do
+    before do
+      @logger_a = double('loggera')
+      @logger_b = double('loggerb')
+      @multi_logger = Bugsnag::Loggers::MultiLogger.new [@logger_a, @logger_b]
+    end
+
+    it "calls each logger with a method" do
+      expect(@logger_a).to receive(:close)
+      expect(@logger_b).to receive(:close)
+      @multi_logger.close
+    end
+
+    it "passes identical arguments through to loggers" do
+      expect(@logger_a).to receive(:add).with("info", "message")
+      expect(@logger_b).to receive(:add).with("info", "message")
+      @multi_logger.add "info", "message"
+    end
+
+    it "returns the lowest log level it supports" do
+      expect(@logger_a).to receive(:debug?).and_return(false)
+      expect(@logger_b).to receive(:debug?).and_return(false)
+      expect(@logger_a).to receive(:info?).and_return(false)
+      expect(@logger_b).to receive(:info?).and_return(true)
+      expect(@multi_logger.level?).to eq("info")
+    end
+  end
+end
+
+    

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -52,6 +52,8 @@ RSpec.configure do |config|
   end
 
   config.after(:each) do
+    Thread.current[Bugsnag::Configuration::THREAD_RECORDER] = nil
+    Thread.current[Bugsnag::Configuration::THREAD_LOCAL_NAME] = nil
     Bugsnag.configuration.clear_request_data
   end
 end


### PR DESCRIPTION
## Additions
- Adds a logger to track events output to a logger to breadcrumbs
- `BugsnagLogger` can be assigned to any interface that uses a Logger, such as `ActiveRecord::Base.logger` or `Mongoid::Loggable.logger`
- Breadcrumb logging threshold can be set during initialisation or at any point afterwards
- `MultiLogger` accepts an array of loggers on creation and will output to each of them on message receipt, allowing user to attach other loggers alongside `BugsnagLogger`

## Discussion
- Considering changing name to `BreadcrumbLogger` to be more explicit about functionality
- I created this as a separate PR to [the breadcrumbs PR](https://github.com/bugsnag/bugsnag-ruby/pull/367) to avoid splitting focus.  I think the breadcrumb feature should be completed before this

## TODO
- Needs tests added
- Needs examples/documenting