### PR TITLE
Add RDoc pages on tag

### DIFF
--- a/.rdoc_options
+++ b/.rdoc_options
@@ -1,0 +1,27 @@
+--- !ruby/object:RDoc::Options
+encoding: UTF-8
+static_path: []
+rdoc_include:
+- "lib/**/*.rb"
+- "README.md"
+- "CONTRIBUTING.md"
+- "CHANGELOG.md"
+charset: UTF-8
+exclude:
+format: hanna
+hyperlink_all: false
+line_numbers: false
+locale:
+locale_dir: locale
+locale_name:
+main_page:
+markup: markdown
+output: rdoc
+output_decoration: true
+page_dir:
+show_hash: false
+tab_width: 8
+template_stylesheets: []
+title: bugsnag-ruby API Documentation
+visibility: :protected
+webcvs:

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,14 +36,11 @@ jobs:
   - stage: test
     env: GEMSETS="test sidekiq"
     rvm: 2.4.1
-
-before_deploy:
-- gem update --system 2.6.14
-- gem --version
-- gem install bundler -v 1.12
-- bundle _1.12.0_ --version
-- bundle _1.12.0_ install --with "$GEMSETS" --binstubs
-- bundle exec rake rdoc
+  - stage: deploy
+    env: GEMSETS="test doc"
+    rvm: 2.4.1
+    script: bundle exec rake rdoc
+    if: tag =~ ^v[1-9]
 
 deploy:
   provider: pages

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,3 +36,19 @@ jobs:
   - stage: test
     env: GEMSETS="test sidekiq"
     rvm: 2.4.1
+
+before_deploy:
+- gem update --system 2.6.14
+- gem --version
+- gem install bundler -v 1.12
+- bundle _1.12.0_ --version
+- bundle _1.12.0_ install --with "$GEMSETS" --binstubs
+- bundle exec rake rdoc
+
+deploy:
+  provider: pages
+  local_dir: rdoc # only include the contents of the generated docs dir
+  skip_cleanup: true
+  github_token: $GITHUB_TOKEN # set in travis-ci dashboard
+  on:
+    tags: true # only deploy when tag is applied to commit

--- a/Gemfile
+++ b/Gemfile
@@ -20,4 +20,8 @@ group :sidekiq, optional: true do
     gem 'sidekiq', '~> 5.0.4'
 end
 
+group :doc, optional: true do
+  gem 'hanna-nouveau'
+end
+
 gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -2,12 +2,13 @@
 
 require 'rdoc/task'
 RDoc::Task.new do |rdoc|
-  version = File.exist?('VERSION') ? File.read('VERSION') : ""
-
   rdoc.rdoc_dir = 'rdoc'
-  rdoc.title = "bugsnag #{version}"
-  rdoc.rdoc_files.include('README*')
+  rdoc.rdoc_files.include('README.md')
+  rdoc.rdoc_files.include('CONTRIBUTING.md')
+  rdoc.rdoc_files.include('CHANGELOG.md')
   rdoc.rdoc_files.include('lib/**/*.rb')
+  rdoc.options.push '-f', 'hanna'
+  rdoc.markup = 'markdown'
 end
 
 # RSpec tasks

--- a/bugsnag.gemspec
+++ b/bugsnag.gemspec
@@ -19,4 +19,5 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.required_ruby_version = '>= 1.9.2'
   s.add_runtime_dependency 'concurrent-ruby', '~> 1.0'
+  s.add_development_dependency 'hanna-nouveau'
 end

--- a/bugsnag.gemspec
+++ b/bugsnag.gemspec
@@ -19,5 +19,4 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.required_ruby_version = '>= 1.9.2'
   s.add_runtime_dependency 'concurrent-ruby', '~> 1.0'
-  s.add_development_dependency 'hanna-nouveau'
 end

--- a/lib/bugsnag.rb
+++ b/lib/bugsnag.rb
@@ -120,18 +120,22 @@ module Bugsnag
       end
     end
 
-    # Configuration getters
+    ##
+    # Returns the client's Configuration object, or creates one if not yet created.
     def configuration
       @configuration = nil unless defined?(@configuration)
       @configuration || LOCK.synchronize { @configuration ||= Bugsnag::Configuration.new }
     end
 
-    # Session tracking
+    ##
+    # Returns the client's SessionTracker object, or creates one if not yet created.
     def session_tracker
       @session_tracker = nil unless defined?(@session_tracker)
       @session_tracker || LOCK.synchronize { @session_tracker ||= Bugsnag::SessionTracker.new}
     end
 
+    ##
+    # Starts a session .
     def start_session
       session_tracker.start_session
     end

--- a/lib/bugsnag.rb
+++ b/lib/bugsnag.rb
@@ -30,7 +30,11 @@ module Bugsnag
   LOCK = Mutex.new
 
   class << self
+
+    ##
     # Configure the Bugsnag notifier application-wide settings.
+    #
+    # Yields a configuration object to use to set application settings.
     def configure
       yield(configuration) if block_given?
 
