### PR TITLE
Cawllec/update rake version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## {version} ({date})
+
+### Fixes
+
+* (Rake) Ensure newer rake versions are used when possible
+  | [#466](https://github.com/bugsnag/bugsnag-ruby/pull/466)
+
 ## 6.7.2 (24 Apr 2018)
 
 ### Fixes

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 
 group :test, optional: true do
-    gem 'rake', '> 10.1.1'
+    gem 'rake', RUBY_VERSION <= '1.9.3' ? '~> 10.1.1' : '~> 12.3.0'
     gem 'rspec'
     gem 'rspec-mocks'
     gem 'rdoc', '~> 5.1.0'

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 
 group :test, optional: true do
-    gem 'rake', '~> 10.1.1'
+    gem 'rake', '> 10.1.1'
     gem 'rspec'
     gem 'rspec-mocks'
     gem 'rdoc', '~> 5.1.0'

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 
 group :test, optional: true do
-    gem 'rake', RUBY_VERSION <= '1.9.3' ? '~> 10.1.1' : '~> 12.3.0'
+    gem 'rake', RUBY_VERSION <= '1.9.3' ? '~> 11.3.0' : '~> 12.3.0'
     gem 'rspec'
     gem 'rspec-mocks'
     gem 'rdoc', '~> 5.1.0'


### PR DESCRIPTION
## Goal

Allow new versions of Rake to be used with testing and later Ruby versions, while retaining

## Changeset

### Changed

- Added conditional to Rake to ensure compatibility across Ruby versions 

## Tests

Locally tested the correct Rake versions are loaded on 1.9.3 vs newer Ruby versions
