### PR TITLE
Session tracking fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Changelog
 ### Enhancements
 
 * Adds support for tracking sessions and crash rate by setting the configuration option `configuration.track_sessions` to `true`.
-  Sessions can be manually created using `Bugsnag.start_session`, and manually delivered using `Bugsnag.send_sessions`.
+  Sessions can be manually created using `Bugsnag.create_session`, and manually delivered using `Bugsnag.send_sessions`.
   | [#411](https://github.com/bugsnag/bugsnag-ruby/pull/411)
 
 ## 6.4.0 (21 Dec 2017)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@ Changelog
 
 ### Enhancements
 
-* Adds support for tracking sessions and crash rate by setting the configuration option `configuration.track_sessions` to `true`.
-  Sessions can be manually created using `Bugsnag.create_session`, and manually delivered using `Bugsnag.send_sessions`.
+* Adds support for tracking sessions and crash rate by setting the configuration option `configuration.auto_capture_sessions` to `true`.
+  Sessions can be manually created using `Bugsnag.start_session`.
   | [#411](https://github.com/bugsnag/bugsnag-ruby/pull/411)
 
 ## 6.4.0 (21 Dec 2017)

--- a/bugsnag.gemspec
+++ b/bugsnag.gemspec
@@ -18,5 +18,5 @@ Gem::Specification.new do |s|
   ]
   s.require_paths = ["lib"]
   s.required_ruby_version = '>= 1.9.2'
-  s.add_runtime_dependency 'concurrent-ruby', '~> 1.0.5'
+  s.add_runtime_dependency 'concurrent-ruby', '~> 1.0'
 end

--- a/bugsnag.gemspec
+++ b/bugsnag.gemspec
@@ -18,4 +18,5 @@ Gem::Specification.new do |s|
   ]
   s.require_paths = ["lib"]
   s.required_ruby_version = '>= 1.9.2'
+  s.add_runtime_dependency 'concurrent-ruby'
 end

--- a/bugsnag.gemspec
+++ b/bugsnag.gemspec
@@ -18,5 +18,5 @@ Gem::Specification.new do |s|
   ]
   s.require_paths = ["lib"]
   s.required_ruby_version = '>= 1.9.2'
-  s.add_runtime_dependency 'concurrent-ruby'
+  s.add_runtime_dependency 'concurrent-ruby', '~> 1.0.5'
 end

--- a/example/rails-51/config/initializers/bugsnag.rb
+++ b/example/rails-51/config/initializers/bugsnag.rb
@@ -1,4 +1,4 @@
 Bugsnag.configure do |config|
   config.api_key = "YOUR_API_KEY"
-  config.auto_session_tracking = true
+  config.auto_capture_sessions = true
 end

--- a/example/rails-51/config/initializers/bugsnag.rb
+++ b/example/rails-51/config/initializers/bugsnag.rb
@@ -1,4 +1,4 @@
 Bugsnag.configure do |config|
   config.api_key = "YOUR_API_KEY"
-  config.track_sessions = true
+  config.auto_session_tracking = true
 end

--- a/lib/bugsnag.rb
+++ b/lib/bugsnag.rb
@@ -40,7 +40,7 @@ module Bugsnag
         @key_warning = true
       end
 
-      if configuration.track_sessions
+      if configuration.auto_session_tracking
         session_tracker.start_delivery_thread
       end
     end

--- a/lib/bugsnag.rb
+++ b/lib/bugsnag.rb
@@ -40,7 +40,9 @@ module Bugsnag
         @key_warning = true
       end
 
-      session_tracker.config = configuration
+      if configuration.track_sessions
+        session_tracker.start_delivery_thread
+      end
     end
 
     # Explicitly notify of an exception
@@ -130,7 +132,7 @@ module Bugsnag
 
     def session_tracker
       @session_tracker = nil unless defined?(@session_tracker)
-      @session_tracker || LOCK.synchronize { @session_tracker ||= Bugsnag::SessionTracker.new(configuration)}
+      @session_tracker || LOCK.synchronize { @session_tracker ||= Bugsnag::SessionTracker.new}
     end
 
     # Allow access to "before notify" callbacks

--- a/lib/bugsnag.rb
+++ b/lib/bugsnag.rb
@@ -126,9 +126,14 @@ module Bugsnag
       @configuration || LOCK.synchronize { @configuration ||= Bugsnag::Configuration.new }
     end
 
+    # Session tracking
     def session_tracker
       @session_tracker = nil unless defined?(@session_tracker)
       @session_tracker || LOCK.synchronize { @session_tracker ||= Bugsnag::SessionTracker.new}
+    end
+
+    def start_session
+      session_tracker.start_session
     end
 
     # Allow access to "before notify" callbacks

--- a/lib/bugsnag.rb
+++ b/lib/bugsnag.rb
@@ -39,10 +39,6 @@ module Bugsnag
         configuration.warn("No valid API key has been set, notifications will not be sent")
         @key_warning = true
       end
-
-      if configuration.auto_capture_sessions
-        session_tracker.start_delivery_thread
-      end
     end
 
     # Explicitly notify of an exception

--- a/lib/bugsnag.rb
+++ b/lib/bugsnag.rb
@@ -116,8 +116,9 @@ module Bugsnag
 
         # Deliver
         configuration.info("Notifying #{configuration.endpoint} of #{report.exceptions.last[:errorClass]}")
-        options = {:headers => report.headers, :trim_payload => true}
-        Bugsnag::Delivery[configuration.delivery_method].deliver(configuration.endpoint, report.as_json, configuration, options)
+        options = {:headers => report.headers}
+        payload = ::JSON.dump(Bugsnag::Helpers.trim_if_needed(report.as_json))
+        Bugsnag::Delivery[configuration.delivery_method].deliver(configuration.endpoint, payload, configuration, options)
       end
     end
 