@@ -41,7 +45,10 @@ module Bugsnag
       end
     end
 
-    # Explicitly notify of an exception
+    ##
+    # Explicitly notify of an exception.
+    #
+    # Optionally accepts a block to append metadata to the yielded report.
     def notify(exception, auto_notify=false, &block)
       unless auto_notify.is_a? TrueClass or auto_notify.is_a? FalseClass
         configuration.warn("Adding metadata/severity using a hash is no longer supported, please use block syntax instead")
@@ -135,12 +142,17 @@ module Bugsnag
     end
 
     ##
-    # Starts a session .
+    # Starts a session.
+    #
+    # Allows Bugsnag to track error rates across releases.
     def start_session
       session_tracker.start_session
     end
 
-    # Allow access to "before notify" callbacks
+    ##
+    # Allow access to "before notify" callbacks as an array.
+    #
+    # These callbacks will be called whenever an error notification is being made.
     def before_notify_callbacks
       Bugsnag.configuration.request_data[:before_callbacks] ||= []
     end

--- a/lib/bugsnag/configuration.rb
+++ b/lib/bugsnag/configuration.rb
@@ -121,40 +121,58 @@ module Bugsnag
       @default_delivery_method = delivery_method
     end
 
+    ##
+    # Indicates whether the notifier should send a notification based on the
+    # configured release stage.
     def should_notify_release_stage?
       @release_stage.nil? || @notify_release_stages.nil? || @notify_release_stages.include?(@release_stage)
     end
 
+    ##
+    # Tests whether the configured API key is valid.
     def valid_api_key?
       !api_key.nil? && api_key =~ API_KEY_REGEX
     end
 
+    ##
+    # Returns the array of data that will be automatically attached to every
+    # error notification.
     def request_data
       Thread.current[THREAD_LOCAL_NAME] ||= {}
     end
 
+    ##
+    # Sets an entry in the array of data attached to every error notification.
     def set_request_data(key, value)
       self.request_data[key] = value
     end
 
+    ##
+    # Unsets an entry in the array of data attached to every error notification.
     def unset_request_data(key, value)
       self.request_data.delete(key)
     end
 
+    ##
+    # Clears the array of data attached to every error notification.
     def clear_request_data
       Thread.current[THREAD_LOCAL_NAME] = nil
     end
 
+    ##
+    # Logs an info level message
     def info(message)
       logger.info(message)
     end
 
-    # Warning logger
+    ##
+    # Logs a warning level message
     def warn(message)
       logger.warn(message)
     end
 
-    # Debug logger
+    ##
+    # Logs a debug level message
     def debug(message)
       logger.debug(message)
     end

--- a/lib/bugsnag/delivery.rb
+++ b/lib/bugsnag/delivery.rb
@@ -5,11 +5,13 @@ module Bugsnag
       # Add a delivery method to the list of supported methods. Any registered
       # method can then be used by name in Configuration.
       #
+      # ```
       # require 'bugsnag'
       # Bugsnag::Delivery.register(:my_delivery_queue, MyDeliveryQueue)
       # Bugsnag.configure do |config|
       #   config.delivery_method = :my_delivery_queue
       # end
+      # ```
       def register(name, delivery_method)
         delivery_methods[name.to_sym] = delivery_method
       end

--- a/lib/bugsnag/delivery.rb
+++ b/lib/bugsnag/delivery.rb
@@ -1,6 +1,7 @@
 module Bugsnag
   module Delivery
     class << self
+      ##
       # Add a delivery method to the list of supported methods. Any registered
       # method can then be used by name in Configuration.
       #
@@ -13,6 +14,7 @@ module Bugsnag
         delivery_methods[name.to_sym] = delivery_method
       end
 
+      ##
       # Reference a delivery method by name
       def [](name)
         delivery_methods[name.to_sym]

--- a/lib/bugsnag/delivery/synchronous.rb
+++ b/lib/bugsnag/delivery/synchronous.rb
@@ -5,6 +5,8 @@ module Bugsnag
   module Delivery
     class Synchronous
       class << self
+        ##
+        # Attempts to deliver a payload to the given endpoint synchronously.
         def deliver(url, body, configuration, options={})
           begin
             response = request(url, body, configuration, options)

--- a/lib/bugsnag/delivery/thread_queue.rb
+++ b/lib/bugsnag/delivery/thread_queue.rb
@@ -8,6 +8,9 @@ module Bugsnag
       MUTEX = Mutex.new
 
       class << self
+
+        ##
+        # Queues a given payload to be delivered asynchronously.
         def deliver(url, body, configuration, options={})
           @configuration = configuration
 

--- a/lib/bugsnag/helpers.rb
+++ b/lib/bugsnag/helpers.rb
@@ -10,6 +10,7 @@ module Bugsnag
     MAX_ARRAY_LENGTH = 40
     RAW_DATA_TYPES = [Numeric, TrueClass, FalseClass]
 
+    ##
     # Trim the size of value if the serialized JSON value is longer than is
     # accepted by Bugsnag
     def self.trim_if_needed(value)
