### PR TITLE
Breadcrumbs/Validator: Allow nil as an acceptable meta_data type

### DIFF
--- a/lib/bugsnag/breadcrumbs/validator.rb
+++ b/lib/bugsnag/breadcrumbs/validator.rb
@@ -49,11 +49,11 @@ module Bugsnag::Breadcrumbs
     ##
     # Tests whether the meta_data types are non-complex objects.
     #
-    # Acceptable types are String, Numeric, TrueClass, and FalseClass.
+    # Acceptable types are String, Numeric, TrueClass, FalseClass, and nil.
     #
     # @param value [Object] the object to be type checked
     def valid_meta_data_type?(value)
-      value.is_a?(String) || value.is_a?(Numeric) || value.is_a?(FalseClass) || value.is_a?(TrueClass)
+      value.nil? || value.is_a?(String) || value.is_a?(Numeric) || value.is_a?(FalseClass) || value.is_a?(TrueClass)
     end
   end
 end

--- a/spec/breadcrumbs/validator_spec.rb
+++ b/spec/breadcrumbs/validator_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe Bugsnag::Breadcrumbs::Validator do
     end
 
     describe "tests meta_data types" do
-      it "accepts Strings, Numerics, & Booleans" do
+      it "accepts Strings, Numerics, Booleans, & nil" do
         config = instance_double(Bugsnag::Configuration)
         allow(config).to receive(:enabled_automatic_breadcrumb_types).and_return(enabled_automatic_breadcrumb_types)
         validator = Bugsnag::Breadcrumbs::Validator.new(config)
@@ -67,7 +67,8 @@ RSpec.describe Bugsnag::Breadcrumbs::Validator do
           :integer => 12345,
           :float => 12345.6789,
           :false => false,
-          :true => true
+          :true => true,
+          :nil => nil
         }
 
         breadcrumb = instance_double(Bugsnag::Breadcrumbs::Breadcrumb, {


### PR DESCRIPTION
## Goal
Allows `nil` to be a valid meta_data value when validating a breadcrumb.