--- a/lib/bugsnag.rb
+++ b/lib/bugsnag.rb
@@ -40,7 +40,7 @@ module Bugsnag
         @key_warning = true
       end
 
-      if configuration.auto_session_tracking
+      if configuration.auto_capture_sessions
         session_tracker.start_delivery_thread
       end
     end

--- a/lib/bugsnag/configuration.rb
+++ b/lib/bugsnag/configuration.rb
@@ -34,6 +34,7 @@ module Bugsnag
     attr_accessor :hostname
     attr_accessor :ignore_classes
     attr_accessor :auto_session_tracking
+    attr_accessor :track_sessions
     attr_accessor :session_endpoint
 
     API_KEY_REGEX = /[0-9a-f]{32}/i
@@ -48,6 +49,8 @@ module Bugsnag
       /secret/i,
       "rack.request.form_vars"
     ].freeze
+
+    alias :track_sessions :auto_session_tracking
 
     def initialize
       @mutex = Mutex.new

--- a/lib/bugsnag/configuration.rb
+++ b/lib/bugsnag/configuration.rb
@@ -23,7 +23,7 @@ module Bugsnag
     attr_accessor :app_type
     attr_accessor :meta_data_filters
     attr_accessor :endpoint
-    attr_accessor :logger 
+    attr_accessor :logger
     attr_accessor :middleware
     attr_accessor :internal_middleware
     attr_accessor :proxy_host

--- a/lib/bugsnag/configuration.rb
+++ b/lib/bugsnag/configuration.rb
@@ -33,7 +33,7 @@ module Bugsnag
     attr_accessor :timeout
     attr_accessor :hostname
     attr_accessor :ignore_classes
-    attr_accessor :track_sessions
+    attr_accessor :auto_session_tracking
     attr_accessor :session_endpoint
 
     API_KEY_REGEX = /[0-9a-f]{32}/i
@@ -61,7 +61,7 @@ module Bugsnag
       self.hostname = default_hostname
       self.timeout = 15
       self.notify_release_stages = nil
-      self.track_sessions = false
+      self.auto_session_tracking = false
       self.session_endpoint = DEFAULT_SESSION_ENDPOINT
 
       # SystemExit and Interrupt are common Exception types seen with successful

--- a/lib/bugsnag/configuration.rb
+++ b/lib/bugsnag/configuration.rb
@@ -33,7 +33,7 @@ module Bugsnag
     attr_accessor :timeout
     attr_accessor :hostname
     attr_accessor :ignore_classes
-    attr_accessor :auto_session_tracking
+    attr_accessor :auto_capture_sessions
     attr_accessor :track_sessions
     attr_accessor :session_endpoint
 
@@ -50,7 +50,7 @@ module Bugsnag
       "rack.request.form_vars"
     ].freeze
 
-    alias :track_sessions :auto_session_tracking
+    alias :track_sessions :auto_capture_sessions
 
     def initialize
       @mutex = Mutex.new
@@ -64,7 +64,7 @@ module Bugsnag
       self.hostname = default_hostname
       self.timeout = 15
       self.notify_release_stages = nil
-      self.auto_session_tracking = false
+      self.auto_capture_sessions = false
       self.session_endpoint = DEFAULT_SESSION_ENDPOINT
 
       # SystemExit and Interrupt are common Exception types seen with successful

--- a/lib/bugsnag/delivery/synchronous.rb
+++ b/lib/bugsnag/delivery/synchronous.rb
@@ -1,21 +1,18 @@
 require "net/https"
+require "bugsnag/delivery/retry"
 require "uri"
 
 module Bugsnag
   module Delivery
     class Synchronous
-      BACKOFF_THREADS = {}
-      BACKOFF_REQUESTS = {}
-      BACKOFF_LOCK = Mutex.new
-
       class << self
         def deliver(url, body, configuration, options={})
           begin
             response = request(url, body, configuration, options)
             configuration.debug("Request to #{url} completed, status: #{response.code}")
             success = options[:success] || '200'
-            if options[:backoff] && !(response.code == success)
-              backoff(url, body, configuration, options)
+            if !(response.code == success)
+              configuration.warn("Notifications to #{url} was reported unsuccessful with code #{response.code}")
             end
           rescue StandardError => e
             # KLUDGE: Since we don't re-raise http exceptions, this breaks rspec
@@ -52,85 +49,6 @@ module Bugsnag
           request.body = body
 
           http.request(request)
