### PR TITLE
Add SignalException to default ignore_classes

### DIFF
--- a/lib/bugsnag/configuration.rb
+++ b/lib/bugsnag/configuration.rb
@@ -69,9 +69,9 @@ module Bugsnag
       self.auto_capture_sessions = false
       self.session_endpoint = DEFAULT_SESSION_ENDPOINT
 
-      # SystemExit and Interrupt are common Exception types seen with successful
-      # exits and are not automatically reported to Bugsnag
-      self.ignore_classes = Set.new([SystemExit, Interrupt])
+      # SystemExit and SignalException are common Exception types seen with
+      # successful exits and are not automatically reported to Bugsnag
+      self.ignore_classes = Set.new([SystemExit, SignalException])
 
       # Read the API key from the environment
       self.api_key = ENV["BUGSNAG_API_KEY"]

--- a/lib/bugsnag/integrations/mailman.rb
+++ b/lib/bugsnag/integrations/mailman.rb
@@ -21,7 +21,6 @@ module Bugsnag
         Bugsnag.configuration.set_request_data :mailman_msg, mail.to_s
         yield
       rescue Exception => ex
-        raise ex if [Interrupt, SystemExit, SignalException].include? ex.class
         Bugsnag.notify(ex, true) do |report|
           report.severity = "error"
           report.severity_reason = {

--- a/lib/bugsnag/integrations/shoryuken.rb
+++ b/lib/bugsnag/integrations/shoryuken.rb
@@ -27,14 +27,12 @@ module Bugsnag
 
         yield
       rescue Exception => ex
-        unless [Interrupt, SystemExit, SignalException].include?(ex.class)
-          Bugsnag.notify(ex, true) do |report|
-            report.severity = "error"
-            report.severity_reason = {
-              :type => Bugsnag::Report::UNHANDLED_EXCEPTION_MIDDLEWARE,
-              :attributes => Bugsnag::Shoryuken::FRAMEWORK_ATTRIBUTES
-            }
-          end
+        Bugsnag.notify(ex, true) do |report|
+          report.severity = "error"
+          report.severity_reason = {
+            :type => Bugsnag::Report::UNHANDLED_EXCEPTION_MIDDLEWARE,
+            :attributes => Bugsnag::Shoryuken::FRAMEWORK_ATTRIBUTES
+          }
         end
         raise
       ensure

--- a/lib/bugsnag/integrations/sidekiq.rb
+++ b/lib/bugsnag/integrations/sidekiq.rb
@@ -31,7 +31,6 @@ module Bugsnag
     end
 
     def self.notify(exception)
-      return if [Interrupt, SystemExit, SignalException].include? exception.class
       Bugsnag.notify(exception, true) do |report|
         report.severity = "error"
         report.severity_reason = {

--- a/lib/bugsnag/integrations/sidekiq.rb
+++ b/lib/bugsnag/integrations/sidekiq.rb
@@ -22,7 +22,6 @@ module Bugsnag
 
         yield
       rescue Exception => ex
-        raise ex if [Interrupt, SystemExit, SignalException].include? ex.class
         Bugsnag.notify(ex, true) do |report|
           report.severity = "error"
           report.severity_reason = {

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -219,7 +219,7 @@ describe Bugsnag::Configuration do
   end
 
   it "should have exit exception classes ignored by default" do
-    expect(subject.ignore_classes).to eq(Set.new([SystemExit, Interrupt]))
+    expect(subject.ignore_classes).to eq(Set.new([SystemExit, SignalException]))
   end
 
 end

--- a/spec/report_spec.rb
+++ b/spec/report_spec.rb
@@ -146,18 +146,27 @@ describe Bugsnag::Report do
   end
 
   it "sets correct severity and reason for specific error classes" do
-    Bugsnag.notify(SignalException.new("TERM"))
-    expect(Bugsnag).to have_sent_notification{ |payload, headers|
-      event = get_event_from_payload(payload)
-      expect(event["unhandled"]).to be false
-      expect(event["severity"]).to eq("info")
-      expect(event["severityReason"]).to eq({
-        "type" => "errorClass",
-        "attributes" => {
-          "errorClass" => "SignalException"
-        }
-      })
-    }
+    original_ignore_classes = Bugsnag.configuration.ignore_classes
+
+    begin
+      # The default ignore_classes includes SignalException, so we need to
+      # temporarily set it to something else.
+      Bugsnag.configuration.ignore_classes = Set[SystemExit]
+      Bugsnag.notify(SignalException.new("TERM"))
+      expect(Bugsnag).to have_sent_notification{ |payload, headers|
+        event = get_event_from_payload(payload)
+        expect(event["unhandled"]).to be false
+        expect(event["severity"]).to eq("info")
+        expect(event["severityReason"]).to eq({
+          "type" => "errorClass",
+          "attributes" => {
+            "errorClass" => "SignalException"
+          }
+        })
+      }
+    ensure
+      Bugsnag.configuration.ignore_classes = original_ignore_classes
+    end
   end
 
   # TODO: nested context
@@ -1052,10 +1061,10 @@ describe Bugsnag::Report do
       expect(exception["message"]).to eq("'nil' was notified as an exception")
 
       stacktrace = exception["stacktrace"][0]
-      expect(stacktrace["lineNumber"]).to eq(1047)
+      expect(stacktrace["lineNumber"]).to eq(1056)
       expect(stacktrace["file"]).to end_with("spec/report_spec.rb")
-      expect(stacktrace["code"]["1046"]).to eq("  it 'uses an appropriate message if nil is notified' do")
-      expect(stacktrace["code"]["1047"]).to eq("    Bugsnag.notify(nil)")
+      expect(stacktrace["code"]["1055"]).to eq("  it 'uses an appropriate message if nil is notified' do")
+      expect(stacktrace["code"]["1056"]).to eq("    Bugsnag.notify(nil)")
     }
   end
 


### PR DESCRIPTION
## Goal

With #397 we receive SignalException error reports when puma shuts down, which aren't really errors.

## Changeset

### Added

### Removed

### Changed
* Changed `Interrupt` to `SignalException` in the default `Bugsnag::Configuration`'s `ignore_classes`

### Linked issues

Related to #397 and #477

## Review

For the submitter, initial self-review:

- [x] Commented on code changes inline explain the reasoning behind the approach
- [x] Reviewed the test cases added for completeness and possible points for discussion
- [ ] A changelog entry was added for the goal of this pull request
- [x] Check the scope of the changeset - is everything in the diff required for the pull request?
- This pull request is ready for:
  - [ ] Initial review of the intended approach, not yet feature complete
  - [ ] Structural review of the classes, functions, and properties modified
  - [x] Final review

For the pull request reviewer(s), this changeset has been reviewed for:

- [ ] Consistency across platforms for structures or concepts added or modified
- [ ] Consistency between the changeset and the goal stated above
- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [ ] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [ ] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [ ] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language
