### PR TITLE
fix(travis): Ensure docs deployment only occurs on deploy stage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,11 +63,10 @@ jobs:
     rvm: 2.4.1
     script: bundle exec rake rdoc
     if: tag =~ ^v[1-9]
-
-deploy:
-  provider: pages
-  local_dir: rdoc # only include the contents of the generated docs dir
-  skip_cleanup: true
-  github_token: $GITHUB_TOKEN # set in travis-ci dashboard
-  on:
-    tags: true # only deploy when tag is applied to commit
+    deploy:
+      provider: pages
+      local_dir: rdoc # only include the contents of the generated docs dir
+      skip_cleanup: true
+      github_token: $GITHUB_TOKEN # set in travis-ci dashboard
+      on:
+        tags: true # only deploy when tag is applied to commit


### PR DESCRIPTION
Fixes an issue when a tag is pushed to master travis attempts to deploy rdoc in all stages, causing issues as rdoc is not being run.

This change moves the deploy options into the `deploy` stage so only that stage triggers the docs deploy attempt.