### PR TITLE
Allow inProject stacktrace filters to be configured

### DIFF
--- a/lib/bugsnag/configuration.rb
+++ b/lib/bugsnag/configuration.rb
@@ -22,6 +22,7 @@ module Bugsnag
     attr_accessor :app_version
     attr_accessor :app_type
     attr_accessor :meta_data_filters
+    attr_accessor :stacktrace_filters
     attr_accessor :endpoint
     attr_accessor :logger
     attr_accessor :middleware
@@ -51,6 +52,12 @@ module Bugsnag
       "rack.request.form_vars"
     ].freeze
 
+    DEFAULT_STACKTRACE_FILTERS = [
+      # Path to vendored code. Used to mark file paths as out of project.
+      /^vendor\//,
+      /^\.bundle\//
+    ]
+
     alias :track_sessions :auto_capture_sessions
     alias :track_sessions= :auto_capture_sessions=
 
@@ -62,6 +69,7 @@ module Bugsnag
       self.send_environment = false
       self.send_code = true
       self.meta_data_filters = Set.new(DEFAULT_META_DATA_FILTERS)
+      self.stacktrace_filters = Set.new(DEFAULT_STACKTRACE_FILTERS)
       self.endpoint = DEFAULT_ENDPOINT
       self.hostname = default_hostname
       self.timeout = 15

--- a/lib/bugsnag/stacktrace.rb
+++ b/lib/bugsnag/stacktrace.rb
@@ -7,9 +7,6 @@ module Bugsnag
     # e.g. "org.jruby.Ruby.runScript(Ruby.java:807)"
     JAVA_BACKTRACE_REGEX = /^(.*)\((.*)(?::([0-9]+))?\)$/
 
-    # Path to vendored code. Used to mark file paths as out of project.
-    VENDOR_PATH = /^(vendor\/|\.bundle\/)/
-
     ##
     # Process a backtrace and the configuration into a parsed stacktrace.
     def initialize(backtrace, configuration)
@@ -46,7 +43,7 @@ module Bugsnag
         if defined?(@configuration.project_root) && @configuration.project_root.to_s != ''
           trace_hash[:inProject] = true if file.start_with?(@configuration.project_root.to_s)
           file.sub!(/#{@configuration.project_root}\//, "")
-          trace_hash.delete(:inProject) if file.match(VENDOR_PATH)
+          trace_hash.delete(:inProject) if @configuration.stacktrace_filters.any? { |filter| file.match(filter) }
         end
 
 


### PR DESCRIPTION
The `vendor` and `.bundle` filters work great for gem code, but we have some helper classes in our code base to DRY up common notification patterns that we would like to be ignored from the Bugsnag stacktraces and groupings.

This PR allows additional stacktrace filters to be added like so:

``` ruby
Bugsnag.configure do |config|
  config.stacktrace_filters << %r{^app/services/exception_notifier.rb}
end
```