### PR TITLE
Breadcrumbs/Mongo: Remove 'started' breadcrumb, add collection detail

### DIFF
--- a/features/fixtures/rails4/app/app/controllers/mongo_controller.rb
+++ b/features/fixtures/rails4/app/app/controllers/mongo_controller.rb
@@ -6,6 +6,11 @@ class MongoController < ApplicationController
     "Statement".prepnd("Failing")
   end
 
+  def get_crash
+    MongoModel.where(string_field: true)
+    "Statement".prepnd("Failing")
+  end
+
   def failure_crash
     begin
       Mongoid::Clients.default.database.command(:bogus => 1)

--- a/features/fixtures/rails4/app/app/controllers/mongo_controller.rb
+++ b/features/fixtures/rails4/app/app/controllers/mongo_controller.rb
@@ -7,7 +7,7 @@ class MongoController < ApplicationController
   end
 
   def get_crash
-    MongoModel.where(string_field: true)
+    MongoModel.where(string_field: true).as_json
     "Statement".prepnd("Failing")
   end
 

--- a/features/fixtures/rails5/app/app/controllers/mongo_controller.rb
+++ b/features/fixtures/rails5/app/app/controllers/mongo_controller.rb
@@ -6,7 +6,7 @@ class MongoController < ApplicationController
   end
 
   def get_crash
-    MongoModel.where(string_field: true)
+    MongoModel.where(string_field: true).as_json
     "Statement".prepnd("Failing")
   end
 

--- a/features/fixtures/rails5/app/app/controllers/mongo_controller.rb
+++ b/features/fixtures/rails5/app/app/controllers/mongo_controller.rb
@@ -5,6 +5,11 @@ class MongoController < ApplicationController
     "Statement".prepnd("Failing")
   end
 
+  def get_crash
+    MongoModel.where(string_field: true)
+    "Statement".prepnd("Failing")
+  end
+
   def failure_crash
     begin
       Mongoid::Clients.default.database.command(:bogus => 1)

--- a/features/fixtures/rails5/app/config/routes.rb
+++ b/features/fixtures/rails5/app/config/routes.rb
@@ -56,5 +56,6 @@ Rails.application.routes.draw do
   get 'breadcrumbs/cache_read', to: 'breadcrumbs#cache_read'
 
   get 'mongo/success_crash', to: 'mongo#success_crash'
+  get 'mongo/get_crash', to: 'mongo#get_crash'
   get 'mongo/failure_crash', to: 'mongo#failure_crash'
 end

--- a/features/rails_features/mongo_breadcrumbs.feature
+++ b/features/rails_features/mongo_breadcrumbs.feature
@@ -51,7 +51,7 @@ Scenario Outline: Breadcrumb with filter parameters
   And the event "breadcrumbs.1.metaData.request_id" is not null
   And the event "breadcrumbs.1.metaData.duration" is not null
   And the event "breadcrumbs.1.metaData.collection" equals "mongo_models"
-  And the event "breadcrumbs.1.metaData.filters" equals "{"string_field":"?"}"
+  And the event "breadcrumbs.1.metaData.filter" equals "{"string_field":"?"}"
 
   Examples:
     | ruby_version | rails_version |

--- a/features/rails_features/mongo_breadcrumbs.feature
+++ b/features/rails_features/mongo_breadcrumbs.feature
@@ -14,8 +14,15 @@ Scenario Outline: Successful breadcrumbs
   And the request is a valid for the error reporting API
   And the request used the "Ruby Bugsnag Notifier" notifier
   And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  And the event has a "process" breadcrumb named "Mongo query started"
   And the event has a "process" breadcrumb named "Mongo query succeeded"
+  And the event "breadcrumbs.1.timestamp" is a timestamp
+  And the event "breadcrumbs.1.metaData.event_name" equals "mongo.succeeded"
+  And the event "breadcrumbs.1.metaData.command_name" equals "insert"
+  And the event "breadcrumbs.1.metaData.database_name" equals "rails<rails_version>_development"
+  And the event "breadcrumbs.1.metaData.operation_id" is not null
+  And the event "breadcrumbs.1.metaData.request_id" is not null
+  And the event "breadcrumbs.1.metaData.duration" is not null
+  And the event "breadcrumbs.1.metaData.collection" equals "mongo_models"
 
   Examples:
     | ruby_version | rails_version |
@@ -35,8 +42,15 @@ Scenario Outline: Failure breadcrumbs
   And the request is a valid for the error reporting API
   And the request used the "Ruby Bugsnag Notifier" notifier
   And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
-  And the event has a "process" breadcrumb named "Mongo query started"
   And the event has a "process" breadcrumb named "Mongo query failed"
+  And the event "breadcrumbs.1.timestamp" is a timestamp
+  And the event "breadcrumbs.1.metaData.event_name" equals "mongo.failed"
+  And the event "breadcrumbs.1.metaData.command_name" equals "bogus"
+  And the event "breadcrumbs.1.metaData.database_name" equals "rails<rails_version>_development"
+  And the event "breadcrumbs.1.metaData.operation_id" is not null
+  And the event "breadcrumbs.1.metaData.request_id" is not null
+  And the event "breadcrumbs.1.metaData.duration" is not null
+  And the event "breadcrumbs.1.metaData.collection" equals 1
 
   Examples:
     | ruby_version | rails_version |

--- a/features/rails_features/mongo_breadcrumbs.feature
+++ b/features/rails_features/mongo_breadcrumbs.feature
@@ -33,6 +33,35 @@ Scenario Outline: Successful breadcrumbs
     | 2.4          | 5             |
     | 2.5          | 5             |
 
