### PR TITLE
Fix max_attempts notification for delayed_job

### DIFF
--- a/lib/bugsnag/integrations/delayed_job.rb
+++ b/lib/bugsnag/integrations/delayed_job.rb
@@ -30,7 +30,8 @@ unless defined? Delayed::Plugins::Bugsnag
               overrides[:job][:queue] = queue
             end
             if job.respond_to?(:attempts)
-              overrides[:job][:attempts] = "#{job.attempts + 1} / #{Delayed::Worker.max_attempts}"
+              max_attempts = job.max_attempts || Delayed::Worker.max_attempts
+              overrides[:job][:attempts] = "#{job.attempts + 1} / #{max_attempts}"
               # +1 as "attempts" is really previous attempts AFAICT, certainly it starts at 0.
             end
             if payload = job.payload_object


### PR DESCRIPTION
Custom jobs can override the default max attempts. Bugsnag doesn't take that into account.

See: https://github.com/collectiveidea/delayed_job/blame/ccbde3dbcd90a409fe3dceae906fa6292ef09692/lib/delayed/worker.rb#L288