-        end
-
-        def backoff(url, body, configuration, options)
-          # Ensure we have the latest configuration for making these requests
-          @latest_configuration = configuration
-
-          BACKOFF_LOCK.lock
-          begin
-            # Define an exit function once to handle outstanding requests
-            @registered_at_exit = false unless defined?(@registered_at_exit)
-            if !@registered_at_exit
-              @registered_at_exit = true
-              at_exit do
-                backoff_exit
-              end
-            end
-            if BACKOFF_REQUESTS[url] && !BACKOFF_REQUESTS[url].empty?
-              last_request = BACKOFF_REQUESTS[url].last
-              new_body_length = ::JSON.dump(body).length
-              old_body_length = ::JSON.dump(last_request[:body]).length
-              if new_body_length + old_body_length >= Bugsnag::Helpers::MAX_PAYLOAD_LENGTH
-                BACKOFF_REQUESTS[url].push({:body => body, :options => options})
-              else
-                Bugsnag::Helpers::deep_merge!(last_request, {:body => body, :options => options})
-              end
-            else
-              BACKOFF_REQUESTS[url] = [{:body => body, :options => options}]
-            end
-            if !(BACKOFF_THREADS[url] && BACKOFF_THREADS[url].status)
-              spawn_backoff_thread(url)
-            end
-          ensure
-            BACKOFF_LOCK.unlock
-          end
-        end
-
-        def backoff_exit
-          # Kill existing threads
-          BACKOFF_THREADS.each do |url, thread|
-            thread.exit
-          end
-          # Retry outstanding requests once, then exit
-          BACKOFF_REQUESTS.each do |url, requests|
-            requests.map! do |req|
-              response = request(url, req[:body], @latest_configuration, req[:options])
-              success = req[:options][:success] || '200'
-              response.code == success
-            end
-            requests.reject! { |i| i }
-            @latest_configuration.warn("Requests to #{url} finished, #{requests.size} failed")
-          end
-        end
-
-        def spawn_backoff_thread(url)
-          new_thread = Thread.new(url) do |url|
-            interval = 2
-            while BACKOFF_REQUESTS[url].size > 0
-              sleep(interval)
-              interval = interval * 2
-              interval = 600 if interval > 600
-              BACKOFF_LOCK.lock
-              begin
-                BACKOFF_REQUESTS[url].map! do |req|
-                  response = request(url, req[:body], @latest_configuration, req[:options])
-                  success = req[:options][:success] || '200'
-                  if response.code == success
-                    @latest_configuration.debug("Request to #{url} completed, status: #{response.code}")
-                    false
-                  else
-                    req
-                  end
-                end
-                BACKOFF_REQUESTS[url].reject! { |i| !i }
-              ensure
-                BACKOFF_LOCK.unlock
-              end
-            end
-          end
-          BACKOFF_THREADS[url] = new_thread
         end
 
         def path(uri)

--- a/lib/bugsnag/delivery/synchronous.rb
+++ b/lib/bugsnag/delivery/synchronous.rb
@@ -1,5 +1,4 @@
 require "net/https"
-require "bugsnag/delivery/retry"
 require "uri"
 
 module Bugsnag

--- a/lib/bugsnag/delivery/synchronous.rb
+++ b/lib/bugsnag/delivery/synchronous.rb
@@ -9,8 +9,7 @@ module Bugsnag
           begin
             response = request(url, body, configuration, options)
             configuration.debug("Request to #{url} completed, status: #{response.code}")
-            code = response.code - (response.code % 100)
-            if !(code == success)
+            if !(response.code[0] == "2")
               configuration.warn("Notifications to #{url} was reported unsuccessful with code #{response.code}")
             end
           rescue StandardError => e

--- a/lib/bugsnag/delivery/synchronous.rb
+++ b/lib/bugsnag/delivery/synchronous.rb
@@ -9,8 +9,8 @@ module Bugsnag
           begin
             response = request(url, body, configuration, options)
             configuration.debug("Request to #{url} completed, status: #{response.code}")
-            success = options[:success] || '200'
-            if !(response.code == success)
+            code = response.code - (response.code % 100)
+            if !(code == success)
               configuration.warn("Notifications to #{url} was reported unsuccessful with code #{response.code}")
             end
           rescue StandardError => e

--- a/lib/bugsnag/delivery/synchronous.rb
+++ b/lib/bugsnag/delivery/synchronous.rb
@@ -62,7 +62,7 @@ module Bugsnag
         def backoff(url, body, configuration, options)
           # Ensure we have the latest configuration for making these requests
           @latest_configuration = configuration
-          
+
           BACKOFF_LOCK.lock
           begin
             # Define an exit function once to handle outstanding requests
@@ -109,7 +109,7 @@ module Bugsnag
             @latest_configuration.warn("Requests to #{url} finished, #{requests.size} failed")
           end
         end
-        
+
         def spawn_backoff_thread(url)
           new_thread = Thread.new(url) do |url|
             interval = 2

--- a/lib/bugsnag/delivery/synchronous.rb
+++ b/lib/bugsnag/delivery/synchronous.rb
@@ -9,7 +9,7 @@ module Bugsnag
           begin
             response = request(url, body, configuration, options)
             configuration.debug("Request to #{url} completed, status: #{response.code}")
-            if !(response.code[0] == "2")
+            if response.code[0] != "2"
               configuration.warn("Notifications to #{url} was reported unsuccessful with code #{response.code}")
             end
           rescue StandardError => e

--- a/lib/bugsnag/delivery/synchronous.rb
+++ b/lib/bugsnag/delivery/synchronous.rb
@@ -31,11 +31,6 @@ module Bugsnag
         def request(url, body, configuration, options)
           uri = URI.parse(url)
 
-          if options[:trim_payload]
-            body = Bugsnag::Helpers.trim_if_needed(body)
-          end
-          payload = ::JSON.dump(body)
-
           if configuration.proxy_host
             http = Net::HTTP.new(uri.host, uri.port, configuration.proxy_host, configuration.proxy_port, configuration.proxy_user, configuration.proxy_password)
           else
@@ -54,7 +49,7 @@ module Bugsnag
           headers.merge!(default_headers)
 
           request = Net::HTTP::Post.new(path(uri), headers)
-          request.body = payload
+          request.body = body
 
           http.request(request)
         end

--- a/lib/bugsnag/delivery/thread_queue.rb
+++ b/lib/bugsnag/delivery/thread_queue.rb
@@ -14,7 +14,6 @@ module Bugsnag
           start_once!
 
           if @queue.length > MAX_OUTSTANDING_REQUESTS
-            puts "Dropping request to #{url}"
             @configuration.warn("Dropping notification, #{@queue.length} outstanding requests")
             return
           end

--- a/lib/bugsnag/delivery/thread_queue.rb
+++ b/lib/bugsnag/delivery/thread_queue.rb
@@ -14,6 +14,7 @@ module Bugsnag
           start_once!
 
           if @queue.length > MAX_OUTSTANDING_REQUESTS
