### PR TITLE
Add in minor fixes/additions missing from current release

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,7 +56,8 @@ If you're a member of the core team, follow these instructions for releasing bug
 * Release to rubygems
 
     ```
-    bundle exec rake release
+    gem build bugsnag.gemspec
+    gem push bugsnag-[version].gem
     ```
 
 * Update the version running in the bugsnag-website project

--- a/lib/bugsnag.rb
+++ b/lib/bugsnag.rb
@@ -13,7 +13,6 @@ require "bugsnag/delivery/synchronous"
 require "bugsnag/delivery/thread_queue"
 
 require "bugsnag/integrations/rack"
-require "bugsnag/integrations/railtie" if defined?(Rails::Railtie)
 
 require "bugsnag/middleware/rack_request"
 require "bugsnag/middleware/warden_user"
@@ -127,6 +126,7 @@ module Bugsnag
   end
 end
 
+require "bugsnag/integrations/railtie" if defined?(Rails::Railtie)
 [:resque, :sidekiq, :mailman, :delayed_job, :shoryuken, :que].each do |integration|
   begin
     require "bugsnag/integrations/#{integration}"

--- a/lib/bugsnag/middleware/clearance_user.rb
+++ b/lib/bugsnag/middleware/clearance_user.rb
@@ -8,13 +8,13 @@ module Bugsnag::Middleware
 
     def call(report)
       if report.request_data[:rack_env] &&
-        report.request_data[:rack_env]["clearance"] &&
-        report.request_data[:rack_env]["clearance"].signed_in? &&
-        report.request_data[:rack_env]["clearance"].current_user
+        report.request_data[:rack_env][:clearance] &&
+        report.request_data[:rack_env][:clearance].signed_in? &&
+        report.request_data[:rack_env][:clearance].current_user
 
         # Extract useful user information
         user = {}
-        user_object = report.request_data[:rack_env]["clearance"].current_user
+        user_object = report.request_data[:rack_env][:clearance].current_user
         if user_object
           # Build the bugsnag user info from the current user record
           COMMON_USER_FIELDS.each do |field|


### PR DESCRIPTION
This adds in minor fixes made in previous releases but no-longer present in the current release
- Add require `railtie` after `Bugsnag` class initialised [references](https://github.com/bugsnag/bugsnag-ruby/commit/f9f59b8e25b577b60e8938b99fe0616e0c7a9a30)
- Symbolised clearance_user array keys [references](https://github.com/bugsnag/bugsnag-ruby/commit/7bbf716dab63b2772e441c3bd1014a1940551a19)

In addition, I've updated the contributing guide with correct instructions as we no longer use the rake build method.