### PR TITLE
Use HTTPS

### DIFF
--- a/bugsnag.gemspec
+++ b/bugsnag.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |s|
 
   s.description = "Ruby notifier for bugsnag.com"
   s.summary = "Ruby notifier for bugsnag.com"
-  s.homepage = "http://github.com/bugsnag/bugsnag-ruby"
+  s.homepage = "https://github.com/bugsnag/bugsnag-ruby"
   s.licenses = ["MIT"]
 
   s.files = `git ls-files`.split("\n").reject {|file| file.start_with? "example/"}

--- a/lib/bugsnag/report.rb
+++ b/lib/bugsnag/report.rb
@@ -6,7 +6,7 @@ module Bugsnag
   class Report
     NOTIFIER_NAME = "Ruby Bugsnag Notifier"
     NOTIFIER_VERSION = Bugsnag::VERSION
-    NOTIFIER_URL = "http://www.bugsnag.com"
+    NOTIFIER_URL = "https://www.bugsnag.com"
 
     UNHANDLED_EXCEPTION = "unhandledException"
     UNHANDLED_EXCEPTION_MIDDLEWARE = "unhandledExceptionMiddleware"


### PR DESCRIPTION
I noticed a couple of URLs within the gem that are not using modern protocols and probably should be. The first is the rather inconsequential homepage specification in the gemspec.

The other is a URL that is passed along with the report indicating the Bugsnag homepage, `NOTIFIER_URL` which I believe also should be using HTTPS.