### PR TITLE
Wait for forked pid to fix tests

### DIFF
--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -60,7 +60,7 @@ describe 'Bugsnag' do
       Process.fork do
         Bugsnag.notify 'yo too'
       end
-      Process.wait
+      Process.waitall
 
       expect(queue.length).to eq(2)
     end

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -57,10 +57,10 @@ describe 'Bugsnag' do
 
       Bugsnag.notify 'yo'
 
-      Process.fork do
+      pid = Process.fork do
         Bugsnag.notify 'yo too'
       end
-      Process.waitall
+      Process.wait(pid)
 
       expect(queue.length).to eq(2)
     end


### PR DESCRIPTION
## Goal

Fix the tests.

I believe that when the threadqueue tests are executed after the logger tests, the `Process.wait` immediately returns as it's previously waited for a child process. This passes the forked pid in so that it waits for the fork to finish which is the intention of the test.