### PR TITLE
fix: Apply metadata filters to referer 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+## TBD
+
+### Fixes
+
+* Apply metadata filters to HTTP referer fields
+  | [#460](https://github.com/bugsnag/bugsnag-ruby/pull/460)
+  | [Renee Balmert](https://github.com/tremlab)
+
 ## 6.7.2 (24 Apr 2018)
 
 ### Fixes

--- a/lib/bugsnag/middleware/rack_request.rb
+++ b/lib/bugsnag/middleware/rack_request.rb
@@ -28,11 +28,20 @@ module Bugsnag::Middleware
         url = "#{request.scheme}://#{request.host}"
         url << ":#{request.port}" unless [80, 443].include?(request.port)
 
+        cleaner = Bugsnag::Cleaner.new(report.configuration.meta_data_filters)
+
         # If app is passed a bad URL, this code will crash attempting to clean it
         begin
-          url << Bugsnag::Cleaner.new(report.configuration.meta_data_filters).clean_url(request.fullpath)
+          url << cleaner.clean_url(request.fullpath)
         rescue StandardError => stde
           Bugsnag.configuration.warn "RackRequest - Rescued error while cleaning request.fullpath: #{stde}"
+        end
+
+        referer = nil
+        begin
+          referer = cleaner.clean_url(request.referer) if request.referer
+        rescue StandardError => stde
+          Bugsnag.configuration.warn "RackRequest - Rescued error while cleaning request.referer: #{stde}"
         end
 
         headers = {}
@@ -49,12 +58,14 @@ module Bugsnag::Middleware
           headers[header_key.split("_").map {|s| s.capitalize}.join("-")] = value
         end
 
+        headers["Referer"] = referer if headers["Referer"]
+
         # Add a request tab
         report.add_tab(:request, {
           :url => url,
           :httpMethod => request.request_method,
           :params => params.to_hash,
-          :referer => request.referer,
+          :referer => referer,
           :clientIp => client_ip,
           :headers => headers
         })

--- a/spec/integrations/rack_spec.rb
+++ b/spec/integrations/rack_spec.rb
@@ -69,6 +69,67 @@ describe Bugsnag::Rack do
       end
     end
 
+    it "correctly redacts from url and referer any value indicated by meta_data_filters" do
+      callback = double
+      rack_env = {
+        :env => true,
+        :HTTP_REFERER => "https://bugsnag.com/about?email=hello@world.com&another_param=thing",
+        "rack.session" => {
+          :session => true
+        }
+      }
+
+      rack_request = double
+      rack_params = {
+        :param => 'test'
+      }
+      allow(rack_request).to receive_messages(
+        :params => rack_params,
+        :ip => "rack_ip",
+        :request_method => "TEST",
+        :path => "/TEST_PATH",
+        :scheme => "http",
+        :host => "test_host",
+        :port => 80,
+        :referer => "https://bugsnag.com/about?email=hello@world.com&another_param=thing",
+        :fullpath => "/TEST_PATH?email=hello@world.com&another_param=thing"
+      )
+      expect(::Rack::Request).to receive(:new).with(rack_env).and_return(rack_request)
+
+      # modify rack_env to include redacted referer
+      report = double("Bugsnag::Report")
+      allow(report).to receive(:request_data).and_return({
+        :rack_env => rack_env
+      })
+      expect(report).to receive(:context=).with("TEST /TEST_PATH")
+      expect(report).to receive(:user).and_return({})
+
+      config = double
+      allow(config).to receive(:send_environment).and_return(true)
+      allow(config).to receive(:meta_data_filters).and_return(['email'])
+      allow(report).to receive(:configuration).and_return(config)
+      expect(report).to receive(:add_tab).once.with(:request, {
+        :url => "http://test_host/TEST_PATH?email=[FILTERED]&another_param=thing",
+        :httpMethod => "TEST",
+        :params => rack_params,
+        :referer => "https://bugsnag.com/about?email=[FILTERED]&another_param=thing",
+        :clientIp => "rack_ip",
+        :headers => {
+          "Referer" => "https://bugsnag.com/about?email=[FILTERED]&another_param=thing"
+        }
+      })
+      # rack_env["HTTP_REFERER"] = "https://bugsnag.com/about?email=[FILTERED]&another_param=thing"
+      expect(report).to receive(:add_tab).once.with(:environment, rack_env)
+      expect(report).to receive(:add_tab).once.with(:session, {
+        :session => true
+      })
+
+      expect(callback).to receive(:call).with(report)
+
+      middleware = Bugsnag::Middleware::RackRequest.new(callback)
+      middleware.call(report)
+    end
+
     it "correctly extracts data from rack middleware" do
       callback = double
       rack_env = {
@@ -78,7 +139,7 @@ describe Bugsnag::Rack do
           :session => true
         }
       }
-      
+
       rack_request = double
       rack_params = {
         :param => 'test'


### PR DESCRIPTION
## Goal

Filter sensitive values from HTTP referer by default

## Changeset

Expanded the scope of the `clean_url` use in `rack_request` to cover `request.headers['Referer']` and `request.referer`

## Tests

Added additional integrations tests to `rack_spec` 