+            puts "Dropping request to #{url}"
             @configuration.warn("Dropping notification, #{@queue.length} outstanding requests")
             return
           end

--- a/lib/bugsnag/integrations/rack.rb
+++ b/lib/bugsnag/integrations/rack.rb
@@ -34,7 +34,9 @@ module Bugsnag
     def call(env)
       # Set the request data for bugsnag middleware to use
       Bugsnag.configuration.set_request_data(:rack_env, env)
-      Bugsnag.session_tracker.create_session
+      if Bugsnag.configuration.auto_capture_sessions
+        Bugsnag.session_tracker.start_session
+      end
 
       begin
         response = @app.call(env)

--- a/lib/bugsnag/integrations/rack.rb
+++ b/lib/bugsnag/integrations/rack.rb
@@ -35,7 +35,7 @@ module Bugsnag
       # Set the request data for bugsnag middleware to use
       Bugsnag.configuration.set_request_data(:rack_env, env)
       if Bugsnag.configuration.auto_capture_sessions
-        Bugsnag.session_tracker.start_session
+        Bugsnag.start_session
       end
 
       begin

--- a/lib/bugsnag/session_tracker.rb
+++ b/lib/bugsnag/session_tracker.rb
@@ -69,7 +69,6 @@ module Bugsnag
         end
         @session_counts[min] ||= 0
         @session_counts[min] += 1
-        puts "Time diff = #{Time.now() - @last_sent}"
         if Time.now() - @last_sent > TIME_THRESHOLD
           deliver_sessions
         end

--- a/lib/bugsnag/session_tracker.rb
+++ b/lib/bugsnag/session_tracker.rb
@@ -43,7 +43,7 @@ module Bugsnag
 
     def send_sessions
       sessions = []
-      counts = @session_counts.dup
+      counts = @session_counts
       @session_counts = Concurrent::Hash.new(0)
       counts.each do |min, count|
         sessions << {
@@ -82,8 +82,8 @@ module Bugsnag
       @session_counts[min] += 1
     end
 
-    def deliver(session_counts)
-      if session_counts.length == 0
+    def deliver(session_payload)
+      if session_payload.length == 0
         Bugsnag.configuration.debug("No sessions to deliver")
         return
       end
@@ -112,7 +112,7 @@ module Bugsnag
           :releaseStage => Bugsnag.configuration.release_stage,
           :type => Bugsnag.configuration.app_type
         },
-        :sessionCounts => session_counts
+        :sessionCounts => session_payload
       }
       payload = ::JSON.dump(body)
 

--- a/lib/bugsnag/session_tracker.rb
+++ b/lib/bugsnag/session_tracker.rb
@@ -22,7 +22,6 @@ module Bugsnag
 
     def initialize
       @session_counts = Concurrent::Hash.new(0)
-      @mutex = Mutex.new
       @track_sessions = false
     end
 

--- a/lib/bugsnag/session_tracker.rb
+++ b/lib/bugsnag/session_tracker.rb
@@ -126,7 +126,7 @@ module Bugsnag
         return
       end
 
