### PR TITLE
Breadcrumbs/leave breadcrumb

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -302,7 +302,7 @@ Metrics/MethodLength:
 # Offense count: 1
 # Configuration parameters: CountComments.
 Metrics/ModuleLength:
-  Max: 125
+  Max: 140
   Exclude:
     - 'lib/bugsnag/helpers.rb'
 

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -302,9 +302,10 @@ Metrics/MethodLength:
 # Offense count: 1
 # Configuration parameters: CountComments.
 Metrics/ModuleLength:
-  Max: 140
+  Max: 125
   Exclude:
     - 'lib/bugsnag/helpers.rb'
+    - 'lib/bugsnag.rb'
 
 # Offense count: 11
 Metrics/PerceivedComplexity:

--- a/lib/bugsnag.rb
+++ b/lib/bugsnag.rb
@@ -29,6 +29,10 @@ require "bugsnag/middleware/callbacks"
 require "bugsnag/middleware/classify_error"
 require "bugsnag/middleware/delayed_job"
 
+require "bugsnag/breadcrumbs/validator"
+require "bugsnag/breadcrumbs/breadcrumb"
+require "bugsnag/breadcrumbs/breadcrumbs"
+
 module Bugsnag
   LOCK = Mutex.new
   INTEGRATIONS = [:resque, :sidekiq, :mailman, :delayed_job, :shoryuken, :que]
@@ -186,6 +190,36 @@ module Bugsnag
         require "bugsnag/integrations/#{integration}"
       else
         configuration.debug("Integration #{integration} is not currently supported")
+      end
+    end
+
+    ##
+    # Leave a breadcrumb to be attached to subsequent reports
+    #
+    # @param name [String] the main breadcrumb name/message
+    # @param meta_data [Hash] String, Numeric, or Boolean meta data to attach
+    # @param type [String] the breadcrumb type, from Bugsnag::Breadcrumbs::VALID_BREADCRUMB_TYPES
+    # @param auto [Symbol] set to :auto if the breadcrumb is automatically created
+    def leave_breadcrumb(name, meta_data={}, type=Bugsnag::Breadcrumbs::MANUAL_BREADCRUMB_TYPE, auto=:manual)
+      breadcrumb = Bugsnag::Breadcrumbs::Breadcrumb.new(name, type, meta_data, auto)
+      validator = Bugsnag::Breadcrumbs::Validator.new(configuration)
+
+      # Initial validation
+      validator.validate(breadcrumb)
+
+      # Skip if it's already invalid
+      unless breadcrumb.ignore?
+        # Run callbacks
+        configuration.before_breadcrumb_callbacks.each do |c|
+          (c.arity > 0 ? c.call(breadcrumb) : c.call)
+          break if breadcrumb.ignore?
+        end
+
+        # Validate again incase of callback alteration
+        validator.validate(breadcrumb)
+
+        # Add to breadcrumbs buffer if still valid
+        configuration.breadcrumbs << breadcrumb unless breadcrumb.ignore?
       end
     end
 

--- a/lib/bugsnag.rb
+++ b/lib/bugsnag.rb
@@ -211,11 +211,14 @@ module Bugsnag
       unless breadcrumb.ignore?
         # Run callbacks
         configuration.before_breadcrumb_callbacks.each do |c|
-          (c.arity > 0 ? c.call(breadcrumb) : c.call)
+          c.arity > 0 ? c.call(breadcrumb) : c.call
           break if breadcrumb.ignore?
         end
 
-        # Validate again incase of callback alteration
+        # Return early if ignored
+        return if breadcrumb.ignore?
+
+        # Validate again in case of callback alteration
         validator.validate(breadcrumb)
 
         # Add to breadcrumbs buffer if still valid

--- a/spec/bugsnag_spec.rb
+++ b/spec/bugsnag_spec.rb
@@ -197,11 +197,11 @@ describe Bugsnag do
     end
 
     it "runs callbacks before leaving" do
