### PR TITLE
V6 parity

### DIFF
--- a/example/que/Gemfile
+++ b/example/que/Gemfile
@@ -1,0 +1,7 @@
+source 'https://rubygems.org'
+
+gem 'que'
+gem 'activerecord'
+gem 'pg'
+gem 'rake'
+gem 'bugsnag', path: '../../'

--- a/example/que/README.md
+++ b/example/que/README.md
@@ -1,0 +1,45 @@
+# Using Bugsnag with Que
+
+This example shows how to use Bugsnag in conjunction with Que to report any exceptions that occur in your applications.
+
+First, install dependencies
+```shell
+bundle install
+```
+
+## Setting up a database
+Que requires a database backend in order to queue jobs.  By default this database will be PostgreSQL although this can be changed via options as detailed in [the que documentation](https://github.com/chanks/que).
+
+Once PostgreSQL is set up as detailed using [the PostgreSQL documentation](https://www.postgresql.org/docs/), ensure Que can connect correctly by setting the environment variable `DBNAME` to the name of an existing PostgreSQL database.
+
+## Configuring Bugsnag with Que
+
+Bugsnag can be configured in one of two ways in your Que app:
+
+1. require `bugsnag` in your application and call `Bugsnag.configure` with a block, setting the appropriate configuration options:
+```ruby
+Bugsnag.configure do |config|
+    config.api_key = "YOUR_API_KEY"
+end
+```
+
+2. require `bugsnag` in your application and input configuration options through environment variables, such as setting `BUGSNAG_API_KEY` to `YOUR_API_KEY`.
+
+All configuration options can be found in the [Bugsnag documentation](https://docs.bugsnag.com/platforms/ruby/other/configuration-options/)
+
+## Running the example
+
+Run the database migration using rake:
+```shell
+bundle exec rake migrate:up
+```
+
+After this is complete, queue up our test job:
+```shell
+bundle exec rake job:enqueue
+```
+
+Then execute the worker and see the errors appear on the [Bugsnag dashboard](https://app.bugsnag.com):
+```shell
+bundle exec rake job:work
+```

--- a/example/que/Rakefile
+++ b/example/que/Rakefile
@@ -1,0 +1,37 @@
+namespace :migrate do
+  desc "Create database and tables"
+  task :up do
+    require_relative 'app/migrations'
+    CreateUsersTable.migrate(:up)
+    require_relative 'app/jobs'
+    Que.migrate!
+  end
+
+  desc "Drop database tables"
+  task :down do
+    require_relative 'app/migrations'
+    CreateUsersTable.migrate(:down)
+  end
+end
+
+namespace :job do
+  desc "Enqueue a job"
+  task :enqueue do
+    require_relative 'app/jobs'
+    user = User.create(name: 'Bob', cheered_at: 5.days.ago)
+    user.save
+    Cheer.enqueue(user.id)
+  end
+
+  desc "Run a worker"
+  task :work do
+    require_relative 'app/jobs'
+    require 'que'
+
+    Que.worker_count = 5
+    Que.mode = :async
+    loop do
+      sleep
+    end
+  end
+end

--- a/example/que/app/jobs.rb
+++ b/example/que/app/jobs.rb
@@ -1,0 +1,25 @@
+require 'active_record'
+require_relative 'model'
+require 'que'
+require 'bugsnag'
+
+Bugsnag.configure do |config|
+  config.api_key = 'YOUR_API_KEY'
+end
+
+Que.connection = ActiveRecord
+
+class Cheer < Que::Job
+  @run_at = proc { 5.seconds.from_now }
+
+  def run(user_id, options={})
+    user = User.find(user_id)
+
+    ActiveRecord::Base.transaction do
+      user.update_attributes cheered_at: Time.now
+
+      raise 'Oh no, a problem!'
+      destroy
+    end
+  end
+end

--- a/example/que/app/migrations.rb
+++ b/example/que/app/migrations.rb
@@ -1,0 +1,15 @@
+require 'active_record'
+require_relative 'model'
+
+class CreateUsersTable < ActiveRecord::Migration[5.1]
+  def up
+    create_table :users do |t|
+      t.string :name
+      t.date :cheered_at
+    end
+  end
+
+  def down
+    drop_table :users
+  end
+end

--- a/example/que/app/model.rb
+++ b/example/que/app/model.rb
@@ -1,0 +1,8 @@
+require 'active_record'
+
+class User < ActiveRecord::Base
+end
+
+ActiveRecord::Base.establish_connection(
+  adapter: 'postgresql', database: ENV['DBNAME']
+)

--- a/example/shoryuken/Gemfile
+++ b/example/shoryuken/Gemfile
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gem "bugsnag",  path: "../../"
+gem "shoryuken"
+gem "aws-sdk-sqs"

--- a/example/shoryuken/README.md
+++ b/example/shoryuken/README.md
@@ -1,0 +1,42 @@
+# Using Bugsnag with Shoryuken
+
+This example shows how to use Bugsnag in conjunction with Shoryuken to report any exceptions that occur in your applications.
+
+First, install dependencies
+```shell
+bundle install
+```
+
+## Configuring Bugsnag with Shoryuken
+
+Bugsnag can be configured in one of two ways in your Shoryuken app:
+
+1. require `bugsnag` in your application and call `Bugsnag.configure` with a block, setting the appropriate configuration options:
+```ruby
+Bugsnag.configure do |config|
+    config.api_key = "YOUR_API_KEY"
+end
+```
+
+2. require `bugsnag` in your application and input configuration options through environment variables, such as setting `BUGSNAG_API_KEY` to `YOUR_API_KEY`.
+
+All configuration options can be found in the [Bugsnag documentation](https://docs.bugsnag.com/platforms/ruby/other/configuration-options/)
+
+## Running the example
+
+Set up your AWS credentials as required in the [Configure the AWS Client](https://github.com/phstc/shoryuken/wiki/Configure-the-AWS-Client) section of the Shoryuken getting started docs.
+
+Start the Shoryuken processor with:
+```shell
+bundle exec shoryuken -r ./shoryuken.rb
+```
+
+In a seperate terminal instance open the console session with:
+```shell
+bundle exec irb -r ./shoryuken.rb
+```
+
+Where you can queue a message with the command:
+```ruby
+BugsnagTest.perform_async "Hello world"
+```

--- a/example/shoryuken/shoryuken.rb
+++ b/example/shoryuken/shoryuken.rb
@@ -1,0 +1,17 @@
+require 'shoryuken'
+require 'bugsnag'
+
+Bugsnag.configure do |config|
+  config.api_key = 'YOUR_API_KEY'
+end
+
+class BugsnagTest
+  include Shoryuken::Worker
+
+  shoryuken_options queue: 'connector_development_default', auto_delete: true
+  
+  def perform(sqs_msg, body)
+    puts "Received message: #{body}"
+    raise 'Uh oh!'
+  end
+end

--- a/lib/bugsnag.rb
+++ b/lib/bugsnag.rb
@@ -31,8 +31,10 @@ module Bugsnag
     def configure
       yield(configuration) if block_given?
 
-      if !configuration.valid_api_key?
+      @key_warning = false unless defined?(@key_warning)
+      if !configuration.valid_api_key? && !@key_warning
         configuration.warn("No valid API key has been set, notifications will not be sent")
+        @key_warning = true
       end
     end
 
@@ -119,7 +121,7 @@ module Bugsnag
   end
 end
 
-[:resque, :sidekiq, :mailman, :delayed_job].each do |integration|
+[:resque, :sidekiq, :mailman, :delayed_job, :shoryuken].each do |integration|
   begin
     require "bugsnag/integrations/#{integration}"
   rescue LoadError

--- a/lib/bugsnag.rb
+++ b/lib/bugsnag.rb
@@ -17,6 +17,7 @@ require "bugsnag/integrations/railtie" if defined?(Rails::Railtie)
 
 require "bugsnag/middleware/rack_request"
 require "bugsnag/middleware/warden_user"
+require "bugsnag/middleware/clearance_user"
 require "bugsnag/middleware/callbacks"
 require "bugsnag/middleware/rails3_request"
 require "bugsnag/middleware/sidekiq"

--- a/lib/bugsnag.rb
+++ b/lib/bugsnag.rb
@@ -122,7 +122,7 @@ module Bugsnag
   end
 end
 
-[:resque, :sidekiq, :mailman, :delayed_job, :shoryuken].each do |integration|
+[:resque, :sidekiq, :mailman, :delayed_job, :shoryuken, :que].each do |integration|
   begin
     require "bugsnag/integrations/#{integration}"
   rescue LoadError

--- a/lib/bugsnag.rb
+++ b/lib/bugsnag.rb
@@ -30,6 +30,10 @@ module Bugsnag
     # Configure the Bugsnag notifier application-wide settings.
     def configure
       yield(configuration) if block_given?
+
+      if !configuration.valid_api_key?
+        configuration.warn("No valid API key has been set, notifications will not be sent")
+      end
     end
 
     # Explicitly notify of an exception

--- a/lib/bugsnag/configuration.rb
+++ b/lib/bugsnag/configuration.rb
@@ -31,7 +31,6 @@ module Bugsnag
     attr_accessor :proxy_password
     attr_accessor :timeout
     attr_accessor :hostname
-    attr_accessor :delivery_method
     attr_accessor :ignore_classes
 
     API_KEY_REGEX = /[0-9a-f]{32}/i
@@ -57,7 +56,6 @@ module Bugsnag
       self.ignore_classes = Set.new([])
       self.endpoint = DEFAULT_ENDPOINT
       self.hostname = default_hostname
-      self.delivery_method = :thread_queue
       self.timeout = 15
       self.notify_release_stages = nil
 
@@ -83,6 +81,18 @@ module Bugsnag
 
       self.middleware = Bugsnag::MiddlewareStack.new
       self.middleware.use Bugsnag::Middleware::Callbacks
+    end
+
+    def delivery_method
+      @delivery_method || @default_delivery_method || :thread_queue
+    end
+
+    def delivery_method=(delivery_method)
+      @delivery_method = delivery_method
+    end
+
+    def default_delivery_method=(delivery_method)
+      @default_delivery_method = delivery_method
     end
 
     def should_notify_release_stage?

--- a/lib/bugsnag/integrations/que.rb
+++ b/lib/bugsnag/integrations/que.rb
@@ -1,0 +1,44 @@
+if defined?(::Que)
+  handler = proc do |error, job|
+    begin
+      job = job.dup # Make sure the original job object is not mutated.
+
+      Bugsnag.notify(error, true) do |report|
+        job[:error_count] += 1
+
+        # If the job was scheduled using ActiveJob then unwrap the job details for clarity:
+        if job[:job_class] == "ActiveJob::QueueAdapters::QueAdapter::JobWrapper"
+          wrapped_job = job[:args].last
+          wrapped_job = wrapped_job.each_with_object({}) { |(k, v), result| result[k.to_sym] = v } # Symbolize keys
+
+          # Align key names with keys in `job`
+          wrapped_job[:queue] = wrapped_job.delete(:queue_name)
+          wrapped_job[:args]  = wrapped_job.delete(:arguments)
+
+          job.merge!(wrapper_job_class: job[:job_class], wrapper_job_id: job[:job_id]).merge!(wrapped_job)
+        end
+
+        report.add_tab(:job, job)
+        report.severity = 'error'
+        report.severity_reason = {
+          :type => Bugsnag::Report::UNHANDLED_EXCEPTION_MIDDLEWARE,
+          :attributes => {
+            :framework => 'Que'
+          }
+        }
+      end
+    rescue => e
+      # Que supresses errors raised by its error handler to avoid killing the worker. Log them somewhere:
+      Bugsnag.configuration.warn("Failed to notify Bugsnag of error in Que job (#{e.class}): #{e.message} \n#{e.backtrace[0..9].join("\n")}")
+      raise
+    end
+  end
+
+  if Que.respond_to?(:error_notifier=)
+    Bugsnag.configuration.app_type ||= "que"
+    Que.error_notifier = handler
+  elsif Que.respond_to?(:error_handler=)
+    Bugsnag.configuration.app_type ||= "que"
+    Que.error_handler = handler
+  end
+end

--- a/lib/bugsnag/integrations/rack.rb
+++ b/lib/bugsnag/integrations/rack.rb
@@ -25,6 +25,7 @@ module Bugsnag
         # Hook up rack-based notification middlewares
         config.middleware.insert_before([Bugsnag::Middleware::Rails3Request,Bugsnag::Middleware::Callbacks], Bugsnag::Middleware::RackRequest) if defined?(::Rack)
         config.middleware.insert_before(Bugsnag::Middleware::Callbacks, Bugsnag::Middleware::WardenUser) if defined?(Warden)
+        config.middleware.insert_before(Bugsnag::Middleware::Callbkacs, Bugsnag::Middleware::ClearanceUser) if defined?(Clearance)
 
         config.app_type ||= "rack"
       end

--- a/lib/bugsnag/integrations/resque.rb
+++ b/lib/bugsnag/integrations/resque.rb
@@ -37,7 +37,7 @@ module Bugsnag
           :type => Bugsnag::Report::UNHANDLED_EXCEPTION_MIDDLEWARE,
           :attributes => FRAMEWORK_ATTRIBUTES
         }
-        report.meta_data.merge!({:context => "#{payload['class']}@#{queue}", :payload => payload, :delivery_method => :synchronous})
+        report.meta_data.merge!({:context => "#{payload['class']}@#{queue}", :payload => payload})
       end
     end
   end
@@ -51,5 +51,5 @@ Bugsnag::Resque.add_failure_backend
 
 Resque.before_first_fork do
   Bugsnag.configuration.app_type = "resque"
-  Bugsnag.configuration.delivery_method = :synchronous
+  Bugsnag.configuration.default_delivery_method = :synchronous
 end

--- a/lib/bugsnag/integrations/shoryuken.rb
+++ b/lib/bugsnag/integrations/shoryuken.rb
@@ -1,0 +1,48 @@
+require 'shoryuken'
+
+module Bugsnag
+  class Shoryuken
+
+    FRAMEWORK_ATTRIBUTES = {
+      :framework => "Shoryuken"
+    }
+
+    def initialize
+      Bugsnag.configure do |config|
+        config.app_type ||= "shoryuken"
+      end
+    end
+
+    def call(_, queue, _, body)
+      begin
+        Bugsnag.before_notify_callbacks << lambda {|report|
+          report.add_tab(:shoryuken, {
+            queue: queue,
+            body: body
+          })
+        }
+
+        yield
+      rescue Exception => ex
+        unless [Interrupt, SystemExit, SignalException].include?(ex.class)
+          Bugsnag.auto_notify(ex, true) do |report|
+            report.severity = "error"
+            report.severity_reason = {
+              :type => Bugsnag::Report::UNHANDLED_EXCEPTION_MIDDLEWARE,
+              :attributes => Bugsnag::Shoryuken::FRAMEWORK_ATTRIBUTES
+            }
+          end
+        end
+        raise
+      ensure
+        Bugsnag.configuration.clear_request_data
+      end
+    end
+  end
+end
+
+::Shoryuken.configure_server do |config|
+  config.server_middleware do |chain|
+    chain.add ::Bugsnag::Shoryuken
+  end
+end

--- a/lib/bugsnag/integrations/shoryuken.rb
+++ b/lib/bugsnag/integrations/shoryuken.rb
@@ -10,6 +10,7 @@ module Bugsnag
     def initialize
       Bugsnag.configure do |config|
         config.app_type ||= "shoryuken"
+        config.default_delivery_method = :synchronous
       end
     end
 

--- a/lib/bugsnag/integrations/sidekiq.rb
+++ b/lib/bugsnag/integrations/sidekiq.rb
@@ -10,7 +10,7 @@ module Bugsnag
     def initialize
       Bugsnag.configuration.internal_middleware.use(Bugsnag::Middleware::Sidekiq)
       Bugsnag.configuration.app_type = "sidekiq"
-      Bugsnag.configuration.delivery_method = :synchronous
+      Bugsnag.configuration.default_delivery_method = :synchronous
     end
 
     def call(worker, msg, queue)

--- a/lib/bugsnag/middleware/clearance_user.rb
+++ b/lib/bugsnag/middleware/clearance_user.rb
@@ -1,0 +1,30 @@
+module Bugsnag::Middleware
+  class ClearanceUser
+    COMMON_USER_FIELDS = [:email, :name, :first_name, :last_name, :created_at, :id]
+    def initialize(bugsnag)
+      @bugsnag = bugsnag
+    end
+
+    def call(report)
+      if report.request_data[:rack_env] && 
+        report.request_data[:rack_env]["clearance"] &&
+        report.request_data[:rack_env]["clearance"].signed_in? &&
+        report.request_data[:rack_env]["clearance"].current_user
+
+        # Extract useful user information
+        user = {}
+        user_object = report.request_data[:rack_env]["clearance"].current_user
+        if user_object
+          # Build the bugsnag user info from the current user record
+          COMMON_USER_FIELDS.each do |field|
+            user[field] = user_object.send(field) if user_object.respond_to?(field)
+          end
+        end
+
+        report.user = user unless user.empty?
+      end
+
+      @bugsnag.call(report)
+    end
+  end
+end

--- a/lib/bugsnag/middleware/sidekiq.rb
+++ b/lib/bugsnag/middleware/sidekiq.rb
@@ -8,7 +8,7 @@ module Bugsnag::Middleware
       sidekiq = report.request_data[:sidekiq]
       if sidekiq
         report.add_tab(:sidekiq, sidekiq)
-        report.context ||= "#{sidekiq[:msg]['wrapper'] || sidekiq[:msg]['class']}@#{sidekiq[:msg]['queue']}"
+        report.context ||= "#{sidekiq[:msg]['wrapped'] || sidekiq[:msg]['class']}@#{sidekiq[:msg]['queue']}"
       end
       @bugsnag.call(report)
     end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -1,0 +1,26 @@
+# encoding: utf-8
+require 'spec_helper'
+
+describe Bugsnag::Configuration do
+  describe "delivery_method" do
+    it "should have the default delivery method" do
+      expect(subject.delivery_method).to eq(:thread_queue)
+    end
+
+    it "should have the defined delivery_method" do
+      subject.delivery_method = :test
+      expect(subject.delivery_method).to eq(:test)
+    end
+
+    it "should allow a new default delivery_method to be set" do
+      subject.default_delivery_method = :test
+      expect(subject.delivery_method).to eq(:test)
+    end
+
+    it "should allow the delivery_method to be set over a default" do
+      subject.default_delivery_method = :test
+      subject.delivery_method = :wow
+      expect(subject.delivery_method).to eq(:wow)
+    end
+  end
+end


### PR DESCRIPTION
Brings this version up to date with changes that've been made to the master branch since this was branched.
So far:
- [x] Adds Clearance user middleware
- [x] Adds Shoryuken integration and example
- [x] Ensures sidekiq refers to "wrapped" message in context rather than "wrapper"
- [x] Warns if API key is not set (but only once!)
- [x] Modify how default delivery methods are set
- [x] Que Integration