### PR TITLE
Breadcrumbs: Add Breadcrumb class

### DIFF
--- a/lib/bugsnag/breadcrumbs/breadcrumb.rb
+++ b/lib/bugsnag/breadcrumbs/breadcrumb.rb
@@ -9,7 +9,7 @@ module Bugsnag::Breadcrumbs
     # @return [Hash, nil] metadata hash containing strings, numbers, or booleans, or nil
     attr_accessor :meta_data
 
-    # @return [Symbol] set to `:auto` if the breadcrumb was automatically generated
+    # @return [Boolean] set to `true` if the breadcrumb was automatically generated
     attr_reader :auto
 
     # @return [Time] a Time object referring to breadcrumb creation time
@@ -36,7 +36,7 @@ module Bugsnag::Breadcrumbs
       @auto = auto == :auto
 
       # Store it as a timestamp for now
-      @timestamp = Time.now
+      @timestamp = Time.now.utc
     end
 
     ##
@@ -69,7 +69,7 @@ module Bugsnag::Breadcrumbs
         :name => @name,
         :type => @type,
         :metaData => @meta_data,
-        :timestamp => @timestamp.utc.iso8601
+        :timestamp => @timestamp.iso8601
       }
     end
   end

--- a/lib/bugsnag/breadcrumbs/breadcrumb.rb
+++ b/lib/bugsnag/breadcrumbs/breadcrumb.rb
@@ -11,7 +11,7 @@ module Bugsnag::Breadcrumbs
       self.message = message
       self.type = type
       self.meta_data = meta_data
-      @auto = auto === :auto
+      @auto = auto == :auto
       @timestamp = Time.now
     end
 

--- a/lib/bugsnag/breadcrumbs/breadcrumb.rb
+++ b/lib/bugsnag/breadcrumbs/breadcrumb.rb
@@ -1,5 +1,4 @@
 module Bugsnag::Breadcrumbs
-
   class Breadcrumb
     attr_accessor :message
     attr_accessor :type
@@ -13,7 +12,7 @@ module Bugsnag::Breadcrumbs
       self.type = type
       self.meta_data = meta_data
       @auto = auto
-      @timestamp = Time.now().utc().strftime('%Y-%m-%dT%H:%M:%S')
+      @timestamp = Time.now.utc.strftime('%Y-%m-%dT%H:%M:%S')
     end
 
     def ignore!

--- a/lib/bugsnag/breadcrumbs/breadcrumb.rb
+++ b/lib/bugsnag/breadcrumbs/breadcrumb.rb
@@ -1,19 +1,34 @@
 module Bugsnag::Breadcrumbs
   class Breadcrumb
-    attr_accessor :message
+    # @return [String] the breadcrumb name
+    attr_accessor :name
+
+    # @return [String] the breadcrumb type
     attr_accessor :type
+
+    # @return [Hash, nil] metadata hash containing strings, numbers, or booleans, or nil
     attr_accessor :meta_data
+
+    # @return [Symbol] set to `:auto` if the breadcrumb was automatically generated
     attr_reader :auto
+
+    # @return [Time] a Time object referring to breadcrumb creation time
     attr_reader :timestamp
 
     ##
-    # Creates a breadcrumb.
+    # Creates a breadcrumb
     #
-    # This will not have been validated, which must occur before this is
-    # attached to a report.
-    def initialize(message, type, meta_data, auto)
+    # This will not have been validated, which must occur before this is attached to a report
+    #
+    # @api private
+    #
+    # @param name [String] the breadcrumb name
+    # @param type [String] the breadcrumb type from Bugsnag::Breadcrumbs::VALID_BREADCRUMB_TYPES
+    # @param meta_data [Hash, nil] a hash containing strings, numbers, or booleans, or nil
+    # @param auto [Symbol] set to `:auto` if the breadcrumb is automatically generated
+    def initialize(name, type, meta_data, auto)
       @should_ignore = false
-      self.message = message
+      self.name = name
       self.type = type
       self.meta_data = meta_data
 