@@ -23,6 +24,10 @@ module Bugsnag
       remove_metadata_from_events(reduced_value)
     end
 
+    ##
+    # Merges r_hash into l_hash recursively, favouring the values in r_hash.
+    #
+    # Returns a new array consisting of the merged values
     def self.deep_merge(l_hash, r_hash)
       l_hash.merge(r_hash) do |key, l_val, r_val|
         if l_val.is_a?(Hash) && r_val.is_a?(Hash)
@@ -35,6 +40,10 @@ module Bugsnag
       end
     end
 
+    ##
+    # Merges r_hash into l_hash recursively, favouring the values in r_hash.
+    #
+    # Overwrites the values in the existing l_hash
     def self.deep_merge!(l_hash, r_hash)
       l_hash.merge!(r_hash) do |key, l_val, r_val|
         if l_val.is_a?(Hash) && r_val.is_a?(Hash)
@@ -51,6 +60,7 @@ module Bugsnag
 
     TRUNCATION_INFO = '[TRUNCATED]'
 
+    ##
     # Check if a value is a raw type which should not be trimmed, truncated
     # or converted to a string
     def self.is_json_raw_type?(value)

--- a/lib/bugsnag/integrations/mailman.rb
+++ b/lib/bugsnag/integrations/mailman.rb
@@ -1,14 +1,14 @@
 require 'mailman'
 
 module Bugsnag
+  ##
+  # Extracts and appends mailman message information to error reports
   class Mailman
 
     FRAMEWORK_ATTRIBUTES = {
       :framework => "Mailman"
     }
 
-    ##
-    # Extracts and appends mailman data to error notifications.
     def initialize
       Bugsnag.configuration.internal_middleware.use(Bugsnag::Middleware::Mailman)
       Bugsnag.configuration.app_type = "mailman"

--- a/lib/bugsnag/integrations/mailman.rb
+++ b/lib/bugsnag/integrations/mailman.rb
@@ -7,11 +7,15 @@ module Bugsnag
       :framework => "Mailman"
     }
 
+    ##
+    # Extracts and appends mailman data to error notifications.
     def initialize
       Bugsnag.configuration.internal_middleware.use(Bugsnag::Middleware::Mailman)
       Bugsnag.configuration.app_type = "mailman"
     end
 
+    ##
+    # Calls the mailman middleware.
     def call(mail)
       begin
         Bugsnag.configuration.set_request_data :mailman_msg, mail.to_s

--- a/lib/bugsnag/integrations/rack.rb
+++ b/lib/bugsnag/integrations/rack.rb
@@ -5,6 +5,8 @@ module Bugsnag
       :framework => "Rack"
     }
 
+    ##
+    # Automatically captures and adds Rack data to error notifications.
     def initialize(app)
       @app = app
 
@@ -31,6 +33,8 @@ module Bugsnag
       end
     end
 
+    ##
+    # Wraps a call to the application with error capturing.
     def call(env)
       # Set the request data for bugsnag middleware to use
       Bugsnag.configuration.set_request_data(:rack_env, env)

--- a/lib/bugsnag/integrations/rack.rb
+++ b/lib/bugsnag/integrations/rack.rb
@@ -1,12 +1,12 @@
 module Bugsnag
+  ##
+  # Automatically captures and adds Rack request information to error reports
   class Rack
 
     FRAMEWORK_ATTRIBUTES = {
       :framework => "Rack"
     }
 
-    ##
-    # Automatically captures and adds Rack data to error notifications.
     def initialize(app)
       @app = app
 
@@ -34,7 +34,7 @@ module Bugsnag
     end
 
     ##
-    # Wraps a call to the application with error capturing.
+    # Wraps a call to the application with error capturing
     def call(env)
       # Set the request data for bugsnag middleware to use
       Bugsnag.configuration.set_request_data(:rack_env, env)

--- a/lib/bugsnag/integrations/rake.rb
+++ b/lib/bugsnag/integrations/rake.rb
@@ -8,6 +8,8 @@ class Rake::Task
     :framework => "Rake"
   }
 
+  ##
+  # Executes the rake task with Bugsnag setup with contextual data.
   def execute_with_bugsnag(args=nil)
     Bugsnag.configuration.app_type ||= "rake"
     old_task = Bugsnag.configuration.request_data[:bugsnag_running_task]

--- a/lib/bugsnag/integrations/resque.rb
+++ b/lib/bugsnag/integrations/resque.rb
@@ -8,11 +8,15 @@ module Bugsnag
       :framework => "Resque"
     }
 
+    ##
+    # Callthrough to Bugsnag configuration.
     def self.configure(&block)
       add_failure_backend
       Bugsnag.configure(&block)
     end
 
+    ##
+    # Sets up the Resque failure backend.
     def self.add_failure_backend
       return if ::Resque::Failure.backend == self
 
@@ -30,6 +34,8 @@ module Bugsnag
       end
     end
 