+Scenario Outline: Breadcrumb with filter parameters
+  Given I set environment variable "RUBY_VERSION" to "<ruby_version>"
+  And I start the service "rails<rails_version>"
+  And I wait for the app to respond on port "6128<rails_version>"
+  When I navigate to the route "/mongo/success_crash" on port "6128<rails_version>"
+  Then I should receive a request
+  And the request is a valid for the error reporting API
+  And the request used the "Ruby Bugsnag Notifier" notifier
+  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And the event has a "process" breadcrumb named "Mongo query succeeded"
+  And the event "breadcrumbs.1.timestamp" is a timestamp
+  And the event "breadcrumbs.1.metaData.event_name" equals "mongo.succeeded"
+  And the event "breadcrumbs.1.metaData.command_name" equals "find"
+  And the event "breadcrumbs.1.metaData.database_name" equals "rails<rails_version>_development"
+  And the event "breadcrumbs.1.metaData.operation_id" is not null
+  And the event "breadcrumbs.1.metaData.request_id" is not null
+  And the event "breadcrumbs.1.metaData.duration" is not null
+  And the event "breadcrumbs.1.metaData.collection" equals "mongo_models"
+  And the event "breadcrumbs.1.metaData.filter_0" equals "string_field"
+
+  Examples:
+    | ruby_version | rails_version |
+    | 2.2          | 4             |
+    | 2.2          | 5             |
+    | 2.3          | 4             |
+    | 2.3          | 5             |
+    | 2.4          | 5             |
+    | 2.5          | 5             |
+
 Scenario Outline: Failure breadcrumbs
   Given I set environment variable "RUBY_VERSION" to "<ruby_version>"
   And I start the service "rails<rails_version>"

--- a/features/rails_features/mongo_breadcrumbs.feature
+++ b/features/rails_features/mongo_breadcrumbs.feature
@@ -37,7 +37,7 @@ Scenario Outline: Breadcrumb with filter parameters
   Given I set environment variable "RUBY_VERSION" to "<ruby_version>"
   And I start the service "rails<rails_version>"
   And I wait for the app to respond on port "6128<rails_version>"
-  When I navigate to the route "/mongo/success_crash" on port "6128<rails_version>"
+  When I navigate to the route "/mongo/get_crash" on port "6128<rails_version>"
   Then I should receive a request
   And the request is a valid for the error reporting API
   And the request used the "Ruby Bugsnag Notifier" notifier
@@ -51,7 +51,7 @@ Scenario Outline: Breadcrumb with filter parameters
   And the event "breadcrumbs.1.metaData.request_id" is not null
   And the event "breadcrumbs.1.metaData.duration" is not null
   And the event "breadcrumbs.1.metaData.collection" equals "mongo_models"
-  And the event "breadcrumbs.1.metaData.filter_0" equals "string_field"
+  And the event "breadcrumbs.1.metaData.filters" equals "{"string_field":"?"}"
 
   Examples:
     | ruby_version | rails_version |

--- a/lib/bugsnag/integrations/mongo.rb
+++ b/lib/bugsnag/integrations/mongo.rb
@@ -56,8 +56,8 @@ module Bugsnag
         collection_key = event.command_name == "getMore" ? "collection" : event.command_name
         meta_data[:collection] = command[collection_key]
         unless command["filter"].nil?
-          filters = command["filter"].map { |key, _v| [key, '?'] }.to_h
-          meta_data[:filters] = JSON.dump(filters)
+          filter = command["filter"].map { |key, _v| [key, '?'] }.to_h
+          meta_data[:filter] = JSON.dump(filter)
         end
       end
       meta_data[:message] = event.message if defined?(event.message)
@@ -78,7 +78,7 @@ module Bugsnag
     #
     # @param request_id [String] the id of the mongo_ruby_driver event
     #
-    # @return [Hash|nil] the requested command, or nil if not found
+    # @return [Hash, nil] the requested command, or nil if not found
     def pop_command(request_id)
       event_commands.delete(request_id)
     end

--- a/lib/bugsnag/integrations/mongo.rb
+++ b/lib/bugsnag/integrations/mongo.rb
@@ -52,11 +52,11 @@ module Bugsnag
         :request_id => event.request_id,
         :duration => event.duration
       }
-      if command = pop_command(event.request_id)
+      if (command = pop_command(event.request_id))
         collection_key = event.command_name == "getMore" ? "collection" : event.command_name
         meta_data[:collection] = command[collection_key]
         unless command["filter"].nil?
-          filters  = command["filter"].map { |key, _v| [key, '?'] }.to_h
+          filters = command["filter"].map { |key, _v| [key, '?'] }.to_h
           meta_data[:filters] = JSON.dump(filters)
         end
       end

--- a/lib/bugsnag/integrations/mongo.rb
+++ b/lib/bugsnag/integrations/mongo.rb
@@ -52,8 +52,12 @@ module Bugsnag
         :request_id => event.request_id,
         :duration => event.duration
       }
-      command = pop_command(event.request_id)
-      meta_data[:collection] = command[event.command_name] if command
+      if command = pop_command(event.request_id)
+        meta_data[:collection] = command[event.command_name]
+        command["filter"].keys.each_with_index do |key, index|
+          meta_data[:"filter_#{index}"] = key
+        end
+      end
       meta_data[:message] = event.message if defined?(event.message)
 
       Bugsnag.leave_breadcrumb(message, meta_data, Bugsnag::Breadcrumbs::PROCESS_BREADCRUMB_TYPE, :auto)


### PR DESCRIPTION
## Goal

Removes the "started" breadcrumb, while adding the commands collection name.

Adds filter keys in the format: `{"filter_1":"?","filter_2":"?"}` etc.

Adds new and improves existing end-to-end tests for mongo breadcrumbs.