### PR TITLE
Re-added apiKey to payload

### DIFF
--- a/lib/bugsnag/report.rb
+++ b/lib/bugsnag/report.rb
@@ -110,6 +110,7 @@ module Bugsnag
 
       # return the payload hash
       {
+        :apiKey => api_key,
         :notifier => {
           :name => NOTIFIER_NAME,
           :version => NOTIFIER_VERSION,

--- a/spec/report_spec.rb
+++ b/spec/report_spec.rb
@@ -33,6 +33,7 @@ describe Bugsnag::Report do
 
     expect(Bugsnag).to have_sent_notification{ |payload, headers|
       expect(headers["Bugsnag-Api-Key"]).to eq("c9d60ae4c7e70c4b6c4ebd3e8056d2b8")
+      expect(payload["apiKey"]).to eq("c9d60ae4c7e70c4b6c4ebd3e8056d2b8")
     }
   end
 


### PR DESCRIPTION
Re-adds `apiKey` to the payload, fixing potential issues occurring on older on-premise versions.