+    ##
+    # Notifies Bugsnag of a raised exception.
     def save
       Bugsnag.notify(exception, true) do |report|
         report.severity = "error"

--- a/lib/bugsnag/integrations/shoryuken.rb
+++ b/lib/bugsnag/integrations/shoryuken.rb
@@ -1,14 +1,14 @@
 require 'shoryuken'
 
 module Bugsnag
+  ##
+  # Extracts and attaches Shoryuken queue information to an error report
   class Shoryuken
 
     FRAMEWORK_ATTRIBUTES = {
       :framework => "Shoryuken"
     }
 
-    ##
-    # Extracts and attaches additional shoryuken application data to the report.
     def initialize
       Bugsnag.configure do |config|
         config.app_type ||= "shoryuken"
@@ -16,8 +16,6 @@ module Bugsnag
       end
     end
 
-    ##
-    # Exectures the middleware.
     def call(_, queue, _, body)
       begin
         Bugsnag.before_notify_callbacks << lambda {|report|

--- a/lib/bugsnag/integrations/shoryuken.rb
+++ b/lib/bugsnag/integrations/shoryuken.rb
@@ -7,6 +7,8 @@ module Bugsnag
       :framework => "Shoryuken"
     }
 
+    ##
+    # Extracts and attaches additional shoryuken application data to the report.
     def initialize
       Bugsnag.configure do |config|
         config.app_type ||= "shoryuken"
@@ -14,6 +16,8 @@ module Bugsnag
       end
     end
 
+    ##
+    # Exectures the middleware.
     def call(_, queue, _, body)
       begin
         Bugsnag.before_notify_callbacks << lambda {|report|

--- a/lib/bugsnag/integrations/sidekiq.rb
+++ b/lib/bugsnag/integrations/sidekiq.rb
@@ -1,22 +1,20 @@
 require 'sidekiq'
 
 module Bugsnag
+  ##
+  # Extracts and attaches Sidekiq job and queue information to an error report
   class Sidekiq
 
     FRAMEWORK_ATTRIBUTES = {
       :framework => "Sidekiq"
     }
 
-    ##
-    # Extracts and attaches additional information about sidekiq applications.
     def initialize
       Bugsnag.configuration.internal_middleware.use(Bugsnag::Middleware::Sidekiq)
       Bugsnag.configuration.app_type = "sidekiq"
       Bugsnag.configuration.default_delivery_method = :synchronous
     end
 
-    ##
-    # Exectures the middleware.
     def call(worker, msg, queue)
       begin
         # store msg/queue in thread local state to be read by Bugsnag::Middleware::Sidekiq

--- a/lib/bugsnag/integrations/sidekiq.rb
+++ b/lib/bugsnag/integrations/sidekiq.rb
@@ -7,12 +7,16 @@ module Bugsnag
       :framework => "Sidekiq"
     }
 
+    ##
+    # Extracts and attaches additional information about sidekiq applications.
     def initialize
       Bugsnag.configuration.internal_middleware.use(Bugsnag::Middleware::Sidekiq)
       Bugsnag.configuration.app_type = "sidekiq"
       Bugsnag.configuration.default_delivery_method = :synchronous
     end
 
+    ##
+    # Exectures the middleware.
     def call(worker, msg, queue)
       begin
         # store msg/queue in thread local state to be read by Bugsnag::Middleware::Sidekiq

--- a/lib/bugsnag/middleware/callbacks.rb
+++ b/lib/bugsnag/middleware/callbacks.rb
@@ -1,9 +1,14 @@
 module Bugsnag::Middleware
   class Callbacks
+
+    ##
+    # Calls all callbacks pre-registered in the configuration.
     def initialize(bugsnag)
       @bugsnag = bugsnag
     end
 
+    ##
+    # Executes the callback.
     def call(report)
       if report.request_data[:before_callbacks]
         report.request_data[:before_callbacks].each {|c| c.call(*[report][0...c.arity]) }

--- a/lib/bugsnag/middleware/callbacks.rb
+++ b/lib/bugsnag/middleware/callbacks.rb
@@ -1,14 +1,12 @@
 module Bugsnag::Middleware
+  ##
+  # Calls all configured callbacks passing an error report
   class Callbacks
 
-    ##
-    # Calls all callbacks pre-registered in the configuration.
     def initialize(bugsnag)
       @bugsnag = bugsnag
     end
 
-    ##
-    # Executes the callback.
     def call(report)
       if report.request_data[:before_callbacks]
         report.request_data[:before_callbacks].each {|c| c.call(*[report][0...c.arity]) }

--- a/lib/bugsnag/middleware/classify_error.rb
+++ b/lib/bugsnag/middleware/classify_error.rb
@@ -14,10 +14,14 @@ module Bugsnag::Middleware
         "SystemExit"
     ]
 
+    ##
+    # Sets the severity to info for the given classes.
     def initialize(bugsnag)
       @bugsnag = bugsnag
     end
 
+    ##
+    # Executes the callback.
     def call(report)
       report.raw_exceptions.each do |ex|
 