@@ -25,32 +40,36 @@ module Bugsnag::Breadcrumbs
     end
 
     ##
-    # Flags the breadcrumb to be ignored.
+    # Flags the breadcrumb to be ignored
     #
-    # Ignored breadcrumbs will not be attached to a report.
+    # Ignored breadcrumbs will not be attached to a report
     def ignore!
       @should_ignore = true
     end
 
     ##
-    # Checks if the `ignore!` method has been called.
+    # Checks if the `ignore!` method has been called
     #
-    # Ignored breadcrumbs will not be attached to a report.
+    # Ignored breadcrumbs will not be attached to a report
+    #
+    # @return [True] if `ignore!` has been called
+    # @return [nil] if `ignore` has not been called
     def ignore?
       @should_ignore
     end
 
     ##
-    # Outputs the breadcrumb data in a formatted hash.
+    # Outputs the breadcrumb data in a formatted hash
     #
-    # These adhere to the breadcrumb format as defined in the Bugsnag error 
-    # reporting API
+    # These adhere to the breadcrumb format as defined in the Bugsnag error reporting API
+    #
+    # @return [Hash] Hash representation of the breadcrumb
     def to_h
       {
-        :name => @message,
+        :name => @name,
         :type => @type,
         :metaData => @meta_data,
-        :timestamp => @timestamp.utc.strftime('%Y-%m-%dT%H:%M:%SZ')
+        :timestamp => @timestamp.utc.iso8601
       }
     end
   end

--- a/lib/bugsnag/breadcrumbs/breadcrumb.rb
+++ b/lib/bugsnag/breadcrumbs/breadcrumb.rb
@@ -6,23 +6,45 @@ module Bugsnag::Breadcrumbs
     attr_reader :auto
     attr_reader :timestamp
 
+    ##
+    # Creates a breadcrumb.
+    #
+    # This will not have been validated, which must occur before this is
+    # attached to a report.
     def initialize(message, type, meta_data, auto)
       @should_ignore = false
       self.message = message
       self.type = type
       self.meta_data = meta_data
+
+      # Use the symbol comparison to improve readability of breadcrumb creation
       @auto = auto == :auto
+
+      # Store it as a timestamp for now
       @timestamp = Time.now
     end
 
+    ##
+    # Flags the breadcrumb to be ignored.
+    #
+    # Ignored breadcrumbs will not be attached to a report.
     def ignore!
       @should_ignore = true
     end
 
+    ##
+    # Checks if the `ignore!` method has been called.
+    #
+    # Ignored breadcrumbs will not be attached to a report.
     def ignore?
       @should_ignore
     end
 
