### PR TITLE
Breadcrumbs: Renamed auto breadcrumb types configuration name

### DIFF
--- a/lib/bugsnag.rb
+++ b/lib/bugsnag.rb
@@ -115,7 +115,8 @@ module Bugsnag
         options = {:headers => report.headers}
         payload = ::JSON.dump(Bugsnag::Helpers.trim_if_needed(report.as_json))
         Bugsnag::Delivery[configuration.delivery_method].deliver(configuration.endpoint, payload, configuration, options)
-        leave_breadcrumb(report.name, report.summary, Bugsnag::Breadcrumbs::ERROR_BREADCRUMB_TYPE, :auto)
+        report_summary = report.summary
+        leave_breadcrumb(report_summary[:error_class], report_summary, Bugsnag::Breadcrumbs::ERROR_BREADCRUMB_TYPE, :auto)
       end
     end
 

--- a/lib/bugsnag/breadcrumbs/validator.rb
+++ b/lib/bugsnag/breadcrumbs/validator.rb
@@ -37,8 +37,8 @@ module Bugsnag::Breadcrumbs
         breadcrumb.type = Bugsnag::Breadcrumbs::MANUAL_BREADCRUMB_TYPE
       end
 
-      # If auto is true, check type is in automatic_breadcrumb_types
-      return unless breadcrumb.auto && !@configuration.automatic_breadcrumb_types.include?(breadcrumb.type)
+      # If auto is true, check type is in enabled_automatic_breadcrumb_types
+      return unless breadcrumb.auto && !@configuration.enabled_automatic_breadcrumb_types.include?(breadcrumb.type)
 
       @configuration.warn("Automatic breadcrumb of type #{breadcrumb.type} ignored: #{breadcrumb.name}")
       breadcrumb.ignore!

--- a/lib/bugsnag/configuration.rb
+++ b/lib/bugsnag/configuration.rb
@@ -42,7 +42,7 @@ module Bugsnag
 
     ##
     # @return [Array<String>] strings indicating allowable automatic breadcrumb types
-    attr_accessor :automatic_breadcrumb_types
+    attr_accessor :enabled_automatic_breadcrumb_types
 
     ##
     # @return [Array<#call>] callables to be run before a breadcrumb is logged
@@ -86,7 +86,7 @@ module Bugsnag
       self.auto_capture_sessions = false
       self.session_endpoint = DEFAULT_SESSION_ENDPOINT
       # All valid breadcrumb types should be allowable initially
-      self.automatic_breadcrumb_types = Bugsnag::Breadcrumbs::VALID_BREADCRUMB_TYPES.dup
+      self.enabled_automatic_breadcrumb_types = Bugsnag::Breadcrumbs::VALID_BREADCRUMB_TYPES.dup
       self.before_breadcrumb_callbacks = []
 
       # Store max_breadcrumbs here instead of outputting breadcrumbs.max_items

--- a/spec/breadcrumbs/validator_spec.rb
+++ b/spec/breadcrumbs/validator_spec.rb
@@ -5,7 +5,7 @@ require 'bugsnag/breadcrumbs/breadcrumb'
 require 'bugsnag/breadcrumbs/validator'
 
 RSpec.describe Bugsnag::Breadcrumbs::Validator do
-  let(:automatic_breadcrumb_types) { Bugsnag::Breadcrumbs::VALID_BREADCRUMB_TYPES }
+  let(:enabled_automatic_breadcrumb_types) { Bugsnag::Breadcrumbs::VALID_BREADCRUMB_TYPES }
   let(:auto) { false }
   let(:name) { "Valid message" }
   let(:type) { Bugsnag::Breadcrumbs::ERROR_BREADCRUMB_TYPE }
@@ -14,7 +14,7 @@ RSpec.describe Bugsnag::Breadcrumbs::Validator do
   describe "#validate" do
     it "does not 'ignore!' a valid breadcrumb" do
       config = instance_double(Bugsnag::Configuration)
