### PR TITLE
Calls bugsnag_* methods on custom exceptions if available

### DIFF
--- a/lib/bugsnag/middleware/exception_meta_data.rb
+++ b/lib/bugsnag/middleware/exception_meta_data.rb
@@ -7,23 +7,21 @@ module Bugsnag::Middleware
     def call(report)
       # Apply the user's information attached to the exceptions
       report.raw_exceptions.each do |exception|
-        if exception.class.include?(Bugsnag::MetaData)
-          if exception.bugsnag_user_id.is_a?(String)
-            report.user = {id: exception.bugsnag_user_id}
-          end
+        if exception.respond_to?(:bugsnag_user_id) && exception.bugsnag_user_id.is_a?(String)
+          report.user = {id: exception.bugsnag_user_id}
+        end
 
-          if exception.bugsnag_context.is_a?(String)
-            report.context = exception.bugsnag_context
-          end
+        if exception.respond_to?(:bugsnag_context) && exception.bugsnag_context.is_a?(String)
+          report.context = exception.bugsnag_context
+        end
 
-          if exception.bugsnag_grouping_hash.is_a?(String)
-            report.grouping_hash = exception.bugsnag_grouping_hash
-          end
+        if exception.respond_to?(:bugsnag_grouping_hash) && exception.bugsnag_grouping_hash.is_a?(String)
+          report.grouping_hash = exception.bugsnag_grouping_hash
+        end
 
-          if exception.respond_to?(:bugsnag_meta_data) && exception.bugsnag_meta_data
-            exception.bugsnag_meta_data.each do |key, value|
-              report.add_tab key, value
-            end
+        if exception.respond_to?(:bugsnag_meta_data) && exception.bugsnag_meta_data
+          exception.bugsnag_meta_data.each do |key, value|
+            report.add_tab key, value
           end
         end
       end

--- a/lib/bugsnag/middleware/exception_meta_data.rb
+++ b/lib/bugsnag/middleware/exception_meta_data.rb
@@ -19,7 +19,7 @@ module Bugsnag::Middleware
           report.grouping_hash = exception.bugsnag_grouping_hash
         end
 
-        if exception.respond_to?(:bugsnag_meta_data) && exception.bugsnag_meta_data
+        if exception.respond_to?(:bugsnag_meta_data) && exception.bugsnag_meta_data.is_a?(Hash)
           exception.bugsnag_meta_data.each do |key, value|
             report.add_tab key, value
           end

--- a/spec/report_spec.rb
+++ b/spec/report_spec.rb
@@ -201,6 +201,42 @@ describe Bugsnag::Report do
     }
   end
 
+  it "accepts context from an exception that mixes in Bugsnag::MetaData" do
+    exception = BugsnagTestExceptionWithMetaData.new("It crashed")
+    exception.bugsnag_context = "Some context here"
+
+    Bugsnag.notify(exception)
+
+    expect(Bugsnag).to have_sent_notification{ |payload, headers|
+      event = get_event_from_payload(payload)
+      expect(event["context"]).to eq("Some context here")
+    }
+  end
+
+  it "accepts a user id from an exception that mixes in Bugsnag::MetaData" do
+    exception = BugsnagTestExceptionWithMetaData.new("It crashed")
+    exception.bugsnag_user_id = "HAL"
+
+    Bugsnag.notify(exception)
+
+    expect(Bugsnag).to have_sent_notification{ |payload, headers|
+      event = get_event_from_payload(payload)
+      expect(event["user"]["id"]).to eq("HAL")
+    }
+  end
+
+  it "accepts a grouping hash from an exception that mixes in Bugsnag::MetaData" do
+    exception = BugsnagTestExceptionWithMetaData.new("It crashed")
+    exception.bugsnag_grouping_hash = "ABCDEFG"
+
+    Bugsnag.notify(exception)
+
+    expect(Bugsnag).to have_sent_notification{ |payload, headers|
+      event = get_event_from_payload(payload)
+      expect(event["groupingHash"]).to eq("ABCDEFG")
+    }
+  end
+
   it "removes tabs" do
     exception = BugsnagTestExceptionWithMetaData.new("It crashed")
     exception.bugsnag_meta_data = {


### PR DESCRIPTION
Based on feedback in #422 and discussion with @kattrali, this PR makes it unnecessary for a custom exception to have included `Bugsnag::MetaData` by checking the functions exist individually.