### PR TITLE
Do not report SignalExceptions in at_exit handler

### DIFF
--- a/lib/bugsnag.rb
+++ b/lib/bugsnag.rb
@@ -118,15 +118,17 @@ module Bugsnag
     def register_at_exit
       return if at_exit_handler_installed?
       @exit_handler_added = true
-      at_exit do
-        if $!
-          Bugsnag.notify($!, true) do |report|
-            report.severity = 'error'
-            report.severity_reason = {
-              :type => Bugsnag::Report::UNHANDLED_EXCEPTION
-            }
-          end
-        end
+      at_exit { $! && at_exit_handler($!) }
+    end
+
+    def at_exit_handler(exception)
+      return if exception.is_a?(SignalException)
+
+      Bugsnag.notify(exception, true) do |report|
+        report.severity = 'error'
+        report.severity_reason = {
+          :type => Bugsnag::Report::UNHANDLED_EXCEPTION
+        }
       end
     end
 


### PR DESCRIPTION
## Goal

The previous behaviour resulted in applications reporting errors even though they were gracefully and without any problems shut down. Example: the puma webserver relies on `SIGTERM` to gracefully shut down its workers and Bugsnag reported errors when it was normally shut down.


With the `at_exit` handler introduced in #397, Bugsnag would catch `SignalExceptions` on exit and report them as error, even though they are none. 

This PR changes the existing behaviour to add `SignalException` as a special case in which the exception should not be passed to `Bugsnag.notify`.

## Changeset


### Added

- `Bugsnag.at_exit_handler`

### Changed

- `Bugsnag.register_at_exit`

## Tests

Due to the Ruby exiting when a `SignalException` is raised I had to refactor the code to make the actual handling of the exit-exceptions testable without the test suite quitting.

### Linked issues

For more information on puma's behaviour, see here: https://github.com/puma/puma/issues/1438
Honeybadger also ignores `SignalException`s: https://github.com/honeybadger-io/honeybadger-ruby/issues/267

## Review

<!-- When submitting for review, consider the points for self-review and the
     criteria which will be used for secondary review -->

For the submitter, initial self-review:

- [x] Commented on code changes inline explain the reasoning behind the approach
- [x] Reviewed the test cases added for completeness and possible points for discussion
- [ ] A changelog entry was added for the goal of this pull request
- [x] Check the scope of the changeset - is everything in the diff required for the pull request?
- This pull request is ready for:
  - [x] Initial review of the intended approach, not yet feature complete
  - [x] Structural review of the classes, functions, and properties modified
  - [x] Final review

For the pull request reviewer(s), this changeset has been reviewed for:

- [ ] Consistency across platforms for structures or concepts added or modified
- [ ] Consistency between the changeset and the goal stated above
- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [ ] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [ ] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [ ] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language
