### PR TITLE
[PLAT-1079] apply meta_data_filters to referer 

### DIFF
--- a/lib/bugsnag/middleware/rack_request.rb
+++ b/lib/bugsnag/middleware/rack_request.rb
@@ -28,11 +28,19 @@ module Bugsnag::Middleware
         url = "#{request.scheme}://#{request.host}"
         url << ":#{request.port}" unless [80, 443].include?(request.port)
 
+        cleaner = Bugsnag::Cleaner.new(report.configuration.meta_data_filters)
+
         # If app is passed a bad URL, this code will crash attempting to clean it
         begin
-          url << Bugsnag::Cleaner.new(report.configuration.meta_data_filters).clean_url(request.fullpath)
+          url << cleaner.clean_url(url)
         rescue StandardError => stde
           Bugsnag.configuration.warn "RackRequest - Rescued error while cleaning request.fullpath: #{stde}"
+        end
+
+        begin
+          clean_referer << cleaner.clean_url(request.referer)
+        rescue StandardError => stde
+          Bugsnag.configuration.warn "RackRequest - Rescued error while cleaning request.referer: #{stde}"
         end
 
         headers = {}
@@ -48,13 +56,16 @@ module Bugsnag::Middleware
 
           headers[header_key.split("_").map {|s| s.capitalize}.join("-")] = value
         end
+        
+        headers.referer = clean_referer
+
 
         # Add a request tab
         report.add_tab(:request, {
           :url => url,
           :httpMethod => request.request_method,
           :params => params.to_hash,
-          :referer => request.referer,
+          :referer => clean_referer,
           :clientIp => client_ip,
           :headers => headers
         })

--- a/lib/bugsnag/middleware/rack_request.rb
+++ b/lib/bugsnag/middleware/rack_request.rb
@@ -74,8 +74,6 @@ module Bugsnag::Middleware
         # Add an environment tab
         if report.configuration.send_environment
           report.add_tab(:environment, env)
-          # below also redacts referer from environemt tab -- need to write tests
-          # report.meta_data[:environment]['HTTP_REFERER'] = referer if report.meta_data[:environment]['HTTP_REFERER']
         end
 
         # Add a session tab

--- a/spec/integrations/rack_spec.rb
+++ b/spec/integrations/rack_spec.rb
@@ -14,7 +14,7 @@ describe Bugsnag::Rack do
   context "when an exception is raised in rack middleware" do
     # Build a fake crashing rack app
     exception = BugsnagTestException.new("It crashed")
-    rack_env = {"key" => "value",}
+    rack_env = {"key" => "value"}
     app = lambda { |env| raise exception }
     rack_stack = Bugsnag::Rack.new(app)
 

--- a/spec/integrations/rack_spec.rb
+++ b/spec/integrations/rack_spec.rb
@@ -69,6 +69,79 @@ describe Bugsnag::Rack do
       end
     end
 
+
+# *********************
+# *********************
+# *********************
+
+    it "correctly redacts from referer any value indicated by meta_data_filters" do
+      callback = double
+      rack_env = {
+        :env => true,
+        :HTTP_REFERER => "test_key",
+        "rack.session" => {
+          :session => true
+        }
+      }
+
+      rack_request = double
+      rack_params = {
+        :param => 'test'
+      }
+      allow(rack_request).to receive_messages(
+        :params => rack_params,
+        :ip => "rack_ip",
+        :request_method => "TEST",
+        :path => "/TEST_PATH",
+        :scheme => "http",
+        :host => "test_host",
+        :port => 80,
+        :referer => "https://bugsnag.com/about?email=hello@world.com&another_param=thing",
+        :fullpath => "/TEST_PATH"
+      )
+      expect(::Rack::Request).to receive(:new).with(rack_env).and_return(rack_request)
+
+      # modify rack_env to include redacted referer
+      # rack_env["HTTP_REFERER"] = "https://bugsnag.com/about?email=[FILTERED]&another_param=thing"
+      report = double("Bugsnag::Report")
+      allow(report).to receive(:request_data).and_return({
+        :rack_env => rack_env
+      })
+      expect(report).to receive(:context=).with("TEST /TEST_PATH")
+      expect(report).to receive(:user).and_return({})
+
+      config = double
+      allow(config).to receive(:send_environment).and_return(true)
+      allow(config).to receive(:meta_data_filters).and_return(['email'])
+      allow(report).to receive(:configuration).and_return(config)
+      expect(report).to receive(:add_tab).once.with(:request, {
+        :url => "http://test_host/TEST_PATH",
+        :httpMethod => "TEST",
+        :params => rack_params,
+        :referer => "https://bugsnag.com/about?email=[FILTERED]&another_param=thing",
+        :clientIp => "rack_ip",
+        :headers => {
+          "Referer"=>
+       +     "https://bugsnag.com/about?email=[FILTERED]&another_param=thing"
+        }
+      })
+      expect(report).to receive(:add_tab).once.with(:session, {
+        :session => true
+      })
+      expect(report).to receive(:add_tab).once.with(:environment, rack_env)
+
+      expect(callback).to receive(:call).with(report)
+
+      middleware = Bugsnag::Middleware::RackRequest.new(callback)
+      middleware.call(report)
+    end
+
+# *********************
+# *********************
+# *********************
+# *********************
+
+
     it "correctly extracts data from rack middleware" do
       callback = double
       rack_env = {
@@ -78,7 +151,7 @@ describe Bugsnag::Rack do
           :session => true
         }
       }
-      
+
       rack_request = double
       rack_params = {
         :param => 'test'


### PR DESCRIPTION
apply metadata filters to referer and headers Referer to redact any values that should be filtered from query params (identical to url cleaning).  Added test for redaction in url, referer and headers Referer.