### PR TITLE
WIP: Breadcrumbs: Rails Breadcrumbs

### DIFF
--- a/features/fixtures/rails3/app/app/controllers/breadcrumbs_controller.rb
+++ b/features/fixtures/rails3/app/app/controllers/breadcrumbs_controller.rb
@@ -1,0 +1,18 @@
+class BreadcrumbsController < ActionController::Base
+  protect_from_forgery
+
+  def index
+    render json: {}
+  end
+
+  def handled
+    Bugsnag.notify("Request breadcrumb")
+    render json: {}
+  end
+
+  def sql_breadcrumb
+    User.take
+    Bugsnag.notify("SQL breadcrumb")
+    render json: {}
+  end
+end

--- a/features/fixtures/rails3/app/config/routes.rb
+++ b/features/fixtures/rails3/app/config/routes.rb
@@ -14,5 +14,6 @@ App::Application.routes.draw do
   get "/send_code/(:action)", controller: 'send_code'
   get "/send_environment/(:action)", controller: 'send_environment'
   get "/warden/(:action)", controller: 'warden'
+  get "/breadcrumbs/(:action)", controller: 'breadcrumbs'
   get "/(:action)", controller: 'application'
 end

--- a/features/fixtures/rails4/app/app/controllers/breadcrumbs_controller.rb
+++ b/features/fixtures/rails4/app/app/controllers/breadcrumbs_controller.rb
@@ -1,0 +1,18 @@
+class BreadcrumbsController < ActionController::Base
+  protect_from_forgery with: :exception
+
+  def index
+    render json: {}
+  end
+
+  def handled
+    Bugsnag.notify("Request breadcrumb")
+    render json: {}
+  end
+
+  def sql_breadcrumb
+    User.take
+    Bugsnag.notify("SQL breadcrumb")
+    render json: {}
+  end
+end

--- a/features/fixtures/rails4/app/config/routes.rb
+++ b/features/fixtures/rails4/app/config/routes.rb
@@ -16,4 +16,5 @@ App::Application.routes.draw do
   get "/send_code/(:action)", controller: 'send_code'
   get "/send_environment/(:action)", controller: 'send_environment'
   get "/devise/(:action)", controller: 'devise'
+  get "/breadcrumbs/(:action)", controller: 'breadcrumbs'
 end

--- a/features/fixtures/rails5/app/app/controllers/breadcrumbs_controller.rb
+++ b/features/fixtures/rails5/app/app/controllers/breadcrumbs_controller.rb
@@ -1,0 +1,14 @@
+class BreadcrumbsController < ActionController::Base
+  protect_from_forgery with: :exception
+
+  def handled
+    Bugsnag.notify("Request breadcrumb")
+    render json: {}
+  end
+
+  def sql_breadcrumb
+    User.take
+    Bugsnag.notify("SQL breadcrumb")
+    render json: {}
+  end
+end

--- a/features/fixtures/rails5/app/config/routes.rb
+++ b/features/fixtures/rails5/app/config/routes.rb
@@ -49,4 +49,7 @@ Rails.application.routes.draw do
   get 'clearance/create', to: 'clearance#create'
   get 'clearance/unhandled', to: 'clearance#unhandled'
   get 'clearance/handled', to: 'clearance#handled'
+
+  get 'breadcrumbs/handled', to: 'breadcrumbs#handled'
+  get 'breadcrumbs/sql_breadcrumb', to: 'breadcrumbs#sql_breadcrumb'
 end

--- a/features/rails_features/breadcrumbs.feature
+++ b/features/rails_features/breadcrumbs.feature
@@ -1,0 +1,58 @@
+Feature: Rails automatic breadcrumbs
+
+Background:
+  Given I set environment variable "BUGSNAG_API_KEY" to "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And I set environment variable "APP_PATH" to "/usr/src"
+  And I configure the bugsnag endpoint
+
+Scenario Outline: Request breadcrumb
+  Given I set environment variable "RUBY_VERSION" to "<ruby_version>"
+  And I start the service "rails<rails_version>"
+  And I wait for the app to respond on port "6128<rails_version>"
+  When I navigate to the route "/breadcrumbs/handled" on port "6128<rails_version>"
+  Then I should receive a request
+  And the request is a valid for the error reporting API
+  And the request used the "Ruby Bugsnag Notifier" notifier
+  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And the event has a "request" breadcrumb named "Controller started processing"
+
+  Examples:
+    | ruby_version | rails_version |
+    | 2.0          | 3             |
+    | 2.1          | 3             |
+    | 2.2          | 3             |
+    | 2.2          | 4             |
+    | 2.2          | 5             |
+    | 2.3          | 3             |
+    | 2.3          | 4             |
+    | 2.3          | 5             |
+    | 2.4          | 3             |
+    | 2.4          | 5             |
+    | 2.5          | 3             |
+    | 2.5          | 5             |
+
+Scenario Outline: SQL Breadcrumb
+  Given I set environment variable "RUBY_VERSION" to "<ruby_version>"
+  And I start the service "rails<rails_version>"
+  And I wait for the app to respond on port "6128<rails_version>"
+  When I navigate to the route "/breadcrumbs/sql_breadcrumb" on port "6128<rails_version>"
+  Then I should receive a request
+  And the request is a valid for the error reporting API
+  And the request used the "Ruby Bugsnag Notifier" notifier
+  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And the event has a "process" breadcrumb named "ActiveRecord SQL query"
+
+  Examples:
+    | ruby_version | rails_version |
+    | 2.0          | 3             |
+    | 2.1          | 3             |
+    | 2.2          | 3             |
+    | 2.2          | 4             |
+    | 2.2          | 5             |
+    | 2.3          | 3             |
+    | 2.3          | 4             |
+    | 2.3          | 5             |
+    | 2.4          | 3             |
+    | 2.4          | 5             |
+    | 2.5          | 3             |
+    | 2.5          | 5             |