-      payload = {
+      body = {
         :notifier => {
           :name => Bugsnag::Report::NOTIFIER_NAME,
           :url => Bugsnag::Report::NOTIFIER_URL,
@@ -142,6 +142,7 @@ module Bugsnag
         },
         :sessionCounts => sessionCounts
       }
+      payload = ::JSON.dump(body)
 
       headers = {
         "Bugsnag-Api-Key" => @config.api_key,

--- a/lib/bugsnag/session_tracker.rb
+++ b/lib/bugsnag/session_tracker.rb
@@ -6,13 +6,11 @@ module Bugsnag
   class SessionTracker
 
     THREAD_SESSION = "bugsnag_session"
-    TIME_THRESHOLD = 60
-    FALLBACK_TIME = 300
-    MAXIMUM_SESSION_COUNT = 50
+    MAXIMUM_SESSION_COUNT = 100
     SESSION_PAYLOAD_VERSION = "1.0"
 
     attr_reader :session_counts
-    attr_writer :config
+    attr_accessor :track_sessions
 
     def self.set_current_session(session)
       Thread.current[THREAD_SESSION] = session
@@ -22,15 +20,14 @@ module Bugsnag
       Thread.current[THREAD_SESSION]
     end
 
-    def initialize(configuration)
+    def initialize
       @session_counts = {}
-      @config = configuration
       @mutex = Mutex.new
-      @last_sent = Time.now
+      @track_sessions = false
     end
 
     def create_session
-      return unless @config.track_sessions
+      return unless @track_sessions
       start_time = Time.now().utc().strftime('%Y-%m-%dT%H:%M:00')
       new_session = {
         :id => SecureRandom.uuid,
@@ -41,15 +38,48 @@ module Bugsnag
         }
       }
       SessionTracker.set_current_session(new_session)
-      add_thread = Thread.new { add_session(start_time) }
+      add_session(start_time)
     end
 
     def send_sessions
+      return unless @track_sessions
       @mutex.lock
       begin
-        deliver_sessions
+        sessions = []
+        @session_counts.each do |min, count|
+          sessions << {
+            :startedAt => min,
+            :sessionsStarted => count
+          }
+        end
+        @session_counts = {}
       ensure
         @mutex.unlock
+      end
+      deliver(sessions)
+    end
+
+    def start_delivery_thread
+      @track_sessions = true
+      @initialised_sessions = false unless defined?(@initialised_sessions)
+      if !@initialised_sessions
+        @initialised_sessions = true
+        at_exit do
+          if !@delivery_thread.nil? && @delivery_thread.status == 'sleep'
+            @delivery_thread.terminate
+            send_sessions
+          else
+            @delivery_thread.join
+          end
+        end
+        @delivery_thread = Thread.new do
+          while true
+            sleep(30)
+            if @session_counts.size > 0
+              send_sessions
+            end
+          end
+        end
       end
     end
 
@@ -57,72 +87,27 @@ module Bugsnag
     def add_session(min)
       @mutex.lock
       begin
-        @registered_at_exit = false unless defined?(@registered_at_exit)
-        if !@registered_at_exit
-          @registered_at_exit = true
-          at_exit do
-            if !@deliver_fallback.nil? && @deliver_fallback.status == 'sleep'
-              @deliver_fallback.terminate
-            end
-            deliver_sessions
-          end
-        end
         @session_counts[min] ||= 0
         @session_counts[min] += 1
-        if Time.now() - @last_sent > TIME_THRESHOLD
-          deliver_sessions
-        end
       ensure
         @mutex.unlock
       end
     end
 
-    def deliver_sessions
-      return unless @config.track_sessions
-      sessions = []
-      @session_counts.each do |min, count|
-        sessions << {
-          :startedAt => min,
-          :sessionsStarted => count
-        }
-        if sessions.size >= MAXIMUM_SESSION_COUNT
-          deliver(sessions)
-          sessions = []
-        end
-      end
-      @session_counts = {}
-      reset_delivery_thread
-      deliver(sessions)
-    end
-
-    def reset_delivery_thread
-      if !@deliver_fallback.nil? && @deliver_fallback.status == 'sleep'
-        @deliver_fallback.terminate
-      end
-      @deliver_fallback = Thread.new do
-        sleep(FALLBACK_TIME)
-        deliver_sessions
-      end
-    end
-
     def deliver(sessionCounts)
+      config = Bugsnag.configuration
       if sessionCounts.length == 0
-        @config.debug("No sessions to deliver")
+        config.debug("No sessions to deliver")
         return
       end
 
-      if !@config.valid_api_key?
-        @config.debug("Not delivering sessions due to an invalid api_key")
+      if !Bugsnag.configuration.valid_api_key?
+        config.debug("Not delivering sessions due to an invalid api_key")
         return
       end
 
-      if !@config.should_notify_release_stage?
-        @config.debug("Not delivering sessions due to notify_release_stages :#{@config.notify_release_stages.inspect}")
-        return
-      end
-
-      if @config.delivery_method != :thread_queue
-        @config.debug("Not delivering sessions due to asynchronous delivery being disabled")
+      if !config.should_notify_release_stage?
+        config.debug("Not delivering sessions due to notify_release_stages :#{@config.notify_release_stages.inspect}")
         return
       end
 
@@ -133,25 +118,24 @@ module Bugsnag
           :version => Bugsnag::Report::NOTIFIER_VERSION
         },
         :device => {
-          :hostname => @config.hostname
+          :hostname => config.hostname
         },
         :app => {
-          :version => @config.app_version,
-          :releaseStage => @config.release_stage,
-          :type => @config.app_type
+          :version => config.app_version,
+          :releaseStage => config.release_stage,
+          :type => config.app_type
         },
         :sessionCounts => sessionCounts
       }
       payload = ::JSON.dump(body)
 
       headers = {
-        "Bugsnag-Api-Key" => @config.api_key,
+        "Bugsnag-Api-Key" => config.api_key,
         "Bugsnag-Payload-Version" => SESSION_PAYLOAD_VERSION
       }
 
       options = {:headers => headers, :success => '202'}
-      @last_sent = Time.now
-      Bugsnag::Delivery[@config.delivery_method].deliver(@config.session_endpoint, payload, @config, options)
+      Bugsnag::Delivery[config.delivery_method].deliver(config.session_endpoint, payload, config, options)
     end
   end
 end

--- a/lib/bugsnag/session_tracker.rb
+++ b/lib/bugsnag/session_tracker.rb
@@ -12,8 +12,6 @@ module Bugsnag
 
     attr_reader :session_counts
 
-    alias :create_session :start_session
-
     def self.set_current_session(session)
       Thread.current[THREAD_SESSION] = session
     end
@@ -40,6 +38,8 @@ module Bugsnag
       SessionTracker.set_current_session(new_session)
       add_session(start_time)
     end
+
+    alias :create_session :start_session
 
     def send_sessions
       sessions = []

--- a/lib/bugsnag/session_tracker.rb
+++ b/lib/bugsnag/session_tracker.rb
@@ -56,7 +56,7 @@ module Bugsnag
     end
 
     def start_delivery_thread
-      MUTEX.synchronise do
+      MUTEX.synchronize do
         @track_sessions = true
         @started = nil unless defined?(@started)
         return if @started == Process.pid

--- a/lib/bugsnag/session_tracker.rb
+++ b/lib/bugsnag/session_tracker.rb
@@ -111,12 +111,12 @@ module Bugsnag
         @config.debug("No sessions to deliver")
         return
       end
-      
+
       if !@config.valid_api_key?
         @config.debug("Not delivering sessions due to an invalid api_key")
         return
       end
-      
+
       if !@config.should_notify_release_stage?
         @config.debug("Not delivering sessions due to notify_release_stages :#{@config.notify_release_stages.inspect}")
         return
@@ -126,7 +126,7 @@ module Bugsnag
         @config.debug("Not delivering sessions due to asynchronous delivery being disabled")
         return
       end