--- a/lib/bugsnag/middleware/classify_error.rb
+++ b/lib/bugsnag/middleware/classify_error.rb
@@ -1,4 +1,6 @@
 module Bugsnag::Middleware
+  ##
+  # Sets the severity to info for low-importance errors
   class ClassifyError
     INFO_CLASSES = [
         "AbstractController::ActionNotFound",
@@ -14,14 +16,10 @@ module Bugsnag::Middleware
         "SystemExit"
     ]
 
-    ##
-    # Sets the severity to info for the given classes.
     def initialize(bugsnag)
       @bugsnag = bugsnag
     end
 
-    ##
-    # Executes the callback.
     def call(report)
       report.raw_exceptions.each do |ex|
 

--- a/lib/bugsnag/middleware/clearance_user.rb
+++ b/lib/bugsnag/middleware/clearance_user.rb
@@ -2,10 +2,14 @@ module Bugsnag::Middleware
   class ClearanceUser
     COMMON_USER_FIELDS = [:email, :name, :first_name, :last_name, :created_at, :id]
 
+    ##
+    # Extracts and appends clearance user information
     def initialize(bugsnag)
       @bugsnag = bugsnag
     end
 
+    ##
+    # Executes the callback.
     def call(report)
       if report.request_data[:rack_env] &&
         report.request_data[:rack_env][:clearance] &&

--- a/lib/bugsnag/middleware/clearance_user.rb
+++ b/lib/bugsnag/middleware/clearance_user.rb
@@ -1,15 +1,13 @@
 module Bugsnag::Middleware
+  ##
+  # Extracts and appends clearance user information
   class ClearanceUser
     COMMON_USER_FIELDS = [:email, :name, :first_name, :last_name, :created_at, :id]
 
-    ##
-    # Extracts and appends clearance user information
     def initialize(bugsnag)
       @bugsnag = bugsnag
     end
 
-    ##
-    # Executes the callback.
     def call(report)
       if report.request_data[:rack_env] &&
         report.request_data[:rack_env][:clearance] &&

--- a/lib/bugsnag/middleware/exception_meta_data.rb
+++ b/lib/bugsnag/middleware/exception_meta_data.rb
@@ -1,13 +1,11 @@
 module Bugsnag::Middleware
+  ##
+  # Extracts data from the exception.
   class ExceptionMetaData
-    ##
-    # Extracts data from the exception.
     def initialize(bugsnag)
       @bugsnag = bugsnag
     end
 
-    ##
-    # Executes the callback.
     def call(report)
       # Apply the user's information attached to the exceptions
       report.raw_exceptions.each do |exception|

--- a/lib/bugsnag/middleware/exception_meta_data.rb
+++ b/lib/bugsnag/middleware/exception_meta_data.rb
@@ -1,9 +1,13 @@
 module Bugsnag::Middleware
   class ExceptionMetaData
+    ##
+    # Extracts data from the exception.
     def initialize(bugsnag)
       @bugsnag = bugsnag
     end
 
+    ##
+    # Executes the callback.
     def call(report)
       # Apply the user's information attached to the exceptions
       report.raw_exceptions.each do |exception|

--- a/lib/bugsnag/middleware/ignore_error_class.rb
+++ b/lib/bugsnag/middleware/ignore_error_class.rb
@@ -1,14 +1,13 @@
 module Bugsnag::Middleware
+  ##
+  # Determines if the exception should be ignored based on the configured
+  # `ignore_classes`
   class IgnoreErrorClass
 
-    ##
-    # Determines if the exception should be ignored.
     def initialize(bugsnag)
       @bugsnag = bugsnag
     end
 
-    ##
-    # Executes the callback.
     def call(report)
       ignore_error_class = report.raw_exceptions.any? do |ex|
         ancestor_chain = ex.class.ancestors.select { |ancestor| ancestor.is_a?(Class) }.to_set

--- a/lib/bugsnag/middleware/ignore_error_class.rb
+++ b/lib/bugsnag/middleware/ignore_error_class.rb
@@ -1,9 +1,14 @@
 module Bugsnag::Middleware
   class IgnoreErrorClass
+
+    ##
+    # Determines if the exception should be ignored.
     def initialize(bugsnag)
       @bugsnag = bugsnag
     end
 
+    ##
+    # Executes the callback.
     def call(report)
       ignore_error_class = report.raw_exceptions.any? do |ex|
         ancestor_chain = ex.class.ancestors.select { |ancestor| ancestor.is_a?(Class) }.to_set

--- a/lib/bugsnag/middleware/mailman.rb
+++ b/lib/bugsnag/middleware/mailman.rb
@@ -1,9 +1,14 @@
 module Bugsnag::Middleware
   class Mailman
+
+    ##
+    # Extracts and attaches mailman data to the request.
     def initialize(bugsnag)
       @bugsnag = bugsnag
     end
 
+    ##
+    # Executes the callback.
     def call(report)
       mailman_msg = report.request_data[:mailman_msg]
       report.add_tab(:mailman, {"message" => mailman_msg}) if mailman_msg