+    ##
+    # Outputs the breadcrumb data in a formatted hash.
+    #
+    # These adhere to the breadcrumb format as defined in the Bugsnag error 
+    # reporting API
     def to_h
       {
         :name => @message,

--- a/lib/bugsnag/breadcrumbs/breadcrumb.rb
+++ b/lib/bugsnag/breadcrumbs/breadcrumb.rb
@@ -11,8 +11,8 @@ module Bugsnag::Breadcrumbs
       self.message = message
       self.type = type
       self.meta_data = meta_data
-      @auto = auto
-      @timestamp = Time.now.utc.strftime('%Y-%m-%dT%H:%M:%S')
+      @auto = auto === :auto
+      @timestamp = Time.now
     end
 
     def ignore!
@@ -25,10 +25,10 @@ module Bugsnag::Breadcrumbs
 
     def to_h
       {
-        :message => message,
-        :type => type,
-        :metaData => meta_data,
-        :timestamp => timestamp
+        :name => @message,
+        :type => @type,
+        :metaData => @meta_data,
+        :timestamp => @timestamp.utc.strftime('%Y-%m-%dT%H:%M:%SZ')
       }
     end
   end

--- a/lib/bugsnag/breadcrumbs/breadcrumb.rb
+++ b/lib/bugsnag/breadcrumbs/breadcrumb.rb
@@ -1,0 +1,36 @@
+module Bugsnag::Breadcrumbs
+
+  class Breadcrumb
+    attr_accessor :message
+    attr_accessor :type
+    attr_accessor :meta_data
+    attr_reader :auto
+    attr_reader :timestamp
+
+    def initialize(message, type, meta_data, auto)
+      @should_ignore = false
+      self.message = message
+      self.type = type
+      self.meta_data = meta_data
+      @auto = auto
+      @timestamp = Time.now().utc().strftime('%Y-%m-%dT%H:%M:%S')
+    end
+
+    def ignore!
+      @should_ignore = true
+    end
+
+    def ignore?
+      @should_ignore
+    end
+
+    def to_h
+      {
+        :message => message,
+        :type => type,
+        :metaData => meta_data,
+        :timestamp => timestamp
+      }
+    end
+  end
+end

--- a/spec/breadcrumbs/breadcrumb_spec.rb
+++ b/spec/breadcrumbs/breadcrumb_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe Bugsnag::Breadcrumbs::Breadcrumb do
     it "is stored as a timestamp" do
       breadcrumb = Bugsnag::Breadcrumbs::Breadcrumb.new(nil, nil, nil, nil)
 
-      expect(breadcrumb.timestamp).to be_within(0.5).of Time.now
+      expect(breadcrumb.timestamp).to be_within(0.5).of Time.now.utc
     end
   end
 
@@ -77,14 +77,17 @@ RSpec.describe Bugsnag::Breadcrumbs::Breadcrumb do
       breadcrumb = Bugsnag::Breadcrumbs::Breadcrumb.new("my message", "test type", {:a => 1, :b => 2}, :manual)
       output = breadcrumb.to_h
 
-      expect(output[:name]).to eq("my message")
-      expect(output[:type]).to eq("test type")
-      expect(output[:metaData]).to eq({ :a => 1, :b => 2})
-
       timestamp_regex = /^\d{4}\-\d{2}\-\d{2}T\d{2}:\d{2}:[\d\.]+Z$/
 
-      expect(output[:timestamp]).to be_a_kind_of(String)
-      expect(output[:timestamp]).to match(timestamp_regex)
+      expect(output).to match(
+        :name => "my message",
+        :type => "test type",
+        :metaData => {
+          :a => 1,
+          :b => 2
+        },
+        :timestamp => match(timestamp_regex)
+      )
     end
   end
 end

--- a/spec/breadcrumbs/breadcrumb_spec.rb
+++ b/spec/breadcrumbs/breadcrumb_spec.rb
@@ -5,27 +5,66 @@ require 'spec_helper'
 require 'bugsnag/breadcrumbs/breadcrumb'
 
 describe Bugsnag::Breadcrumbs::Breadcrumb do
-  describe "initialize" do
-    it "should assign arguments correctly" do
-      breadcrumb = Bugsnag::Breadcrumbs::Breadcrumb.new("my message", "test type", {:a => 1, :b => 2}, :manual)
+  describe "#message" do
+    it "is assigned in #initialize" do
+      breadcrumb = Bugsnag::Breadcrumbs::Breadcrumb.new("my message", nil, nil, nil)
 
       expect(breadcrumb.message).to eq("my message")
-      expect(breadcrumb.type).to eq("test type")
-      expect(breadcrumb.meta_data).to eq({:a => 1, :b => 2})
-      expect(breadcrumb.auto).to eq(:manual)
-
-      expect(breadcrumb.timestamp).to_not be_nil
     end
   end
 
-  describe "ignore" do
-    it "should not be ignored by default" do
+  describe "#type" do
+    it "is assigned in #initialize" do
+      breadcrumb = Bugsnag::Breadcrumbs::Breadcrumb.new(nil, "test type", nil, nil)
+
+      expect(breadcrumb.type).to eq("test type")
+    end
+  end
+
+  describe "#meta_data" do
+    it "is assigned in #initialize" do
+      breadcrumb = Bugsnag::Breadcrumbs::Breadcrumb.new(nil, nil, {:a => 1, :b => 2}, nil)
+
+      expect(breadcrumb.meta_data).to eq({:a => 1, :b => 2})
+    end
+  end
+
+  describe "#auto" do
+    it "defaults to false" do
+      breadcrumb = Bugsnag::Breadcrumbs::Breadcrumb.new(nil, nil, nil, nil)
+
+      expect(breadcrumb.auto).to eq(false)
+    end
+
+    it "is true if auto argument == :auto" do
+      breadcrumb = Bugsnag::Breadcrumbs::Breadcrumb.new(nil, nil, nil, :auto)
+
+      expect(breadcrumb.auto).to eq(true)
+    end
+
+    it "if false if auto argument is anything else" do
+      breadcrumb = Bugsnag::Breadcrumbs::Breadcrumb.new(nil, nil, nil, :manual)
+
+      expect(breadcrumb.auto).to eq(false)
+    end
+  end
+
+  describe "#timestamp" do
+    it "is stored as a timestamp" do
+      breadcrumb = Bugsnag::Breadcrumbs::Breadcrumb.new(nil, nil, nil, nil)
+
+      expect(breadcrumb.timestamp).to be_within(0.5.second).of Time.now
+    end
+  end
+
+  describe "#ignore" do
+    it "is not ignored by default" do
       breadcrumb = Bugsnag::Breadcrumbs::Breadcrumb.new("my message", "test type", {:a => 1, :b => 2}, :manual)
 
       expect(breadcrumb.ignore?).to eq(false)
     end
 
-    it "should be able to be ignored" do
+    it "is able to be ignored" do
       breadcrumb = Bugsnag::Breadcrumbs::Breadcrumb.new("my message", "test type", {:a => 1, :b => 2}, :manual)
       breadcrumb.ignore!
 
@@ -33,15 +72,19 @@ describe Bugsnag::Breadcrumbs::Breadcrumb do
     end
   end
 
-  describe "to_h" do
-    it "should output a hash" do
+  describe "#to_h" do
+    it "outputs as a hash" do
       breadcrumb = Bugsnag::Breadcrumbs::Breadcrumb.new("my message", "test type", {:a => 1, :b => 2}, :manual)
       output = breadcrumb.to_h
 
-      expect(output[:message]).to eq("my message")
+      expect(output[:name]).to eq("my message")
       expect(output[:type]).to eq("test type")
       expect(output[:metaData]).to eq({ :a => 1, :b => 2})
-      expect(output[:timestamp]).to_not be_nil
+
+      timestamp_regex = /^\d{4}\-\d{2}\-\d{2}T\d{2}:\d{2}:[\d\.]+Z$/
+
+      expect(output[:timestamp]).to be_a_kind_of(String)
+      expect(output[:timestamp]).to match(timestamp_regex)
     end
   end
 end

--- a/spec/breadcrumbs/breadcrumb_spec.rb
+++ b/spec/breadcrumbs/breadcrumb_spec.rb
@@ -5,11 +5,11 @@ require 'spec_helper'
 require 'bugsnag/breadcrumbs/breadcrumb'
 
 RSpec.describe Bugsnag::Breadcrumbs::Breadcrumb do
-  describe "#message" do
+  describe "#name" do
     it "is assigned in #initialize" do
       breadcrumb = Bugsnag::Breadcrumbs::Breadcrumb.new("my message", nil, nil, nil)
 
-      expect(breadcrumb.message).to eq("my message")
+      expect(breadcrumb.name).to eq("my message")
     end
   end
 
@@ -42,7 +42,7 @@ RSpec.describe Bugsnag::Breadcrumbs::Breadcrumb do
       expect(breadcrumb.auto).to eq(true)
     end
 
-    it "if false if auto argument is anything else" do
+    it "is false if auto argument is anything else" do
       breadcrumb = Bugsnag::Breadcrumbs::Breadcrumb.new(nil, nil, nil, :manual)
 
       expect(breadcrumb.auto).to eq(false)
@@ -53,18 +53,18 @@ RSpec.describe Bugsnag::Breadcrumbs::Breadcrumb do
     it "is stored as a timestamp" do
       breadcrumb = Bugsnag::Breadcrumbs::Breadcrumb.new(nil, nil, nil, nil)
 
-      expect(breadcrumb.timestamp).to be_within(0.5.second).of Time.now
+      expect(breadcrumb.timestamp).to be_within(0.5).of Time.now
     end
   end
 
-  describe "#ignore" do
-    it "is not ignored by default" do
+  describe "#ignore?" do
+    it "is not true by default" do
       breadcrumb = Bugsnag::Breadcrumbs::Breadcrumb.new("my message", "test type", {:a => 1, :b => 2}, :manual)
 
       expect(breadcrumb.ignore?).to eq(false)
     end
 
-    it "is able to be ignored" do
+    it "is able to be set" do
       breadcrumb = Bugsnag::Breadcrumbs::Breadcrumb.new("my message", "test type", {:a => 1, :b => 2}, :manual)
       breadcrumb.ignore!
 

--- a/spec/breadcrumbs/breadcrumb_spec.rb
+++ b/spec/breadcrumbs/breadcrumb_spec.rb
@@ -1,0 +1,47 @@
+# encoding: utf-8
+
+require 'spec_helper'
+
+require 'bugsnag/breadcrumbs/breadcrumb'
+
+describe Bugsnag::Breadcrumbs::Breadcrumb do
+  describe "initialize" do
+    it "should assign arguments correctly" do
+      breadcrumb = Bugsnag::Breadcrumbs::Breadcrumb.new("my message", "test type", {:a => 1, :b => 2}, :manual)
+
+      expect(breadcrumb.message).to eq("my message")
+      expect(breadcrumb.type).to eq("test type")
+      expect(breadcrumb.meta_data).to eq({:a => 1, :b => 2})
+      expect(breadcrumb.auto).to eq(:manual)
+
+      expect(breadcrumb.timestamp).to_not be_nil
+    end
+  end
+
+  describe "ignore" do
+    it "should not be ignored by default" do
+      breadcrumb = Bugsnag::Breadcrumbs::Breadcrumb.new("my message", "test type", {:a => 1, :b => 2}, :manual)
+
+      expect(breadcrumb.ignore?).to eq(false)
+    end
+
+    it "should be able to be ignored" do
+      breadcrumb = Bugsnag::Breadcrumbs::Breadcrumb.new("my message", "test type", {:a => 1, :b => 2}, :manual)
+      breadcrumb.ignore!
+
+      expect(breadcrumb.ignore?).to eq(true)
+    end
+  end
+
+  describe "to_h" do
+    it "should output a hash" do
+      breadcrumb = Bugsnag::Breadcrumbs::Breadcrumb.new("my message", "test type", {:a => 1, :b => 2}, :manual)
+      output = breadcrumb.to_h
+
+      expect(output[:message]).to eq("my message")
+      expect(output[:type]).to eq("test type")
+      expect(output[:metaData]).to eq({ :a => 1, :b => 2})
+      expect(output[:timestamp]).to_not be_nil
+    end
+  end
+end

--- a/spec/breadcrumbs/breadcrumb_spec.rb
+++ b/spec/breadcrumbs/breadcrumb_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 require 'bugsnag/breadcrumbs/breadcrumb'
 
-describe Bugsnag::Breadcrumbs::Breadcrumb do
+RSpec.describe Bugsnag::Breadcrumbs::Breadcrumb do
   describe "#message" do
     it "is assigned in #initialize" do
       breadcrumb = Bugsnag::Breadcrumbs::Breadcrumb.new("my message", nil, nil, nil)

--- a/spec/breadcrumbs/breadcrumb_spec.rb
+++ b/spec/breadcrumbs/breadcrumb_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe Bugsnag::Breadcrumbs::Breadcrumb do
           :a => 1,
           :b => 2
         },
-        :timestamp => match(timestamp_regex)
+        :timestamp => eq(breadcrumb.timestamp.iso8601)
       )
     end
   end


### PR DESCRIPTION
Adds Bugsnag::Breadcrumbs::Breadcrumb class and tests in order to support Ruby Breadcrumbs feature.