### PR TITLE
Set consistent context in delayed_job integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+* Set default Delayed Job error context to job class
+  | [#499](https://github.com/bugsnag/bugsnag-ruby/pull/499)
+  | [Mike Stewart](https://github.com/mike-stewart)
+
 ## 6.9.0 (12 Nov 2018)
 
 ### Enhancements

--- a/lib/bugsnag/middleware/delayed_job.rb
+++ b/lib/bugsnag/middleware/delayed_job.rb
@@ -24,6 +24,7 @@ module Bugsnag::Middleware
           job_data[:active_job] = job.payload_object.job_data if job.payload_object.respond_to?(:job_data)
           payload_data = construct_job_payload(job.payload_object)
           report.context = payload_data[:display_name] if payload_data.include?(:display_name)
+          report.context ||= payload_data[:class] if payload_data.include?(:class)
           job_data[:payload] = payload_data
         end
 


### PR DESCRIPTION
## Goal

<!-- What is the intent of this change?
e.g. "When initializing the Bugsnag client, it is currently difficult to (...)
      this change simplifies the process by (...)"

     "Improves the performance of data filtering"

     "Adds additional test coverage to multi-threaded use of Configuration
      objects"
-->
Currently, a context is only set on DelayedJob errors if a display_name is set on the job, which is not always the case. The default context that it falls back to (top stack trace line) doesn't seem useful.

The default results in errors like `ActiveRecord::StatementInvalid app/models/foo.rb:100`. It does not indicate which job is failing, so one cannot understand the problem at glance in the dashboard.

Other integrations attempt to set a useful default context, see:
https://github.com/bugsnag/bugsnag-ruby/blob/56f387ef36c157a2b6fbf7d9e6807d21d1e62393/lib/bugsnag/integrations/resque.rb#L46
https://github.com/bugsnag/bugsnag-ruby/blob/56f387ef36c157a2b6fbf7d9e6807d21d1e62393/lib/bugsnag/middleware/rails3_request.rb#L19

I think it would make sense to use the job name as the default context. This is consistent with other error monitoring tools I've used.

<!-- For new features, include design documentation:

## Design

Why was this approach to the goal used?

-->

## Changeset

<!-- What structures or properties or functions were:

### Added

### Removed

### Changed

-->

## Tests

<!-- How was this change tested? What manual and automated tests were
     run/added? -->
Tests pass without changes. Let me know if you think additional coverage is needed.

## Discussion

### Alternative Approaches

<!-- What other approaches were considered or discussed? -->
I first tried defining a before_notify_callback to override the context, but that did not work.

### Outstanding Questions

<!-- Are there any parts of the design or the implementation which seem
     less than ideal and that could require additional discussion?
     List here: -->

### Linked issues

<!--

Fixes #
Related to #

-->

## Review

<!-- When submitting for review, consider the points for self-review and the
     criteria which will be used for secondary review -->

For the submitter, initial self-review:

- [x] Commented on code changes inline explain the reasoning behind the approach
- [x] Reviewed the test cases added for completeness and possible points for discussion
- [x] A changelog entry was added for the goal of this pull request
- [x] Check the scope of the changeset - is everything in the diff required for the pull request?
- This pull request is ready for:
  - [x] Initial review of the intended approach, not yet feature complete
  - [x] Structural review of the classes, functions, and properties modified
  - [x] Final review

For the pull request reviewer(s), this changeset has been reviewed for:

- [ ] Consistency across platforms for structures or concepts added or modified
- [ ] Consistency between the changeset and the goal stated above
- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [ ] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [ ] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [ ] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language

@snmaynard @Cawllec 