-      
+
       payload = {
         :notifier => {
           :name => Bugsnag::Report::NOTIFIER_NAME,

--- a/lib/bugsnag/session_tracker.rb
+++ b/lib/bugsnag/session_tracker.rb
@@ -62,7 +62,7 @@ module Bugsnag
         at_exit do
           if !@delivery_thread.nil?
             @delivery_thread.execute
-            @delivery_thread.terminate
+            @delivery_thread.shutdown
           else
             if @session_counts.size > 0
               send_sessions

--- a/lib/bugsnag/session_tracker.rb
+++ b/lib/bugsnag/session_tracker.rb
@@ -42,7 +42,6 @@ module Bugsnag
       }
       SessionTracker.set_current_session(new_session)
       add_thread = Thread.new { add_session(start_time) }
-      add_thread.join()
     end
 
     def send_sessions

--- a/lib/bugsnag/session_tracker.rb
+++ b/lib/bugsnag/session_tracker.rb
@@ -6,7 +6,7 @@ module Bugsnag
   class SessionTracker
 
     THREAD_SESSION = "bugsnag_session"
-    TIME_THRESHOLD = 2
+    TIME_THRESHOLD = 60
     FALLBACK_TIME = 300
     MAXIMUM_SESSION_COUNT = 50
     SESSION_PAYLOAD_VERSION = "1.0"

--- a/lib/bugsnag/session_tracker.rb
+++ b/lib/bugsnag/session_tracker.rb
@@ -6,7 +6,7 @@ module Bugsnag
   class SessionTracker
 
     THREAD_SESSION = "bugsnag_session"
-    TIME_THRESHOLD = 60
+    TIME_THRESHOLD = 2
     FALLBACK_TIME = 300
     MAXIMUM_SESSION_COUNT = 50
     SESSION_PAYLOAD_VERSION = "1.0"
@@ -69,6 +69,7 @@ module Bugsnag
         end
         @session_counts[min] ||= 0
         @session_counts[min] += 1
+        puts "Time diff = #{Time.now() - @last_sent}"
         if Time.now() - @last_sent > TIME_THRESHOLD
           deliver_sessions
         end
@@ -149,7 +150,7 @@ module Bugsnag
         "Bugsnag-Payload-Version" => SESSION_PAYLOAD_VERSION
       }
 
-      options = {:headers => headers, :backoff => true, :success => '202'}
+      options = {:headers => headers, :success => '202'}
       @last_sent = Time.now
       Bugsnag::Delivery[@config.delivery_method].deliver(@config.session_endpoint, payload, @config, options)
     end

--- a/lib/bugsnag/session_tracker.rb
+++ b/lib/bugsnag/session_tracker.rb
@@ -10,7 +10,7 @@ module Bugsnag
     SESSION_PAYLOAD_VERSION = "1.0"
 
     attr_reader :session_counts
-    attr_accessor :track_sessions
+    attr_reader :track_sessions
 
     def self.set_current_session(session)
       Thread.current[THREAD_SESSION] = session
@@ -121,7 +121,7 @@ module Bugsnag
         "Bugsnag-Payload-Version" => SESSION_PAYLOAD_VERSION
       }
 
-      options = {:headers => headers, :success => '202'}
+      options = {:headers => headers}
       Bugsnag::Delivery[Bugsnag.configuration.delivery_method].deliver(Bugsnag.configuration.session_endpoint, payload, Bugsnag.configuration, options)
     end
   end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -25,7 +25,7 @@ describe Bugsnag::Configuration do
 
     it "should have sensible defaults for session tracking" do
       expect(subject.session_endpoint).to eq("https://sessions.bugsnag.com")
-      expect(subject.track_sessions).to be false
+      expect(subject.auto_session_tracking).to be false
     end
   end
 

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -25,7 +25,7 @@ describe Bugsnag::Configuration do
 
     it "should have sensible defaults for session tracking" do
       expect(subject.session_endpoint).to eq("https://sessions.bugsnag.com")
-      expect(subject.auto_session_tracking).to be false
+      expect(subject.auto_capture_sessions).to be false
     end
   end
 

--- a/spec/report_spec.rb
+++ b/spec/report_spec.rb
@@ -1006,7 +1006,7 @@ describe Bugsnag::Report do
     Bugsnag.notify(exception)
     expect(Bugsnag).not_to have_sent_notification
   end
-    
+
 
   if defined?(JRUBY_VERSION)
 

--- a/spec/session_tracker_spec.rb
+++ b/spec/session_tracker_spec.rb
@@ -3,6 +3,12 @@ require 'webrick'
 require 'spec_helper'
 require 'json'
 
+module Bugsnag
+  class SessionTracker
+    attr_accessor :track_sessions
+  end
+end
+
 describe Bugsnag::SessionTracker do
   server = nil
   queue = Queue.new
@@ -38,7 +44,7 @@ describe Bugsnag::SessionTracker do
 
   it 'adds session object to queue' do
     tracker = Bugsnag::SessionTracker.new
-    tracker.auto_session_tracking = true
+    tracker.track_sessions = true
     tracker.create_session
     while tracker.session_counts.size == 0
       sleep(0.05)
@@ -52,7 +58,7 @@ describe Bugsnag::SessionTracker do
 
   it 'stores session in thread' do
     tracker = Bugsnag::SessionTracker.new
-    tracker.auto_session_tracking = true
+    tracker.track_sessions = true
     tracker.create_session
     session = Thread.current[Bugsnag::SessionTracker::THREAD_SESSION]
     expect(session.include? :id).to be true
@@ -66,7 +72,7 @@ describe Bugsnag::SessionTracker do
 
   it 'gives unique ids to each session' do
     tracker = Bugsnag::SessionTracker.new
-    tracker.auto_session_tracking = true
+    tracker.track_sessions = true
     tracker.create_session
     session_one = Thread.current[Bugsnag::SessionTracker::THREAD_SESSION]
     tracker.create_session

--- a/spec/session_tracker_spec.rb
+++ b/spec/session_tracker_spec.rb
@@ -86,6 +86,9 @@ describe Bugsnag::SessionTracker do
     end
     expect(Bugsnag.session_tracker.session_counts.size).to eq(1)
     Bugsnag.session_tracker.send_sessions
