### PR TITLE
fix: Log a warning when notifying with arguments

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source "https://rubygems.org"
 group :test, optional: true do
     gem 'rake', '~> 10.1.1'
     gem 'rspec'
+    gem 'rspec-mocks'
     gem 'rdoc'
     gem 'pry'
     gem 'addressable', '~> 2.3.8'

--- a/lib/bugsnag.rb
+++ b/lib/bugsnag.rb
@@ -43,6 +43,10 @@ module Bugsnag
 
     # Explicitly notify of an exception
     def notify(exception, auto_notify=false, &block)
+      unless auto_notify.is_a? TrueClass or auto_notify.is_a? FalseClass
+        configuration.warn("Adding metadata/severity using a hash is no longer supported, please use block syntax instead")
+        auto_notify = false
+      end
 
       if !configuration.auto_notify && auto_notify
         configuration.debug("Not notifying because auto_notify is disabled")

--- a/spec/bugsnag_spec.rb
+++ b/spec/bugsnag_spec.rb
@@ -1,0 +1,19 @@
+# encoding: utf-8
+require 'spec_helper'
+
+describe Bugsnag do
+  describe 'notify' do
+    before do
+      Bugsnag.configuration.logger = spy('logger')
+    end
+
+    it 'does not log an error when sending valid arguments as auto_notify' do
+      notify_test_exception(true)
+      expect(Bugsnag.configuration.logger).to_not have_received(:warn)
+    end
+    it 'logs an error when sending invalid arguments as auto_notify' do
+      notify_test_exception({severity: 'info'})
+      expect(Bugsnag.configuration.logger).to have_received(:warn)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,6 +12,7 @@ require 'bugsnag'
 
 require 'webmock/rspec'
 require 'rspec/expectations'
+require 'rspec/mocks'
 
 class BugsnagTestException < RuntimeError; end
 


### PR DESCRIPTION
As all metadata is now appended via blocks, show a warning to ease
upgrading.