### PR TITLE
Added support for skip_bugsnag flag on exceptions

### DIFF
--- a/lib/bugsnag.rb
+++ b/lib/bugsnag.rb
@@ -62,6 +62,11 @@ module Bugsnag
         return
       end
 
+      if exception.respond_to?(:skip_bugsnag) && exception.skip_bugsnag
+        configuration.debug("Not notifying due to skip_bugsnag flag")
+        return
+      end
+
       report = Report.new(exception, configuration, auto_notify)
 
       # If this is an auto_notify we yield the block before the any middleware is run

--- a/spec/report_spec.rb
+++ b/spec/report_spec.rb
@@ -1000,6 +1000,14 @@ describe Bugsnag::Report do
     }
   end
 
+  it 'does not notify if skip_bugsnag is true' do
+    exception = BugsnagTestException.new("It crashed")
+    exception.skip_bugsnag = true
+    Bugsnag.notify(exception)
+    expect(Bugsnag).not_to have_sent_notification
+  end
+    
+
   if defined?(JRUBY_VERSION)
 
     it "should work with java.lang.Throwables" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,7 +14,9 @@ require 'webmock/rspec'
 require 'rspec/expectations'
 require 'rspec/mocks'
 
-class BugsnagTestException < RuntimeError; end
+class BugsnagTestException < RuntimeError
+  attr_accessor :skip_bugsnag
+end
 
 def get_event_from_payload(payload)
   expect(payload["events"].size).to eq(1)


### PR DESCRIPTION
Adds supports for setting a `skip_bugsnag` flag on exceptions to allow re-raising after notifying as requested in #345 