### PR TITLE
fix: Set explicit nokogiri version to work with Ruby 2.0

### DIFF
--- a/features/fixtures/rails3/app/Gemfile
+++ b/features/fixtures/rails3/app/Gemfile
@@ -2,6 +2,8 @@ source 'https://rubygems.org'
 
 gem 'rails', '3.2.22.5'
 
+gem 'nokogiri', '1.6.8'
+
 gem 'sqlite3'
 
 gem 'jquery-rails'

--- a/spec/fixtures/apps/rails-initializer-config/Gemfile
+++ b/spec/fixtures/apps/rails-initializer-config/Gemfile
@@ -1,4 +1,5 @@
 source 'https://rubygems.org'
 
 gem 'railties', '4.2.10', require: %w(action_controller rails)
+gem 'nokogiri', '1.6.8'
 gem 'bugsnag', path: '../../../..'

--- a/spec/fixtures/apps/rails-invalid-initializer-config/Gemfile
+++ b/spec/fixtures/apps/rails-invalid-initializer-config/Gemfile
@@ -1,4 +1,5 @@
 source 'https://rubygems.org'
 
 gem 'railties', '4.2.10', require: %w(action_controller rails)
+gem 'nokogiri', '1.6.8'
 gem 'bugsnag', path: '../../../..'

--- a/spec/fixtures/apps/rails-no-config/Gemfile
+++ b/spec/fixtures/apps/rails-no-config/Gemfile
@@ -1,4 +1,5 @@
 source 'https://rubygems.org'
 
 gem 'railties', '4.2.10', require: %w(action_controller rails)
+gem 'nokogiri', '1.6.8'
 gem 'bugsnag', path: '../../../..'


### PR DESCRIPTION
## Goal

Fixes broken rails tests (as of the 16th of June) in Ruby 2.0.0 by fixing the Nokogiri version of fixtures.