### PR TITLE
fix: Add mac specific host for docker

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,7 @@ end
 
 group :maze, optional: true do
   gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner' if RUBY_VERSION >= '2.0.0'
+  gem 'os'
 end
 
 gemspec

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -1,4 +1,5 @@
 require 'open3'
+require 'os'
 
 Before do
   find_default_docker_compose
@@ -18,9 +19,11 @@ def output_logs
 end
 
 def current_ip
-  # Parses the output of `ifconfig` to retreive the host IP for docker to talk to
-  # Breaks compatability with Windows
-  ip_addr = `ifconfig | grep -Eo 'inet (addr:)?([0-9]*\\\.){3}[0-9]*' | grep -v '127.0.0.1'`
-  ip_list = /((?:[0-9]*\.){3}[0-9]*)/.match(ip_addr)
-  ip_list.captures.first
+  if OS.mac?
+    'host.docker.internal'
+  else
+    ip_addr = `ifconfig | grep -Eo 'inet (addr:)?([0-9]*\\\.){3}[0-9]*' | grep -v '127.0.0.1'`
+    ip_list = /((?:[0-9]*\.){3}[0-9]*)/.match(ip_addr)
+    ip_list.captures.first
+  end
 end


### PR DESCRIPTION
Stops ip issues when communicating to the WeBrick server from inside the maze docker container, when running locally.