-      allow(config).to receive(:automatic_breadcrumb_types).and_return(automatic_breadcrumb_types)
+      allow(config).to receive(:enabled_automatic_breadcrumb_types).and_return(enabled_automatic_breadcrumb_types)
       validator = Bugsnag::Breadcrumbs::Validator.new(config)
 
       breadcrumb = instance_double(Bugsnag::Breadcrumbs::Breadcrumb, {
@@ -33,7 +33,7 @@ RSpec.describe Bugsnag::Breadcrumbs::Validator do
 
     it "trims long messages to length and warns" do
       config = instance_double(Bugsnag::Configuration)
-      allow(config).to receive(:automatic_breadcrumb_types).and_return(automatic_breadcrumb_types)
+      allow(config).to receive(:enabled_automatic_breadcrumb_types).and_return(enabled_automatic_breadcrumb_types)
       validator = Bugsnag::Breadcrumbs::Validator.new(config)
 
       name = "1234567890123456789012345678901234567890"
@@ -59,7 +59,7 @@ RSpec.describe Bugsnag::Breadcrumbs::Validator do
     describe "tests meta_data types" do
       it "accepts Strings, Numerics, & Booleans" do
         config = instance_double(Bugsnag::Configuration)
-        allow(config).to receive(:automatic_breadcrumb_types).and_return(automatic_breadcrumb_types)
+        allow(config).to receive(:enabled_automatic_breadcrumb_types).and_return(enabled_automatic_breadcrumb_types)
         validator = Bugsnag::Breadcrumbs::Validator.new(config)
 
         meta_data = {
@@ -86,7 +86,7 @@ RSpec.describe Bugsnag::Breadcrumbs::Validator do
 
       it "rejects Arrays, Hashes, and non-primitive objects" do
         config = instance_double(Bugsnag::Configuration)
-        allow(config).to receive(:automatic_breadcrumb_types).and_return(automatic_breadcrumb_types)
+        allow(config).to receive(:enabled_automatic_breadcrumb_types).and_return(enabled_automatic_breadcrumb_types)
         validator = Bugsnag::Breadcrumbs::Validator.new(config)
 
         class TestClass
@@ -127,7 +127,7 @@ RSpec.describe Bugsnag::Breadcrumbs::Validator do
 
     it "tests type, defaulting to 'manual' if invalid" do
       config = instance_double(Bugsnag::Configuration)
-      allow(config).to receive(:automatic_breadcrumb_types).and_return(automatic_breadcrumb_types)
+      allow(config).to receive(:enabled_automatic_breadcrumb_types).and_return(enabled_automatic_breadcrumb_types)
       validator = Bugsnag::Breadcrumbs::Validator.new(config)
 
       type = "Not a valid type"
@@ -148,11 +148,11 @@ RSpec.describe Bugsnag::Breadcrumbs::Validator do
       validator.validate(breadcrumb)
     end
 
-    describe "with automatic_breadcrumb_types set" do
+    describe "with enabled_automatic_breadcrumb_types set" do
       it "rejects automatic breadcrumbs with rejected types" do
         config = instance_double(Bugsnag::Configuration)
         allowed_breadcrumb_types = []
-        allow(config).to receive(:automatic_breadcrumb_types).and_return(allowed_breadcrumb_types)
+        allow(config).to receive(:enabled_automatic_breadcrumb_types).and_return(allowed_breadcrumb_types)
         validator = Bugsnag::Breadcrumbs::Validator.new(config)
 
         auto = true
@@ -176,7 +176,7 @@ RSpec.describe Bugsnag::Breadcrumbs::Validator do
       it "does not reject manual breadcrumbs with rejected types" do
         config = instance_double(Bugsnag::Configuration)
         allowed_breadcrumb_types = []
-        allow(config).to receive(:automatic_breadcrumb_types).and_return(allowed_breadcrumb_types)
+        allow(config).to receive(:enabled_automatic_breadcrumb_types).and_return(allowed_breadcrumb_types)
         validator = Bugsnag::Breadcrumbs::Validator.new(config)
 
         type = Bugsnag::Breadcrumbs::ERROR_BREADCRUMB_TYPE

--- a/spec/bugsnag_spec.rb
+++ b/spec/bugsnag_spec.rb
@@ -34,7 +34,7 @@ describe Bugsnag do
       expect(breadcrumb.type).to eq(Bugsnag::Breadcrumbs::ERROR_BREADCRUMB_TYPE)
       expect(breadcrumb.auto).to eq(true)
       expect(breadcrumb.meta_data).to eq({
-        :name => 'ZeroDivisionError',
+        :error_class => 'ZeroDivisionError',
         :message => 'divided by 0',
         :severity => 'warning'
       })
@@ -50,7 +50,7 @@ describe Bugsnag do
       expect(breadcrumb.type).to eq(Bugsnag::Breadcrumbs::ERROR_BREADCRUMB_TYPE)
       expect(breadcrumb.auto).to eq(true)
       expect(breadcrumb.meta_data).to eq({
-        :name => 'RuntimeError',
+        :error_class => 'RuntimeError',
         :message => 'notified string',
         :severity => 'warning'
       })
@@ -277,7 +277,7 @@ describe Bugsnag do
     end
 
     it "doesn't add when ignored by the validator" do
-      Bugsnag.configuration.automatic_breadcrumb_types = []
+      Bugsnag.configuration.enabled_automatic_breadcrumb_types = []
       Bugsnag.leave_breadcrumb("TestName", {}, Bugsnag::Breadcrumbs::ERROR_BREADCRUMB_TYPE, :auto)
       expect(breadcrumbs.to_a.size).to eq(0)
     end
@@ -291,7 +291,7 @@ describe Bugsnag do
     end
 
     it "doesn't add when ignored after the callbacks" do
-      Bugsnag.configuration.automatic_breadcrumb_types = [
+      Bugsnag.configuration.enabled_automatic_breadcrumb_types = [
         Bugsnag::Breadcrumbs::MANUAL_BREADCRUMB_TYPE
       ]
       Bugsnag.configuration.before_breadcrumb_callbacks << Proc.new do |breadcrumb|
@@ -302,7 +302,7 @@ describe Bugsnag do
     end
 
     it "doesn't call callbacks if ignored early" do
-      Bugsnag.configuration.automatic_breadcrumb_types = []
+      Bugsnag.configuration.enabled_automatic_breadcrumb_types = []
       Bugsnag.configuration.before_breadcrumb_callbacks << Proc.new do |breadcrumb|
         fail "This shouldn't be called"
       end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -277,14 +277,14 @@ describe Bugsnag::Configuration do
     end
   end
 
-  describe "#automatic_breadcrumb_types" do
+  describe "#enabled_automatic_breadcrumb_types" do
     it "defaults to Bugsnag::Breadcrumbs::VALID_BREADCRUMB_TYPES" do
-      expect(subject.automatic_breadcrumb_types).to eq(Bugsnag::Breadcrumbs::VALID_BREADCRUMB_TYPES)
+      expect(subject.enabled_automatic_breadcrumb_types).to eq(Bugsnag::Breadcrumbs::VALID_BREADCRUMB_TYPES)
     end
 
     it "is an editable array" do
-      subject.automatic_breadcrumb_types << "Some custom type"
-      expect(subject.automatic_breadcrumb_types).to include("Some custom type")
+      subject.enabled_automatic_breadcrumb_types << "Some custom type"
+      expect(subject.enabled_automatic_breadcrumb_types).to include("Some custom type")
     end
   end
 


### PR DESCRIPTION
## Goal

Updates the `automatic_breadcrumb_types` configuration option to `enabled_automatic_breadcrumb_types`