### PR TITLE
Updates the travis bundle to specify bundler version in each build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 language: ruby
 
 env:
-- BUNDLE_VERSION=1.12.0 GEMSETS=test
+- GEMSETS=test
 
 before_install:
 - gem update --system 2.6.14
@@ -25,24 +25,32 @@ jobs:
     rvm: jruby-19mode
   - stage: test
     rvm: 1.9.3
+    env:
+    - BUNDLE_VERSION=1.12.0
   - stage: test
     rvm: 2.0.0
+    env:
+    - BUNDLE_VERSION=1.12.0
   - stage: test
     rvm: 2.1.10
   - stage: test
     env:
+    - BUNDLE_VERSION=1.12.0
     - GEMSETS="test sidekiq"
     rvm: 2.2.4
   - stage: test
     env:
+    - BUNDLE_VERSION=1.12.0
     - GEMSETS="test sidekiq coverage"
     rvm: 2.3.0
   - stage: test
     env:
+    - BUNDLE_VERSION=1.12.0
     - GEMSETS="test sidekiq"
     rvm: 2.4.1
   - stage: deploy
     env:
+    - BUNDLE_VERSION=1.12.0
     - GEMSETS="test doc"
     rvm: 2.4.1
     script: bundle exec rake rdoc

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,28 +1,34 @@
 sudo: false
 language: ruby
 
+env:
+- BUNDLE_VERSION=1.12.0
+- GEMSETS=test
+
 before_install:
 - gem update --system 2.6.14
+- gem --version
+- gem install bundler -v $BUNDLE_VERSION
+- bundle _${BUNDLE_VERSION}_ --version
 
 install:
-- bundle install --with "$GEMSETS" --binstubs
+- bundle _${BUNDLE_VERSION}_ install --with "$GEMSETS" --binstubs
 
 script:
-- bundle exec ./bin/rake spec
+- bundle _${BUNDLE_VERSION}_ exec ./bin/rake spec
 
 jobs:
   include:
   - stage: test
-    env: GEMSETS=test
+    env:
+    - GEMSETS=test
+    - BUNDLE_VERSION=1.16.1
     rvm: jruby-19mode
   - stage: test
-    env: GEMSETS=test
     rvm: 1.9.3
   - stage: test
-    env: GEMSETS=test
     rvm: 2.0.0
   - stage: test
-    env: GEMSETS=test
     rvm: 2.1.10
   - stage: test
     env: GEMSETS="test sidekiq"

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ install:
 - bundle _${BUNDLE_VERSION}_ install --with "$GEMSETS" --binstubs
 
 script:
-- bundle _${BUNDLE_VERSION}_ exec ./bin/rake spec
+- bundle exec ./bin/rake spec
 
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 sudo: false
 language: ruby
 
-env:
-- GEMSETS=test
-
 before_install:
 - gem update --system 2.6.14
 - gem --version
@@ -27,12 +24,17 @@ jobs:
     rvm: 1.9.3
     env:
     - BUNDLE_VERSION=1.12.0
+    - GEMSETS=test
   - stage: test
     rvm: 2.0.0
     env:
     - BUNDLE_VERSION=1.12.0
+    - GEMSETS=test
   - stage: test
-    rvm: 2.1.10
+    rvm: 2.1.
+    env:
+    - BUNDLE_VERSION=1.12.0
+    - GEMSETS=test
   - stage: test
     env:
     - BUNDLE_VERSION=1.12.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,9 @@ language: ruby
 
 before_install:
 - gem update --system 2.6.14
-- gem --version
-- gem install bundler -v 1.12
-- bundle _1.12.0_ --version
 
 install:
-- bundle _1.12.0_ install --with "$GEMSETS" --binstubs
+- bundle install --with "$GEMSETS" --binstubs
 
 script:
 - bundle exec ./bin/rake spec

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,7 @@ sudo: false
 language: ruby
 
 env:
-- BUNDLE_VERSION=1.12.0
-- GEMSETS=test
+- BUNDLE_VERSION=1.12.0 GEMSETS=test
 
 before_install:
 - gem update --system 2.6.14

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,8 @@ jobs:
   include:
   - stage: test
     env:
-    - GEMSETS=test
     - BUNDLE_VERSION=1.16.1
+    - GEMSETS=test
     rvm: jruby-19mode
   - stage: test
     rvm: 1.9.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,8 @@ sudo: false
 language: ruby
 
 env:
-- BUNDLE_VERSION=1.12.0 GEMSETS=test
+- BUNDLE_VERSION=1.12.0
+- GEMSETS=test
 
 before_install:
 - gem update --system 2.6.14
@@ -30,16 +31,20 @@ jobs:
   - stage: test
     rvm: 2.1.10
   - stage: test
-    env: GEMSETS="test sidekiq"
+    env:
+    - GEMSETS="test sidekiq"
     rvm: 2.2.4
   - stage: test
-    env: GEMSETS="test sidekiq coverage"
+    env:
+    - GEMSETS="test sidekiq coverage"
     rvm: 2.3.0
   - stage: test
-    env: GEMSETS="test sidekiq"
+    env:
+    - GEMSETS="test sidekiq"
     rvm: 2.4.1
   - stage: deploy
-    env: GEMSETS="test doc"
+    env:
+    - GEMSETS="test doc"
     rvm: 2.4.1
     script: bundle exec rake rdoc
     if: tag =~ ^v[1-9]


### PR DESCRIPTION
This fixes the issue with `jruby-d19` where `rvm/executable-hooks` relied on `bundler v1.16` to function.
Also allows different bundler versions to be specified for each stage for future use.

If necessary this can be changed to the single bundler version with an override for `jruby-d19`.