### PR TITLE
Add SystemExit & Interrupt to ignore_classes by default

### DIFF
--- a/lib/bugsnag/configuration.rb
+++ b/lib/bugsnag/configuration.rb
@@ -53,11 +53,14 @@ module Bugsnag
       self.send_environment = false
       self.send_code = true
       self.meta_data_filters = Set.new(DEFAULT_META_DATA_FILTERS)
-      self.ignore_classes = Set.new([])
       self.endpoint = DEFAULT_ENDPOINT
       self.hostname = default_hostname
       self.timeout = 15
       self.notify_release_stages = nil
+
+      # SystemExit and Interrupt are common Exception types seen with successful
+      # exits and are not automatically reported to Bugsnag
+      self.ignore_classes = Set.new([SystemExit, Interrupt])
 
       # Read the API key from the environment
       self.api_key = ENV["BUGSNAG_API_KEY"]

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -23,4 +23,8 @@ describe Bugsnag::Configuration do
       expect(subject.delivery_method).to eq(:wow)
     end
   end
+
+  it "should have exit exception classes ignored by default" do
+    expect(subject.ignore_classes).to eq(Set.new([SystemExit, Interrupt]))
+  end
 end


### PR DESCRIPTION
Re-adds commonly seen exit 'exceptions' to default ignore_classes set to prevent them automatically triggering a notification.
- Adds `SystemExit` and `Interrupt` to `ignore_classes` set by default.
- Fixes issue described in #383 