+    while Bugsnag.session_tracker.session_counts.size == 1
+      sleep(0.05)
+    end
     expect(Bugsnag.session_tracker.session_counts.size).to eq(0)
     while queue.empty?
       sleep(0.05)
@@ -112,6 +115,9 @@ describe Bugsnag::SessionTracker do
     end
     expect(Bugsnag.session_tracker.session_counts.size).to eq(1)
     Bugsnag.session_tracker.send_sessions
+    while Bugsnag.session_tracker.session_counts.size == 1
+      sleep(0.05)
+    end
     expect(Bugsnag.session_tracker.session_counts.size).to eq(0)
     while queue.empty?
       sleep(0.05)

--- a/spec/session_tracker_spec.rb
+++ b/spec/session_tracker_spec.rb
@@ -27,7 +27,7 @@ describe Bugsnag::SessionTracker do
 
   after do
     Bugsnag.configure do |conf|
-      conf.auto_session_tracking = false
+      conf.auto_capture_sessions = false
       conf.delivery_method = :synchronous
     end
     server.stop
@@ -36,7 +36,7 @@ describe Bugsnag::SessionTracker do
 
   it 'does not create session object if disabled' do
     config = Bugsnag::Configuration.new
-    config.auto_session_tracking = false
+    config.auto_capture_sessions = false
     tracker = Bugsnag::SessionTracker.new
     tracker.create_session
     expect(tracker.session_counts.size).to eq(0)
@@ -82,7 +82,7 @@ describe Bugsnag::SessionTracker do
 
   it 'sends sessions when send_sessions is called' do
     Bugsnag.configure do |conf|
-      conf.auto_session_tracking = true
+      conf.auto_capture_sessions = true
       conf.delivery_method = :thread_queue
       conf.session_endpoint = "http://localhost:#{server.config[:Port]}"
     end
@@ -110,7 +110,7 @@ describe Bugsnag::SessionTracker do
 
   it 'sets details from config' do
     Bugsnag.configure do |conf|
-      conf.auto_session_tracking = true
+      conf.auto_capture_sessions = true
       conf.release_stage = "test_stage"
       conf.delivery_method = :thread_queue
       conf.session_endpoint = "http://localhost:#{server.config[:Port]}"
@@ -153,7 +153,7 @@ describe Bugsnag::SessionTracker do
 
   it 'uses middleware to attach session to notification' do
     Bugsnag.configure do |conf|
-      conf.auto_session_tracking = true
+      conf.auto_capture_sessions = true
       conf.release_stage = "test_stage"
     end
     Bugsnag.session_tracker.create_session

--- a/spec/session_tracker_spec.rb
+++ b/spec/session_tracker_spec.rb
@@ -21,7 +21,7 @@ describe Bugsnag::SessionTracker do
 
   after do
     Bugsnag.configure do |conf|
-      conf.track_sessions = false
+      conf.auto_session_tracking = false
       conf.delivery_method = :synchronous
     end
     server.stop
@@ -30,7 +30,7 @@ describe Bugsnag::SessionTracker do
 
   it 'does not create session object if disabled' do
     config = Bugsnag::Configuration.new
-    config.track_sessions = false
+    config.auto_session_tracking = false
     tracker = Bugsnag::SessionTracker.new
     tracker.create_session
     expect(tracker.session_counts.size).to eq(0)
@@ -38,7 +38,7 @@ describe Bugsnag::SessionTracker do
 
   it 'adds session object to queue' do
     tracker = Bugsnag::SessionTracker.new
-    tracker.track_sessions = true
+    tracker.auto_session_tracking = true
     tracker.create_session
     while tracker.session_counts.size == 0
       sleep(0.05)
@@ -52,7 +52,7 @@ describe Bugsnag::SessionTracker do
 
   it 'stores session in thread' do
     tracker = Bugsnag::SessionTracker.new
-    tracker.track_sessions = true
+    tracker.auto_session_tracking = true
     tracker.create_session
     session = Thread.current[Bugsnag::SessionTracker::THREAD_SESSION]
     expect(session.include? :id).to be true
@@ -66,7 +66,7 @@ describe Bugsnag::SessionTracker do
 
   it 'gives unique ids to each session' do
     tracker = Bugsnag::SessionTracker.new
-    tracker.track_sessions = true
+    tracker.auto_session_tracking = true
     tracker.create_session
     session_one = Thread.current[Bugsnag::SessionTracker::THREAD_SESSION]
     tracker.create_session
@@ -76,7 +76,7 @@ describe Bugsnag::SessionTracker do
 
   it 'sends sessions when send_sessions is called' do
     Bugsnag.configure do |conf|
-      conf.track_sessions = true
+      conf.auto_session_tracking = true
       conf.delivery_method = :thread_queue
       conf.session_endpoint = "http://localhost:#{server.config[:Port]}"
     end
@@ -104,7 +104,7 @@ describe Bugsnag::SessionTracker do
 
   it 'sets details from config' do
     Bugsnag.configure do |conf|
-      conf.track_sessions = true
+      conf.auto_session_tracking = true
       conf.release_stage = "test_stage"
       conf.delivery_method = :thread_queue
       conf.session_endpoint = "http://localhost:#{server.config[:Port]}"
@@ -147,7 +147,7 @@ describe Bugsnag::SessionTracker do
 
   it 'uses middleware to attach session to notification' do
     Bugsnag.configure do |conf|
-      conf.track_sessions = true
+      conf.auto_session_tracking = true
       conf.release_stage = "test_stage"
     end
     Bugsnag.session_tracker.create_session

