### PR TITLE
Set the rails logger after initialisation

### DIFF
--- a/lib/bugsnag/integrations/railtie.rb
+++ b/lib/bugsnag/integrations/railtie.rb
@@ -22,7 +22,6 @@ module Bugsnag
       # Skipping API key validation as the key may be set later in an
       # initializer. If not, the key will be validated in after_initialize.
       Bugsnag.configure(false) do |config|
-        config.logger = ::Rails.logger
         config.release_stage = ENV["BUGSNAG_RELEASE_STAGE"] || ::Rails.env.to_s
         config.project_root = ::Rails.root.to_s
         config.middleware.insert_before Bugsnag::Middleware::Callbacks, Bugsnag::Middleware::Rails3Request
@@ -41,9 +40,10 @@ module Bugsnag
       Bugsnag.configuration.app_type = "rails"
     end
 
-    # Configure meta_data_filters after initialization, so that rails initializers
-    # may set filter_parameters which will be picked up by Bugsnag.
     config.after_initialize do
+      config.logger = ::Rails.logger
+      # Configure meta_data_filters after initialization, so that rails initializers
+      # may set filter_parameters which will be picked up by Bugsnag.
       Bugsnag.configure do |config|
         config.meta_data_filters += ::Rails.configuration.filter_parameters.map do |filter|
           case filter


### PR DESCRIPTION
## Goal

Currently, bugsnag logging does not work in rails unless you explicitly set the logger in your bugsnag initializer, and so all logging messages are being lost. I'd like to fix that so that it works out of the box.

### Changed

I've moved the code to set up the bugsnag logger to run after the railtie has been initialized. This fixes the issue for me (I believe because the rails logger has not been set up yet in the `before_initialize` hook, but is available in `after_initialize`).

## Tests

I think there are no existing tests for the railtie?

## Review

For the submitter, initial self-review:

- [x] Commented on code changes inline explain the reasoning behind the approach
- [x] Reviewed the test cases added for completeness and possible points for discussion
- [x] A changelog entry was added for the goal of this pull request
- [x] Check the scope of the changeset - is everything in the diff required for the pull request?
- This pull request is ready for:
  - [ ] Initial review of the intended approach, not yet feature complete
  - [x] Structural review of the classes, functions, and properties modified
  - [ ] Final review

For the pull request reviewer(s), this changeset has been reviewed for:

- [ ] Consistency across platforms for structures or concepts added or modified
- [ ] Consistency between the changeset and the goal stated above
- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [ ] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [ ] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [ ] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language
