### PR TITLE
Marks .bundle/ files out of project

### DIFF
--- a/lib/bugsnag/stacktrace.rb
+++ b/lib/bugsnag/stacktrace.rb
@@ -8,7 +8,7 @@ module Bugsnag
     JAVA_BACKTRACE_REGEX = /^(.*)\((.*)(?::([0-9]+))?\)$/
 
     # Path to vendored code. Used to mark file paths as out of project.
-    VENDOR_PATH = /^(vendor\/|.bundle\/)/
+    VENDOR_PATH = /^(vendor\/|\.bundle\/)/
 
     def initialize(backtrace, configuration)
       @configuration = configuration

--- a/lib/bugsnag/stacktrace.rb
+++ b/lib/bugsnag/stacktrace.rb
@@ -8,7 +8,7 @@ module Bugsnag
     JAVA_BACKTRACE_REGEX = /^(.*)\((.*)(?::([0-9]+))?\)$/
 
     # Path to vendored code. Used to mark file paths as out of project.
-    VENDOR_PATH = 'vendor/'
+    VENDOR_PATH = /^(vendor\/|.bundle\/)/
 
     def initialize(backtrace, configuration)
       @configuration = configuration
@@ -44,7 +44,7 @@ module Bugsnag
         if defined?(@configuration.project_root) && @configuration.project_root.to_s != ''
           trace_hash[:inProject] = true if file.start_with?(@configuration.project_root.to_s)
           file.sub!(/#{@configuration.project_root}\//, "")
-          trace_hash.delete(:inProject) if file.start_with?(VENDOR_PATH)
+          trace_hash.delete(:inProject) if file.match(VENDOR_PATH)
         end
 
 

--- a/spec/report_spec.rb
+++ b/spec/report_spec.rb
@@ -536,6 +536,9 @@ describe Bugsnag::Report do
       File.join(project_root, "lib/helpers/string.rb:32:in `splice'"),
       File.join(project_root, "lib/vendor/lib/article.rb:158:in `initialize'"),
       File.join(project_root, "lib/prog.rb:158:in `read_articles'"),
+      File.join(project_root, ".bundle/strutils/lib.string.rb:508:in `splice'"),
+      File.join(project_root, ".bundles/strutils/lib.string.rb:508:in `splice'"),
+      File.join(project_root, "lib/.bundle/article.rb:158:in `initialize'"),
       "app.rb:10:in `main'",
       "(pry):3:in `__pry__'"
     ]}
@@ -549,7 +552,10 @@ describe Bugsnag::Report do
       expect(exception["stacktrace"][3]["inProject"]).to be true
       expect(exception["stacktrace"][4]["inProject"]).to be true
       expect(exception["stacktrace"][5]["inProject"]).to be_nil
-      expect(exception["stacktrace"][6]["inProject"]).to be_nil
+      expect(exception["stacktrace"][6]["inProject"]).to be true
+      expect(exception["stacktrace"][7]["inProject"]).to be true
+      expect(exception["stacktrace"][8]["inProject"]).to be_nil
+      expect(exception["stacktrace"][9]["inProject"]).to be_nil
     }
   end
 

--- a/spec/report_spec.rb
+++ b/spec/report_spec.rb
@@ -537,6 +537,7 @@ describe Bugsnag::Report do
       File.join(project_root, "lib/vendor/lib/article.rb:158:in `initialize'"),
       File.join(project_root, "lib/prog.rb:158:in `read_articles'"),
       File.join(project_root, ".bundle/strutils/lib.string.rb:508:in `splice'"),
+      File.join(project_root, "abundle/article.rb:158:in `initialize'"),
       File.join(project_root, ".bundles/strutils/lib.string.rb:508:in `splice'"),
       File.join(project_root, "lib/.bundle/article.rb:158:in `initialize'"),
       "app.rb:10:in `main'",
@@ -554,8 +555,9 @@ describe Bugsnag::Report do
       expect(exception["stacktrace"][5]["inProject"]).to be_nil
       expect(exception["stacktrace"][6]["inProject"]).to be true
       expect(exception["stacktrace"][7]["inProject"]).to be true
-      expect(exception["stacktrace"][8]["inProject"]).to be_nil
+      expect(exception["stacktrace"][8]["inProject"]).to be true
       expect(exception["stacktrace"][9]["inProject"]).to be_nil
+      expect(exception["stacktrace"][10]["inProject"]).to be_nil
     }
   end
 


### PR DESCRIPTION
Marks any files in `.bundle/` as out of project along with `vendor/` files.