--- a/lib/bugsnag/integrations/rails/rails_breadcrumbs.rb
+++ b/lib/bugsnag/integrations/rails/rails_breadcrumbs.rb
@@ -1,0 +1,139 @@
+require "bugnsag/breadcrumbs/breadcrumbs"
+
+module Bugsnag::Railtie
+  DEFAULT_RAILS_BREADCRUMBS = [
+    {
+      :id => "perform_action.action_cable",
+      :message => "Perform ActionCable",
+      :type => Bugsnag::Breadcrumbs::PROCESS_BREADCRUMB_TYPE,
+      :allowed_data => [
+        :event_id,
+        :channel_class,
+        :action,
+        :data
+      ]
+    },
+    {
+      :id => "perform.active_job",
+      :message => "Perform ActiveJob"
+      :type => Bugsnag::Breadcrumbs::PROCESS_BREADCRUMB_TYPE,
+      :allowed_data => [
+        :event_id,
+        :adapter,
+        :job
+      ]
+    },
+    {
+      :id => "cache_read.active_support",
+      :message => "Read cache",
+      :type => Bugsnag::Breadcrumbs::PROCESS_BREADCRUMB_TYPE,
+      :allowed_data => [
+        :event_id,
+        :key,
+        :keys,
+        :hit,
+        :hits,
+        :super_operation
+      ]
+    },
+    {
+      :id => "cache_fetch_hit.active_support",
+      :message => "Fetch cache hit",
+      :type => Bugsnag::Breadcrumbs::PROCESS_BREADCRUMB_TYPE,
+      :allowed_data => [
+        :event_id,
+        :key,
+        :keys
+      ]
+    },
+    {
+      :id => "sql.active_record",
+      :message => "ActiveRecord SQL query",
+      :type => Bugsnag::Breadcrumbs::PROCESS_BREADCRUMB_TYPE,
+      :allowed_data => [
+        :event_id,
+        :name,
+        :connection_id,
+        :cached
+      ]
+    },
+    {
+      :id => "start_processing.action_controller",
+      :message => "Controller started processing"
+      :type => Bugsnag::Breadcrumbs::REQUEST_BREADCRUMB_TYPE,
+      :allowed_data => [
+        :event_id,
+        :controller,
+        :action,
+        :path
+      ]
+    },
+    {
+      :id => "process_action.action_controller",
+      :message => "Controller action processed",
+      :type => Bugsnag::Breadcrumbs::REQUEST_BREADCRUMB_TYPE,
+      :allowed_data => [
+        :event_id,
+        :controller,
+        :action,
+        :status,
+        :view_runtime,
+        :db_runtime
+      ]
+    },
+    {
+      :id => "redirect_to.action_controller",
+      :message => "Controller redirect",
+      :type => Bugsnag::Breadcrumbs::REQUEST_BREADCRUMB_TYPE,
+      :allowed_data => [
+        :event_id,
+        :status,
+        :location
+      ]
+    },
+    {
+      :id => "halted_callback.action_controller",
+      :message => "Controller halted via callback",
+      :type => Bugsnag::Breadcrumbs::REQUEST_BREADCRUMB_TYPE,
+      :allowed_data => [
+        :event_id,
+        :filter
+      ]
+    },
+    {
+      :id => "render_template.action_view",
+      :message => "ActionView template rendered"
+      :type => Bugsnag::Breadcrumbs::REQUEST_BREADCRUMB_TYPE,
+      :allowed_data => [
+        :event_id,
+        :identifier,
+        :layout
+      ]
+    },
+    {
+      :id => "render_partial.action_view",
+      :message => "ActionView partial rendered",
+      :type => Bugsnag::Breadcrumbs::REQUEST_BREADCRUMB_TYPE,
+      :allowed_data => [
+        :event_id,
+        :identifier
+      ]
+    },
+    {
+      :id => "deliver.action_mailer",
+      :message => "ActionMail delivered",
+      :type => Bugsnag::Breadcrumbs::REQUEST_BREADCRUMB_TYPE,
+      :allowed_data => [
+        :event_id,
+        :mailer,
+        :message_id,
+        :subject,
+        :to,
+        :from,
+        :bcc,
+        :cc,
+        :date
+      ]
+    }
+  ]
+end

