### PR TITLE
fix: Remove local rails config

### DIFF
--- a/example/rails-51/config/initializers/bugsnag.rb
+++ b/example/rails-51/config/initializers/bugsnag.rb
@@ -1,5 +1,4 @@
 Bugsnag.configure do |config|
-  config.api_key = "12312312312312312312312312312312"
-  config.auto_capture_sessions = false
-  config.endpoint = "http://localhost:62000"
+  config.api_key = "YOUR_API_KEY_HERE"
+  config.auto_capture_sessions = true
 end

--- a/example/rails-51/config/initializers/bugsnag.rb
+++ b/example/rails-51/config/initializers/bugsnag.rb
@@ -1,4 +1,3 @@
 Bugsnag.configure do |config|
   config.api_key = "YOUR_API_KEY_HERE"
-  config.auto_capture_sessions = true
 end


### PR DESCRIPTION
## Goal

The example config used for local testing had been checked in at some point, this rectifies that.