-      Bugsnag.configuration.before_breadcrumb_callbacks << Proc.new { |breadcrumb|
+      Bugsnag.configuration.before_breadcrumb_callbacks << Proc.new do |breadcrumb|
         breadcrumb.meta_data = {
           :callback => true
         }
-      }
+      end
       Bugsnag.leave_breadcrumb("TestName")
       expect(breadcrumbs.to_a.size).to eq(1)
       expect(breadcrumbs.first.to_h).to match({
@@ -215,7 +215,7 @@ describe Bugsnag do
     end
 
     it "validates after callbacks" do
-      Bugsnag.configuration.before_breadcrumb_callbacks << Proc.new { |breadcrumb|
+      Bugsnag.configuration.before_breadcrumb_callbacks << Proc.new do |breadcrumb|
         breadcrumb.meta_data = {
           :int => 1,
           :array => [1, 2, 3],
@@ -226,7 +226,7 @@ describe Bugsnag do
         }
         breadcrumb.type = "Not a real type"
         breadcrumb.name = "123123123123123123123123123123456456456456456"
-      }
+      end
       Bugsnag.leave_breadcrumb("TestName")
       expect(breadcrumbs.to_a.size).to eq(1)
       expect(breadcrumbs.first.to_h).to match({

--- a/spec/bugsnag_spec.rb
+++ b/spec/bugsnag_spec.rb
@@ -134,7 +134,7 @@ describe Bugsnag do
     end
   end
 
-  describe "#leave_breadcrumb" do
+  describe ".leave_breadcrumb" do
 
     let(:breadcrumbs) { Bugsnag.configuration.breadcrumbs }
     let(:timestamp_regex) { /^\d{4}\-\d{2}\-\d{2}T\d{2}:\d{2}:[\d\.]+Z$/ }
@@ -246,9 +246,9 @@ describe Bugsnag do
     end
 
     it "doesn't add if ignored in a callback" do
-      Bugsnag.configuration.before_breadcrumb_callbacks << Proc.new { |breadcrumb|
+      Bugsnag.configuration.before_breadcrumb_callbacks << Proc.new do |breadcrumb|
         breadcrumb.ignore!
-      }
+      end
       Bugsnag.leave_breadcrumb("TestName")
       expect(breadcrumbs.to_a.size).to eq(0)
     end
@@ -257,28 +257,28 @@ describe Bugsnag do
       Bugsnag.configuration.automatic_breadcrumb_types = [
         Bugsnag::Breadcrumbs::MANUAL_BREADCRUMB_TYPE
       ]
-      Bugsnag.configuration.before_breadcrumb_callbacks << Proc.new { |breadcrumb|
+      Bugsnag.configuration.before_breadcrumb_callbacks << Proc.new do |breadcrumb|
         breadcrumb.type = Bugsnag::Breadcrumbs::ERROR_BREADCRUMB_TYPE
-      }
+      end
       Bugsnag.leave_breadcrumb("TestName", {}, Bugsnag::Breadcrumbs::MANUAL_BREADCRUMB_TYPE, :auto)
       expect(breadcrumbs.to_a.size).to eq(0)
     end
 
     it "doesn't call callbacks if ignored early" do
       Bugsnag.configuration.automatic_breadcrumb_types = []
-      Bugsnag.configuration.before_breadcrumb_callbacks << Proc.new { |breadcrumb|
+      Bugsnag.configuration.before_breadcrumb_callbacks << Proc.new do |breadcrumb|
         fail "This shouldn't be called"
-      }
+      end
       Bugsnag.leave_breadcrumb("TestName", {}, Bugsnag::Breadcrumbs::ERROR_BREADCRUMB_TYPE, :auto)
     end
 
     it "doesn't continue to call callbacks if ignored in them" do
-      Bugsnag.configuration.before_breadcrumb_callbacks << Proc.new { |breadcrumb|
+      Bugsnag.configuration.before_breadcrumb_callbacks << Proc.new do |breadcrumb|
         breadcrumb.ignore!
-      }
-      Bugsnag.configuration.before_breadcrumb_callbacks << Proc.new { |breadcrumb|
+      end
+      Bugsnag.configuration.before_breadcrumb_callbacks << Proc.new do |breadcrumb|
         fail "This shouldn't be called"
-      }
+      end
       Bugsnag.leave_breadcrumb("TestName")
     end
   end

--- a/spec/bugsnag_spec.rb
+++ b/spec/bugsnag_spec.rb
@@ -133,4 +133,153 @@ describe Bugsnag do
       Kernel.send(:remove_const, :REQUIRED)
     end
   end
+
+  describe "#leave_breadcrumb" do
+
+    let(:breadcrumbs) { Bugsnag.configuration.breadcrumbs }
+    let(:timestamp_regex) { /^\d{4}\-\d{2}\-\d{2}T\d{2}:\d{2}:[\d\.]+Z$/ }
+
+    it "requires only a name argument" do
+      Bugsnag.leave_breadcrumb("TestName")
+      expect(breadcrumbs.to_a.size).to eq(1)
+      expect(breadcrumbs.first.to_h).to match({
+        :name => "TestName",
+        :type => Bugsnag::Breadcrumbs::MANUAL_BREADCRUMB_TYPE,
+        :metaData => {},
+        :timestamp => match(timestamp_regex)
+      })
+    end
+
+    it "accepts meta_data" do
+      Bugsnag.leave_breadcrumb("TestName", { :a => 1, :b => "2" })
+      expect(breadcrumbs.to_a.size).to eq(1)
+      expect(breadcrumbs.first.to_h).to match({
+        :name => "TestName",
+        :type => Bugsnag::Breadcrumbs::MANUAL_BREADCRUMB_TYPE,
+        :metaData => { :a => 1, :b => "2" },
+        :timestamp => match(timestamp_regex)
+      })
+    end
+
+    it "allows different message types" do
+      Bugsnag.leave_breadcrumb("TestName", {}, Bugsnag::Breadcrumbs::ERROR_BREADCRUMB_TYPE)
+      expect(breadcrumbs.to_a.size).to eq(1)
+      expect(breadcrumbs.first.to_h).to match({
+        :name => "TestName",
+        :type => Bugsnag::Breadcrumbs::ERROR_BREADCRUMB_TYPE,
+        :metaData => {},
+        :timestamp => match(timestamp_regex)
+      })
+    end
+
+    it "validates before leaving" do
+      Bugsnag.leave_breadcrumb(
+        "123123123123123123123123123123456456456456456456456456456456",
+        {
+          :a => 1,
+          :b => [1, 2, 3, 4],
+          :c => {
+            :test => true,
+            :test2 => false
+          }
+        },
+        "Not a real type"
+      )
+      expect(breadcrumbs.to_a.size).to eq(1)
+      expect(breadcrumbs.first.to_h).to match({
+        :name => "123123123123123123123123123123",
+        :type => Bugsnag::Breadcrumbs::MANUAL_BREADCRUMB_TYPE,
+        :metaData => {
+          :a => 1
+        },
+        :timestamp => match(timestamp_regex)
+      })
+    end
+
+    it "runs callbacks before leaving" do
+      Bugsnag.configuration.before_breadcrumb_callbacks << Proc.new { |breadcrumb|
+        breadcrumb.meta_data = {
+          :callback => true
+        }
+      }
+      Bugsnag.leave_breadcrumb("TestName")
+      expect(breadcrumbs.to_a.size).to eq(1)
+      expect(breadcrumbs.first.to_h).to match({
+        :name => "TestName",
+        :type => Bugsnag::Breadcrumbs::MANUAL_BREADCRUMB_TYPE,
+        :metaData => {
+          :callback => true
+        },
+        :timestamp => match(timestamp_regex)
+      })
+    end
+
+    it "validates after callbacks" do
+      Bugsnag.configuration.before_breadcrumb_callbacks << Proc.new { |breadcrumb|
+        breadcrumb.meta_data = {
+          :int => 1,
+          :array => [1, 2, 3],
+          :hash => {
+            :a => 1,
+            :b => 2
+          }
+        }
+        breadcrumb.type = "Not a real type"
+        breadcrumb.name = "123123123123123123123123123123456456456456456"
+      }
+      Bugsnag.leave_breadcrumb("TestName")
+      expect(breadcrumbs.to_a.size).to eq(1)
+      expect(breadcrumbs.first.to_h).to match({
+        :name => "123123123123123123123123123123",
+        :type => Bugsnag::Breadcrumbs::MANUAL_BREADCRUMB_TYPE,
+        :metaData => {
+          :int => 1
+        },
+        :timestamp => match(timestamp_regex)
+      })
+    end
+
+    it "doesn't add when ignored by the validator" do
+      Bugsnag.configuration.automatic_breadcrumb_types = []
+      Bugsnag.leave_breadcrumb("TestName", {}, Bugsnag::Breadcrumbs::ERROR_BREADCRUMB_TYPE, :auto)
+      expect(breadcrumbs.to_a.size).to eq(0)
+    end
+
+    it "doesn't add if ignored in a callback" do
+      Bugsnag.configuration.before_breadcrumb_callbacks << Proc.new { |breadcrumb|
+        breadcrumb.ignore!
+      }
+      Bugsnag.leave_breadcrumb("TestName")
+      expect(breadcrumbs.to_a.size).to eq(0)
+    end
+
+    it "doesn't add when ignored after the callbacks" do
+      Bugsnag.configuration.automatic_breadcrumb_types = [
+        Bugsnag::Breadcrumbs::MANUAL_BREADCRUMB_TYPE
+      ]
+      Bugsnag.configuration.before_breadcrumb_callbacks << Proc.new { |breadcrumb|
+        breadcrumb.type = Bugsnag::Breadcrumbs::ERROR_BREADCRUMB_TYPE
+      }
+      Bugsnag.leave_breadcrumb("TestName", {}, Bugsnag::Breadcrumbs::MANUAL_BREADCRUMB_TYPE, :auto)
+      expect(breadcrumbs.to_a.size).to eq(0)
+    end
+
+    it "doesn't call callbacks if ignored early" do
+      Bugsnag.configuration.automatic_breadcrumb_types = []
+      Bugsnag.configuration.before_breadcrumb_callbacks << Proc.new { |breadcrumb|
+        fail "This shouldn't be called"
+      }
+      Bugsnag.leave_breadcrumb("TestName", {}, Bugsnag::Breadcrumbs::ERROR_BREADCRUMB_TYPE, :auto)
+    end
+
+    it "doesn't continue to call callbacks if ignored in them" do
+      Bugsnag.configuration.before_breadcrumb_callbacks << Proc.new { |breadcrumb|
+        breadcrumb.ignore!
+      }
+      Bugsnag.configuration.before_breadcrumb_callbacks << Proc.new { |breadcrumb|
+        fail "This shouldn't be called"
+      }
+      Bugsnag.leave_breadcrumb("TestName")
+    end
+  end
 end


### PR DESCRIPTION
## Goal

Adds the `leave_breadcrumb` method and associated tests for the Breadcrumbs implementation.