--- a/lib/bugsnag/integrations/rails/rails_breadcrumbs.rb
+++ b/lib/bugsnag/integrations/rails/rails_breadcrumbs.rb
@@ -1,6 +1,6 @@
-require "bugnsag/breadcrumbs/breadcrumbs"
+require "bugsnag/breadcrumbs/breadcrumbs"
 
-module Bugsnag::Railtie
+module Bugsnag::RailsBreadcrumbs
   DEFAULT_RAILS_BREADCRUMBS = [
     {
       :id => "perform_action.action_cable",
@@ -15,7 +15,7 @@ module Bugsnag::Railtie
     },
     {
       :id => "perform.active_job",
-      :message => "Perform ActiveJob"
+      :message => "Perform ActiveJob",
       :type => Bugsnag::Breadcrumbs::PROCESS_BREADCRUMB_TYPE,
       :allowed_data => [
         :event_id,
@@ -59,7 +59,7 @@ module Bugsnag::Railtie
     },
     {
       :id => "start_processing.action_controller",
-      :message => "Controller started processing"
+      :message => "Controller started processing",
       :type => Bugsnag::Breadcrumbs::REQUEST_BREADCRUMB_TYPE,
       :allowed_data => [
         :event_id,
@@ -102,7 +102,7 @@ module Bugsnag::Railtie
     },
     {
       :id => "render_template.action_view",
-      :message => "ActionView template rendered"
+      :message => "ActionView template rendered",
       :type => Bugsnag::Breadcrumbs::REQUEST_BREADCRUMB_TYPE,
       :allowed_data => [
         :event_id,

--- a/lib/bugsnag/integrations/railtie.rb
+++ b/lib/bugsnag/integrations/railtie.rb
@@ -4,6 +4,7 @@ require "rails"
 require "bugsnag"
 require "bugsnag/middleware/rails3_request"
 require "bugsnag/middleware/rack_request"
+require "bugsnag/integrations/rails_breadcrumbs"
 
 module Bugsnag
   class Railtie < Rails::Railtie
@@ -38,6 +39,8 @@ module Bugsnag
         include Bugsnag::Rails::ActiveRecordRescue
       end
 
+      Bugsnag::Railtie::DEFAULT_RAILS_BREADCRUMBS.each { |event| event_subscription(event) }
+
       Bugsnag.configuration.app_type = "rails"
     end
 
@@ -61,6 +64,24 @@ module Bugsnag
         app.config.middleware.insert_after ActionDispatch::DebugExceptions, Bugsnag::Rack
       rescue
         app.config.middleware.use Bugsnag::Rack
+      end
+    end
+
+    ##
+    # Subscribes to an ActiveSupport event, leaving a breadcrumb when it triggers
+    #
+    # @api private
+    # @param event [Hash] details of the event to subscribe to
+    def event_subscription(event)
+      ActiveSupport::Notifications.subscribe(event[:id]) do |*, data|
+        filtered_data = data.select{ |k, v| event[:allowed_data].include?(k) }
+        filtered_data[:event_id] = event[:id]
+        Bugsnag.leave_breadcrumb(
+          event[:message],
+          event[:type],
+          filtered_data,
+          :auto
+        )
       end
     end
   end

--- a/lib/bugsnag/integrations/railtie.rb
+++ b/lib/bugsnag/integrations/railtie.rb
@@ -4,7 +4,7 @@ require "rails"
 require "bugsnag"
 require "bugsnag/middleware/rails3_request"
 require "bugsnag/middleware/rack_request"
-require "bugsnag/integrations/rails_breadcrumbs"
+require "bugsnag/integrations/rails/rails_breadcrumbs"
 
 module Bugsnag
   class Railtie < Rails::Railtie
@@ -39,7 +39,7 @@ module Bugsnag
         include Bugsnag::Rails::ActiveRecordRescue
       end
 
-      Bugsnag::Railtie::DEFAULT_RAILS_BREADCRUMBS.each { |event| event_subscription(event) }
+      Bugsnag::RailsBreadcrumbs::DEFAULT_RAILS_BREADCRUMBS.each { |event| event_subscription(event) }
 
       Bugsnag.configuration.app_type = "rails"
     end
@@ -78,8 +78,8 @@ module Bugsnag
         filtered_data[:event_id] = event[:id]
         Bugsnag.leave_breadcrumb(
           event[:message],
-          event[:type],
           filtered_data,
+          event[:type],
           :auto
         )
       end


### PR DESCRIPTION
## Goal

Adds `ActiveSupport::Notifications` subscriber for creating automatic breadcrumbs from Rails events.

TODO: 
- Add more tests
- Remove meta_data collection for data that breaks validation rules.

NOTE:
- This is PR'd into the breadcrumbs/update-report-branch purely so the changes are minimal.  Once that PR is complete, this'll be changed to the breadcrumbs/base branch.