### PR TITLE
Fix NameError when exception is raised in delayed_job

### DIFF
--- a/bugsnag.gemspec
+++ b/bugsnag.gemspec
@@ -25,4 +25,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'pry'
   s.add_development_dependency 'addressable', '~> 2.3.8'
   s.add_development_dependency 'webmock', '2.1.0'
+  s.add_development_dependency 'delayed_job'
 end

--- a/lib/bugsnag/delayed_job.rb
+++ b/lib/bugsnag/delayed_job.rb
@@ -19,7 +19,7 @@ unless defined? Delayed::Plugins::Bugsnag
                 :id => job.id,
               },
               :severity_reason => {
-                :type => Bugsnag::Notification::UNHANDLED_EXCEPTION_MIDDLEWARE,
+                :type => ::Bugsnag::Notification::UNHANDLED_EXCEPTION_MIDDLEWARE,
                 :attributes => {
                   :framework => "DelayedJob"
                 }

--- a/spec/delayed_job_spec.rb
+++ b/spec/delayed_job_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe ::Delayed::Plugins::Bugsnag do
+  describe '#error' do
+    it 'should not raise exception' do
+      payload = Object.new
+      payload.extend(described_class::Notify)
+      expect do
+        payload.error(double('job', id: 1, payload_object: nil), '')
+      end.not_to raise_error
+    end
+  end
+end


### PR DESCRIPTION
This PR should fix the following exception is raised when exception is raised in delayed_job.

`NameError: uninitialized constant Notification::UNHANDLED_EXCEPTION_MIDDLEWARE`