--- a/lib/bugsnag/middleware/mailman.rb
+++ b/lib/bugsnag/middleware/mailman.rb
@@ -1,14 +1,12 @@
 module Bugsnag::Middleware
+  ##
+  # Extracts and attaches mailman data to an error report
   class Mailman
 
-    ##
-    # Extracts and attaches mailman data to the request.
     def initialize(bugsnag)
       @bugsnag = bugsnag
     end
 
-    ##
-    # Executes the callback.
     def call(report)
       mailman_msg = report.request_data[:mailman_msg]
       report.add_tab(:mailman, {"message" => mailman_msg}) if mailman_msg

--- a/lib/bugsnag/middleware/rack_request.rb
+++ b/lib/bugsnag/middleware/rack_request.rb
@@ -2,10 +2,14 @@ module Bugsnag::Middleware
   class RackRequest
     SPOOF = "[SPOOF]".freeze
 
+    ##
+    # Extracts and attaches rack data to the request.
     def initialize(bugsnag)
       @bugsnag = bugsnag
     end
 
+    ##
+    # Executes the callback.
     def call(report)
       if report.request_data[:rack_env]
         env = report.request_data[:rack_env]

--- a/lib/bugsnag/middleware/rack_request.rb
+++ b/lib/bugsnag/middleware/rack_request.rb
@@ -1,15 +1,13 @@
 module Bugsnag::Middleware
+  ##
+  # Extracts and attaches rack data to an error report
   class RackRequest
     SPOOF = "[SPOOF]".freeze
 
-    ##
-    # Extracts and attaches rack data to the request.
     def initialize(bugsnag)
       @bugsnag = bugsnag
     end
 
-    ##
-    # Executes the callback.
     def call(report)
       if report.request_data[:rack_env]
         env = report.request_data[:rack_env]

--- a/lib/bugsnag/middleware/rails3_request.rb
+++ b/lib/bugsnag/middleware/rails3_request.rb
@@ -2,10 +2,14 @@ module Bugsnag::Middleware
   class Rails3Request
     SPOOF = "[SPOOF]".freeze
 
+    ##
+    # Extracts and attaches rails data to the request.
     def initialize(bugsnag)
       @bugsnag = bugsnag
     end
 
+    ##
+    # Executes the callback.
     def call(report)
       if report.request_data[:rack_env]
         env = report.request_data[:rack_env]

--- a/lib/bugsnag/middleware/rails3_request.rb
+++ b/lib/bugsnag/middleware/rails3_request.rb
@@ -1,15 +1,13 @@
 module Bugsnag::Middleware
+  ##
+  # Extracts and attaches rails and rack environment data to an error report
   class Rails3Request
     SPOOF = "[SPOOF]".freeze
 
-    ##
-    # Extracts and attaches rails data to the request.
     def initialize(bugsnag)
       @bugsnag = bugsnag
     end
 
-    ##
-    # Executes the callback.
     def call(report)
       if report.request_data[:rack_env]
         env = report.request_data[:rack_env]

--- a/lib/bugsnag/middleware/rake.rb
+++ b/lib/bugsnag/middleware/rake.rb
@@ -1,9 +1,13 @@
 module Bugsnag::Middleware
   class Rake
+    ##
+    # Extracts and attaches rake data to the request.
     def initialize(bugsnag)
       @bugsnag = bugsnag
     end
 
+    ##
+    # Executes the callback.
     def call(report)
       task = report.request_data[:bugsnag_running_task]
 

--- a/lib/bugsnag/middleware/rake.rb
+++ b/lib/bugsnag/middleware/rake.rb
@@ -1,13 +1,11 @@
 module Bugsnag::Middleware
+  ##
+  # Extracts and attaches rake task information to an error report
   class Rake
-    ##
-    # Extracts and attaches rake data to the request.
     def initialize(bugsnag)
       @bugsnag = bugsnag
     end
 
-    ##
-    # Executes the callback.
     def call(report)
       task = report.request_data[:bugsnag_running_task]
 

--- a/lib/bugsnag/middleware/session_data.rb
+++ b/lib/bugsnag/middleware/session_data.rb
@@ -1,9 +1,14 @@
 module Bugsnag::Middleware
   class SessionData
+
+    ##
+    # Attaches the current session data to the report if necessary.
     def initialize(bugsnag)
       @bugsnag = bugsnag
     end
 
+    ##
+    # Executes the callback.
     def call(report)
       session = Bugsnag::SessionTracker.get_current_session
       unless session.nil?

--- a/lib/bugsnag/middleware/session_data.rb
+++ b/lib/bugsnag/middleware/session_data.rb
@@ -1,14 +1,12 @@
 module Bugsnag::Middleware
+  ##
+  # Attaches information about current session to an error report
   class SessionData
 
-    ##
-    # Attaches the current session data to the report if necessary.
     def initialize(bugsnag)
       @bugsnag = bugsnag
     end
 