--- a/spec/session_tracker_spec.rb
+++ b/spec/session_tracker_spec.rb
@@ -67,7 +67,7 @@ describe Bugsnag::SessionTracker do
       conf.session_endpoint = "http://localhost:#{server.config[:Port]}"
     end
     WebMock.allow_net_connect!
-    Bugsnag.session_tracker.start_session
+    Bugsnag.start_session
     expect(Bugsnag.session_tracker.session_counts.size).to eq(1)
     Bugsnag.session_tracker.send_sessions
     expect(Bugsnag.session_tracker.session_counts.size).to eq(0)
@@ -87,7 +87,7 @@ describe Bugsnag::SessionTracker do
       conf.session_endpoint = "http://localhost:#{server.config[:Port]}"
     end
     WebMock.allow_net_connect!
-    Bugsnag.session_tracker.start_session
+    Bugsnag.start_session
     expect(Bugsnag.session_tracker.session_counts.size).to eq(1)
     Bugsnag.session_tracker.send_sessions
     expect(Bugsnag.session_tracker.session_counts.size).to eq(0)
@@ -118,7 +118,7 @@ describe Bugsnag::SessionTracker do
       conf.auto_capture_sessions = true
       conf.release_stage = "test_stage"
     end
-    Bugsnag.session_tracker.start_session
+    Bugsnag.start_session
     Bugsnag.notify(BugsnagTestException.new("It crashed"))
     expect(Bugsnag).to have_sent_notification{ |payload, headers|
       event = payload["events"][0]

--- a/spec/session_tracker_spec.rb
+++ b/spec/session_tracker_spec.rb
@@ -8,8 +8,6 @@ describe Bugsnag::SessionTracker do
   queue = Queue.new
 
   before do
-    @config = Bugsnag::Configuration.new
-    @config.track_sessions = true
     server = WEBrick::HTTPServer.new :Port => 0, :Logger => WEBrick::Log.new("/dev/null"), :AccessLog => []
     server.mount_proc '/' do |req, res|
       headers = []
@@ -33,13 +31,14 @@ describe Bugsnag::SessionTracker do
   it 'does not create session object if disabled' do
     config = Bugsnag::Configuration.new
     config.track_sessions = false
-    tracker = Bugsnag::SessionTracker.new(config)
+    tracker = Bugsnag::SessionTracker.new
     tracker.create_session
     expect(tracker.session_counts.size).to eq(0)
   end
 
   it 'adds session object to queue' do
-    tracker = Bugsnag::SessionTracker.new(@config)
+    tracker = Bugsnag::SessionTracker.new
+    tracker.track_sessions = true
     tracker.create_session
     while tracker.session_counts.size == 0
       sleep(0.05)
@@ -52,7 +51,8 @@ describe Bugsnag::SessionTracker do
   end
 
   it 'stores session in thread' do
-    tracker = Bugsnag::SessionTracker.new(@config)
+    tracker = Bugsnag::SessionTracker.new
+    tracker.track_sessions = true
     tracker.create_session
     session = Thread.current[Bugsnag::SessionTracker::THREAD_SESSION]
     expect(session.include? :id).to be true
@@ -65,7 +65,8 @@ describe Bugsnag::SessionTracker do
   end
 
   it 'gives unique ids to each session' do
-    tracker = Bugsnag::SessionTracker.new(@config)
+    tracker = Bugsnag::SessionTracker.new
+    tracker.track_sessions = true
     tracker.create_session
     session_one = Thread.current[Bugsnag::SessionTracker::THREAD_SESSION]
     tracker.create_session

--- a/spec/session_tracker_spec.rb
+++ b/spec/session_tracker_spec.rb
@@ -21,7 +21,7 @@ describe Bugsnag::SessionTracker do
     Thread.new{ server.start }
   end
 
-  after do    
+  after do
     Bugsnag.configure do |conf|
       conf.track_sessions = false
       conf.delivery_method = :synchronous

--- a/spec/session_tracker_spec.rb
+++ b/spec/session_tracker_spec.rb
@@ -41,6 +41,9 @@ describe Bugsnag::SessionTracker do
   it 'adds session object to queue' do
     tracker = Bugsnag::SessionTracker.new(@config)
     tracker.create_session
+    while tracker.session_counts.size == 0
+      sleep(0.05)
+    end
     expect(tracker.session_counts.size).to eq(1)
     time = tracker.session_counts.keys.last
     count = tracker.session_counts[time]
@@ -78,6 +81,9 @@ describe Bugsnag::SessionTracker do
     end
     WebMock.allow_net_connect!
     Bugsnag.session_tracker.create_session
+    while Bugsnag.session_tracker.session_counts.size == 0
+      sleep(0.05)
+    end
     expect(Bugsnag.session_tracker.session_counts.size).to eq(1)
     Bugsnag.session_tracker.send_sessions
     expect(Bugsnag.session_tracker.session_counts.size).to eq(0)
@@ -101,6 +107,9 @@ describe Bugsnag::SessionTracker do
     end
     WebMock.allow_net_connect!
     Bugsnag.session_tracker.create_session
+    while Bugsnag.session_tracker.session_counts.size == 0
+      sleep(0.05)
+    end
     expect(Bugsnag.session_tracker.session_counts.size).to eq(1)
     Bugsnag.session_tracker.send_sessions
     expect(Bugsnag.session_tracker.session_counts.size).to eq(0)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,10 +23,6 @@ def get_event_from_payload(payload)
   payload["events"].first
 end
 
-def get_headers_from_payload(payload)
-
-end
-
 def get_exception_from_payload(payload)
   event = get_event_from_payload(payload)
   expect(event["exceptions"].size).to eq(1)


### PR DESCRIPTION
Fixes several issue from initial session-tracking release including:
- Standardises API
- Reduces number of spawned threads
- Uses concurrent ruby for safer concurrency
- Fixed breaking changes