### PR TITLE
Set the args data correctly in DelayedJob plugin when the payload object is a custom class

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Bugsnag exception reporter for Ruby
 [![build status](https://travis-ci.org/bugsnag/bugsnag-ruby.svg?branch=master)](https://travis-ci.org/bugsnag/bugsnag-ruby)
+![Gem Version](https://badge.fury.io/rb/bugsnag.svg)
+[![SemVer](https://api.dependabot.com/badges/compatibility_score?dependency-name=bugsnag&package-manager=bundler&version-scheme=semver)](https://dependabot.com/compatibility-score.html?dependency-name=bugsnag&package-manager=bundler&version-scheme=semver)
+
 
 
 The Bugsnag exception reporter for Ruby gives you instant notification of exceptions thrown from your **[Rails](https://www.bugsnag.com/platforms/rails)**, **Sinatra**, **Rack** or **plain Ruby** app. Any uncaught exceptions will trigger a notification to be sent to your Bugsnag project.
@@ -7,7 +10,7 @@ The Bugsnag exception reporter for Ruby gives you instant notification of except
 ## Features
 
 * Automatically report unhandled exceptions and crashes
-* Report handled exceptions 
+* Report handled exceptions
 * Attach user information to determine how many people are affected by a crash
 * Send customized diagnostic data
 

--- a/lib/bugsnag/integrations/delayed_job.rb
+++ b/lib/bugsnag/integrations/delayed_job.rb
@@ -46,6 +46,8 @@ unless defined? Delayed::Plugins::Bugsnag
                 p[:args] = payload.args
               elsif payload.respond_to?(:to_h)
                 p[:args] = payload.to_h
+              elsif payload.respond_to?(:instance_values)
+                p[:args] = payload.instance_values
               end
 
               if payload.is_a?(::Delayed::PerformableMethod) && (object = payload.object)

--- a/spec/integrations/delayed_job_spec.rb
+++ b/spec/integrations/delayed_job_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe ::Delayed::Plugins::Bugsnag do
       job = double
       custom_class = double
       allow(custom_class).to receive_messages(
-        :instance_values => { 'argument': 'value' }
+        :instance_values => { 'argument' => 'value' }
       )
       allow(job).to receive_messages(
         :id => "TEST",
@@ -40,7 +40,7 @@ RSpec.describe ::Delayed::Plugins::Bugsnag do
           "attempts" => "1 / 3",
           "payload" => {
             "class" => custom_class.class.name,
-            "args" => { :argument => 'value' }
+            "args" => { 'argument' => 'value' }
           }
         })
       }

--- a/spec/integrations/delayed_job_spec.rb
+++ b/spec/integrations/delayed_job_spec.rb
@@ -5,24 +5,19 @@ require 'spec_helper'
 RSpec.describe ::Delayed::Plugins::Bugsnag do
   describe '#error' do
     it 'should set the args data correctly when the payload_object is a custom class' do
-      class MyKlass
-        def initialize(my_argument)
-          @my_argument = my_argument
-        end
-
-        def perform
-        end
-      end
-
       payload = Object.new
       payload.extend(described_class::Notify)
       job = double
+      custom_class = double
+      allow(custom_class).to receive_messages(
+        :instance_values => { 'argument': 'value' }
+      )
       allow(job).to receive_messages(
         :id => "TEST",
         :queue => "TEST_QUEUE",
         :attempts => 0,
         :max_attempts => 3,
-        :payload_object => MyKlass.new(123)
+        :payload_object => custom_class
       )
 
       expect do
@@ -44,8 +39,8 @@ RSpec.describe ::Delayed::Plugins::Bugsnag do
           "queue" => "TEST_QUEUE",
           "attempts" => "1 / 3",
           "payload" => {
-            "class" => MyKlass.class.name,
-            "args" => { 'my_argument' => 123 }
+            "class" => custom_class.class.name,
+            "args" => { 'argument': 'value' }
           }
         })
       }

--- a/spec/integrations/delayed_job_spec.rb
+++ b/spec/integrations/delayed_job_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe ::Delayed::Plugins::Bugsnag do
           "attempts" => "1 / 3",
           "payload" => {
             "class" => custom_class.class.name,
-            "args" => { 'argument': 'value' }
+            "args" => { :argument => 'value' }
           }
         })
       }


### PR DESCRIPTION
## Goal

Example:

We have a custom class that responds to `perform`
```ruby
class NewsLetter
  def initialize(a)
    @a = a
  end

  def perform
  end
end
```
and when we invoke this using `DelayedJob` like
`Delayed::Job.enqueue(NewsLetter.new(2))`,

the `payload` object generated is like 
`#<NewsLetter:0x00007f8cfaa9a860 @a=2>`


Now, this does not respond to the methods `args` or `to_h`, which is what Bugsnag gem currently uses to identify the arguments passed to the job.

Since `args` are not being set in such cases, it becomes very difficult to triage and debug failed `DelayedJob` jobs, because there is no information about the job to begin with:

Eg:

<img width="665" alt="screen shot 2018-08-17 at 12 17 48 pm" src="https://user-images.githubusercontent.com/4034241/44251851-960a3900-a217-11e8-9e0a-28fee79a6da8.png">

As you can see, the only information available about the failed jobs are it's class name and the ID, which is not very helpful in debugging. For debugging to happen effectively, we need the arguments that were passed to this class.

This change is intended to push as much information as possible in the `args` section of the bugsnag payload in such cases, so that debugging becomes easier.

## Tests

Added test cases for where the `DelayedJob` class is a custom class

## Discussion

### Alternative Approaches

### Outstanding Questions

### Linked issues


## Review

<!-- When submitting for review, consider the points for self-review and the
     criteria which will be used for secondary review -->

For the submitter, initial self-review:

- [ ] Commented on code changes inline explain the reasoning behind the approach
- [x] Reviewed the test cases added for completeness and possible points for discussion
- [ ] A changelog entry was added for the goal of this pull request
- [ ] Check the scope of the changeset - is everything in the diff required for the pull request?
- This pull request is ready for:
  - [ ] Initial review of the intended approach, not yet feature complete
  - [ ] Structural review of the classes, functions, and properties modified
  - [x] Final review

For the pull request reviewer(s), this changeset has been reviewed for:

- [ ] Consistency across platforms for structures or concepts added or modified
- [ ] Consistency between the changeset and the goal stated above
- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [ ] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [ ] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [ ] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language