-    ##
-    # Executes the callback.
     def call(report)
       session = Bugsnag::SessionTracker.get_current_session
       unless session.nil?

--- a/lib/bugsnag/middleware/sidekiq.rb
+++ b/lib/bugsnag/middleware/sidekiq.rb
@@ -1,14 +1,12 @@
 module Bugsnag::Middleware
+  ##
+  # Attaches Sidekiq job information to an error report
   class Sidekiq
 
-    ##
-    # Extracts and attaches sidekiq data to the request.
     def initialize(bugsnag)
       @bugsnag = bugsnag
     end
 
-    ##
-    # Executes the callback.
     def call(report)
       sidekiq = report.request_data[:sidekiq]
       if sidekiq

--- a/lib/bugsnag/middleware/sidekiq.rb
+++ b/lib/bugsnag/middleware/sidekiq.rb
@@ -1,9 +1,14 @@
 module Bugsnag::Middleware
   class Sidekiq
+
+    ##
+    # Extracts and attaches sidekiq data to the request.
     def initialize(bugsnag)
       @bugsnag = bugsnag
     end
 
+    ##
+    # Executes the callback.
     def call(report)
       sidekiq = report.request_data[:sidekiq]
       if sidekiq

--- a/lib/bugsnag/middleware/suggestion_data.rb
+++ b/lib/bugsnag/middleware/suggestion_data.rb
@@ -1,17 +1,15 @@
 module Bugsnag::Middleware
+  ##
+  # Attaches any "Did you mean?" suggestions to the report
   class SuggestionData
 
     CAPTURE_REGEX = /Did you mean\?([\s\S]+)$/
     DELIMITER = "\n"
 
-    ##
-    # Attaches any "Did you mean?" style suggestion data to the report.
     def initialize(bugsnag)
       @bugsnag = bugsnag
     end
 
-    ##
-    # Executes the callback.
     def call(report)
       matches = []
       report.raw_exceptions.each do |exception|

--- a/lib/bugsnag/middleware/suggestion_data.rb
+++ b/lib/bugsnag/middleware/suggestion_data.rb
@@ -4,10 +4,14 @@ module Bugsnag::Middleware
     CAPTURE_REGEX = /Did you mean\?([\s\S]+)$/
     DELIMITER = "\n"
 
+    ##
+    # Attaches any "Did you mean?" style suggestion data to the report.
     def initialize(bugsnag)
       @bugsnag = bugsnag
     end
 
+    ##
+    # Executes the callback.
     def call(report)
       matches = []
       report.raw_exceptions.each do |exception|

--- a/lib/bugsnag/middleware/warden_user.rb
+++ b/lib/bugsnag/middleware/warden_user.rb
@@ -1,16 +1,14 @@
 module Bugsnag::Middleware
+  ##
+  # Extracts and attaches user information from Warden to an error report
   class WardenUser
     SCOPE_PATTERN = /^warden\.user\.([^.]+)\.key$/
     COMMON_USER_FIELDS = [:email, :name, :first_name, :last_name, :created_at, :id]
 
-    ##
-    # Extracts and attaches warden user data to the report.
     def initialize(bugsnag)
       @bugsnag = bugsnag
     end
 
-    ##
-    # Executes the callback.
     def call(report)
       if report.request_data[:rack_env] && report.request_data[:rack_env]["warden"]
         env = report.request_data[:rack_env]

--- a/lib/bugsnag/middleware/warden_user.rb
+++ b/lib/bugsnag/middleware/warden_user.rb
@@ -3,10 +3,14 @@ module Bugsnag::Middleware
     SCOPE_PATTERN = /^warden\.user\.([^.]+)\.key$/
     COMMON_USER_FIELDS = [:email, :name, :first_name, :last_name, :created_at, :id]
 
+    ##
+    # Extracts and attaches warden user data to the report.
     def initialize(bugsnag)
       @bugsnag = bugsnag
     end
 
+    ##
+    # Executes the callback.
     def call(report)
       if report.request_data[:rack_env] && report.request_data[:rack_env]["warden"]
         env = report.request_data[:rack_env]

--- a/lib/bugsnag/middleware_stack.rb
+++ b/lib/bugsnag/middleware_stack.rb
@@ -1,11 +1,17 @@
 module Bugsnag
   class MiddlewareStack
+    ##
+    # Creates the middleware stack.
     def initialize
       @middlewares = []
       @disabled_middleware = []
       @mutex = Mutex.new
     end
 
+    ##
+    # Defines a new middleware to use in the middleware call sequence.
+    #
+    # Will return early if given middleware is disabled or already included.
     def use(new_middleware)
       @mutex.synchronize do
         return if @disabled_middleware.include?(new_middleware)
@@ -15,6 +21,11 @@ module Bugsnag
       end
     end
 
+    ##
+    # Inserts a new middleware to use after a given middleware already added.
+    #
+    # Will return early if given middleware is disabled or already added.
+    # New middleware will be inserted last if the existing middleware is not already included.
     def insert_after(after, new_middleware)
       @mutex.synchronize do
         return if @disabled_middleware.include?(new_middleware)
