### PR TITLE
Fix shoryuken integration

### DIFF
--- a/lib/bugsnag/integrations/shoryuken.rb
+++ b/lib/bugsnag/integrations/shoryuken.rb
@@ -26,7 +26,7 @@ module Bugsnag
         yield
       rescue Exception => ex
         unless [Interrupt, SystemExit, SignalException].include?(ex.class)
-          Bugsnag.auto_notify(ex, true) do |report|
+          Bugsnag.notify(ex, true) do |report|
             report.severity = "error"
             report.severity_reason = {
               :type => Bugsnag::Report::UNHANDLED_EXCEPTION_MIDDLEWARE,

--- a/lib/bugsnag/stacktrace.rb
+++ b/lib/bugsnag/stacktrace.rb
@@ -42,7 +42,7 @@ module Bugsnag
 
         # Clean up the file path in the stacktrace
         if defined?(@configuration.project_root) && @configuration.project_root.to_s != ''
-          trace_hash[:inProject] = true if file.start_with?(@configuration.project_root)
+          trace_hash[:inProject] = true if file.start_with?(@configuration.project_root.to_s)
           file.sub!(/#{@configuration.project_root}\//, "")
           trace_hash.delete(:inProject) if file.start_with?(VENDOR_PATH)
         end


### PR DESCRIPTION
This PR fixes shoryuken integration by using `Bugsnag.notify` instead of `Bugsnag.auto_notify` removed in a1b9e42dd. It also fixes a minor bug introduced in 7323b6a which causes Bugsnag to crash when `project_root` is `Pathname`, not a `String` (e.g., when `project_root` is set to `Rails.root` or `Hanami.root`).