### PR TITLE
Improve DelayedJob max attempts handling

### DIFF
--- a/lib/bugsnag/integrations/delayed_job.rb
+++ b/lib/bugsnag/integrations/delayed_job.rb
@@ -30,9 +30,9 @@ unless defined? Delayed::Plugins::Bugsnag
               overrides[:job][:queue] = queue
             end
             if job.respond_to?(:attempts)
-              max_attempts = job.respond_to?(:max_attempts) ? job.max_attempts : Delayed::Worker.max_attempts
+              max_attempts = (job.respond_to?(:max_attempts) && job.max_attempts) || Delayed::Worker.max_attempts
               overrides[:job][:attempts] = "#{job.attempts + 1} / #{max_attempts}"
-              # +1 as "attempts" is really previous attempts AFAICT, certainly it starts at 0.
+              # +1 as "attempts" is zero-based and does not include the current failed attempt
             end
             if payload = job.payload_object
               p = {


### PR DESCRIPTION
- If the max attempts method returns nil it should fallback to Delayed::Worker.max_attempts
- Clarify comment