@@ -34,6 +45,11 @@ module Bugsnag
       end
     end
 
+    ##
+    # Inserts a new middleware to use before a given middleware already added.
+    #
+    # Will return early if given middleware is disabled or already added.
+    # New middleware will be inserted last if the existing middleware is not already included.
     def insert_before(before, new_middleware)
       @mutex.synchronize do
         return if @disabled_middleware.include?(new_middleware)
@@ -57,12 +73,14 @@ module Bugsnag
       end
     end
 
-    # This allows people to proxy methods to the array if they want to do more complex stuff
+    ##
+    # Allows the user to proxy methods for more complex functionality.
     def method_missing(method, *args, &block)
       @middlewares.send(method, *args, &block)
     end
 
-    # Runs the middleware stack and calls
+    ##
+    # Runs the middleware stack.
     def run(report)
       # The final lambda is the termination of the middleware stack. It calls deliver on the notification
       lambda_has_run = false

--- a/lib/bugsnag/report.rb
+++ b/lib/bugsnag/report.rb
@@ -37,6 +37,8 @@ module Bugsnag
     attr_accessor :severity_reason
     attr_accessor :user
 
+    ##
+    # Initializes a new report from an exception.
     def initialize(exception, passed_configuration, auto_notify=false)
       @should_ignore = false
       @unhandled = auto_notify
@@ -58,7 +60,8 @@ module Bugsnag
       self.user = {}
     end
 
-    # Add a new tab to this notification
+    ##
+    # Add a new metadata tab to this notification.
     def add_tab(name, value)
       return if name.nil?
 
@@ -72,14 +75,16 @@ module Bugsnag
       end
     end
 
-    # Remove a tab from this notification
+    ##
+    # Removes a metadata tab from this notification.
     def remove_tab(name)
       return if name.nil?
 
       meta_data.delete(name)
     end
 
-    # Build an exception payload
+    ##
+    # Builds and returns the exception payload for this notification.
     def as_json
       # Build the payload's exception event
       payload_event = {
@@ -120,6 +125,8 @@ module Bugsnag
       }
     end
 
+    ##
+    # Returns the headers required for the notification.
     def headers
       {
         "Bugsnag-Api-Key" => api_key,
@@ -128,14 +135,20 @@ module Bugsnag
       }
     end
 
+    ##
+    # Whether this report should be ignored and not sent.
     def ignore?
       @should_ignore
     end
 
+    ##
+    # Data set on the configuration to be attached to every error notification.
     def request_data
       configuration.request_data
     end
 
+    ##
+    # Tells the client this report should not be sent.
     def ignore!
       @should_ignore = true
     end

--- a/lib/bugsnag/session_tracker.rb
+++ b/lib/bugsnag/session_tracker.rb
@@ -12,18 +12,28 @@ module Bugsnag
 
     attr_reader :session_counts
 
+    ##
+    # Sets the session information for this thread.
     def self.set_current_session(session)
       Thread.current[THREAD_SESSION] = session
     end
 
+    ##
+    # Returns the session information for this thread.
     def self.get_current_session
       Thread.current[THREAD_SESSION]
     end
 
+    ##
+    # Initializes the session tracker.
     def initialize
       @session_counts = Concurrent::Hash.new(0)
     end
 
+    ##
+    # Starts a new session, storing it on the current thread.
+    #
+    # This allows Bugsnag to track error rates for a release.
     def start_session
       start_delivery_thread
       start_time = Time.now().utc().strftime('%Y-%m-%dT%H:%M:00')
@@ -41,6 +51,8 @@ module Bugsnag
 
     alias_method :create_session, :start_session
 
+    ##
+    # Delivers the current session_counts lists to the session endpoint.
     def send_sessions
       sessions = []
       counts = @session_counts
@@ -54,6 +66,7 @@ module Bugsnag
       deliver(sessions)
     end
 
+    private
     def start_delivery_thread
       MUTEX.synchronize do
         @started = nil unless defined?(@started)
@@ -77,7 +90,6 @@ module Bugsnag
       end
     end
 
-    private
     def add_session(min)
       @session_counts[min] += 1
     end

--- a/lib/bugsnag/stacktrace.rb
+++ b/lib/bugsnag/stacktrace.rb
@@ -10,6 +10,8 @@ module Bugsnag
     # Path to vendored code. Used to mark file paths as out of project.
     VENDOR_PATH = /^(vendor\/|\.bundle\/)/
 
+    ##
+    # Process a backtrace and the configuration into a parsed stacktrace.
     def initialize(backtrace, configuration)
       @configuration = configuration
 
@@ -66,6 +68,8 @@ module Bugsnag
       end.compact
     end
 
+    ##
+    # Returns the processed backtrace
     def to_a
       @processed_backtrace
     end


### PR DESCRIPTION
Adds a command to travis-ci to build and upload the repositories [rdocs](https://github.com/ruby/rdoc) to the repository page.

In addition, added basic informational rdoc comments to the majority of public methods.