### PR TITLE
Enabled setting proxy_host through environment variables

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -26,6 +26,7 @@ guide](https://docs.bugsnag.com/platforms/ruby/capistrano) for more information.
 * `Configuration.delay_with_resque` has been removed
 * `Configuration.vendor_paths` has been removed
 * `Configuration.params_filters` has been renamed to `Configuration.meta_data_filters` to be clearer
+* `Configuration.proxy_host` will now default to `ENV['http_proxy']` if set. It can still be manually set.
 
 #### Notifying
 

--- a/lib/bugsnag/configuration.rb
+++ b/lib/bugsnag/configuration.rb
@@ -64,6 +64,9 @@ module Bugsnag
       # Read the API key from the environment
       self.api_key = ENV["BUGSNAG_API_KEY"]
 
+      # Read NET::HTTP proxy environment variable
+      self.proxy_host = ENV["http_proxy"]
+
       # Set up logging
       self.logger = Logger.new(STDOUT)
       self.logger.level = Logger::INFO


### PR DESCRIPTION
- Enables setting of proxy_host from Environment variable as described [here](https://ruby-doc.org/stdlib-2.4.1/libdoc/net/http/rdoc/Net/HTTP.html#class-Net::HTTP-label-Proxies)
- Fixes the behaviour described [here](https://github.com/bugsnag/bugsnag-ruby/issues/371)