### PR TITLE
Expanded support for proxy config from environment variables

### DIFF
--- a/lib/bugsnag/configuration.rb
+++ b/lib/bugsnag/configuration.rb
@@ -77,7 +77,7 @@ module Bugsnag
 
       # Read NET::HTTP proxy environment variables
       if proxy_uri = ENV["https_proxy"] || ENV['http_proxy']
-        set_proxy(proxy_uri)
+        parse_proxy(proxy_uri)
       end
 
       # Set up logging
@@ -181,7 +181,7 @@ module Bugsnag
 
     ##
     # Parses and sets proxy from a uri
-    def set_proxy(uri)
+    def parse_proxy(uri)
       proxy = URI.parse(uri)
       self.proxy_host = proxy.host
       self.proxy_port = proxy.port

--- a/lib/bugsnag/configuration.rb
+++ b/lib/bugsnag/configuration.rb
@@ -76,7 +76,7 @@ module Bugsnag
       self.api_key = ENV["BUGSNAG_API_KEY"]
 
       # Read NET::HTTP proxy environment variables
-      if proxy_uri = ENV["https_proxy"] || ENV['http_proxy']
+      if (proxy_uri = ENV["https_proxy"] || ENV['http_proxy'])
         parse_proxy(proxy_uri)
       end
 

--- a/lib/bugsnag/configuration.rb
+++ b/lib/bugsnag/configuration.rb
@@ -75,13 +75,9 @@ module Bugsnag
       # Read the API key from the environment
       self.api_key = ENV["BUGSNAG_API_KEY"]
 
-      # Read NET::HTTP proxy environment variable
-      if ENV["http_proxy"]
-        uri = URI.parse(ENV["http_proxy"])
-        self.proxy_host = uri.host
-        self.proxy_port = uri.port
-        self.proxy_user = uri.user
-        self.proxy_password = uri.password
+      # Read NET::HTTP proxy environment variables
+      if proxy_uri = ENV["https_proxy"] || ENV['http_proxy']
+        set_proxy(proxy_uri)
       end
 
       # Set up logging
@@ -181,6 +177,16 @@ module Bugsnag
     # Logs a debug level message
     def debug(message)
       logger.debug(message)
+    end
+
+    ##
+    # Parses and sets proxy from a uri
+    def set_proxy(uri)
+      proxy = URI.parse(uri)
+      self.proxy_host = proxy.host
+      self.proxy_port = proxy.port
+      self.proxy_user = proxy.user
+      self.proxy_password = proxy.password
     end
 
     private

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -29,6 +29,55 @@ describe Bugsnag::Configuration do
     end
   end
 
+  describe "set_proxy" do
+    it "defaults proxy settings to nil" do
+      expect(subject.proxy_host).to be nil
+      expect(subject.proxy_port).to be nil
+      expect(subject.proxy_user).to be nil
+      expect(subject.proxy_password).to be nil
+    end
+
+    it "allows proxy settings to be set directly" do
+      subject.proxy_host = "http://localhost"
+      subject.proxy_port = 34000
+      subject.proxy_user = "user"
+      subject.proxy_password = "password"
+      expect(subject.proxy_host).to eq("http://localhost")
+      expect(subject.proxy_port).to eq(34000)
+      expect(subject.proxy_user).to eq("user")
+      expect(subject.proxy_password).to eq("password")
+    end
+
+    it "parses a uri if provided" do
+      subject.set_proxy("http://user:password@localhost:34000")
+      expect(subject.proxy_host).to eq("localhost")
+      expect(subject.proxy_port).to eq(34000)
+      expect(subject.proxy_user).to eq("user")
+      expect(subject.proxy_password).to eq("password")
+    end
+
+    it "automatically parses http_proxy environment variable" do
+      ENV['http_proxy'] = "http://user:password@localhost:34000"
+      expect(subject.proxy_host).to eq("localhost")
+      expect(subject.proxy_port).to eq(34000)
+      expect(subject.proxy_user).to eq("user")
+      expect(subject.proxy_password).to eq("password")
+    end
+
+    it "automatically parses https_proxy environment variable" do
+      ENV['https_proxy'] = "https://user:password@localhost:34000"
+      expect(subject.proxy_host).to eq("localhost")
+      expect(subject.proxy_port).to eq(34000)
+      expect(subject.proxy_user).to eq("user")
+      expect(subject.proxy_password).to eq("password")
+    end
+
+    after do
+      ENV['http_proxy'] = nil
+      ENV['https_proxy'] = nil
+    end
+  end
+
   it "should have exit exception classes ignored by default" do
     expect(subject.ignore_classes).to eq(Set.new([SystemExit, Interrupt]))
   end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -49,7 +49,7 @@ describe Bugsnag::Configuration do
     end
 
     it "parses a uri if provided" do
-      subject.set_proxy("http://user:password@localhost:34000")
+      subject.parse_proxy("http://user:password@localhost:34000")
       expect(subject.proxy_host).to eq("localhost")
       expect(subject.proxy_port).to eq(34000)
       expect(subject.proxy_user).to eq("user")


### PR DESCRIPTION
Expands setting of `config.proxy` options to both `ENV['http_proxy']` and `ENV['https_proxy']` automatically.