### PR TITLE
Breadcrumbs: Additional Rails ActiveRecord data

### DIFF
--- a/features/fixtures/docker-compose.yml
+++ b/features/fixtures/docker-compose.yml
@@ -120,6 +120,7 @@ services:
       - BUGSNAG_SESSION_ENDPOINT
       - BUGSNAG_TIMEOUT
       - CALLBACK_INITIATOR
+      - SQL_ONLY_BREADCRUMBS
     ports:
       - target: 3000
         published: 61283
@@ -157,6 +158,7 @@ services:
       - BUGSNAG_SESSION_ENDPOINT
       - BUGSNAG_TIMEOUT
       - CALLBACK_INITIATOR
+      - SQL_ONLY_BREADCRUMBS
     ports:
       - target: 3000
         published: 61284
@@ -194,6 +196,7 @@ services:
       - BUGSNAG_SESSION_ENDPOINT
       - BUGSNAG_TIMEOUT
       - CALLBACK_INITIATOR
+      - SQL_ONLY_BREADCRUMBS
     ports:
       - target: 3000
         published: 61285

--- a/features/fixtures/rails3/app/app/controllers/breadcrumbs_controller.rb
+++ b/features/fixtures/rails3/app/app/controllers/breadcrumbs_controller.rb
@@ -1,4 +1,3 @@
-require 'pp'
 class BreadcrumbsController < ApplicationController
   def handled
     Bugsnag.notify("Request breadcrumb")

--- a/features/fixtures/rails3/app/app/controllers/breadcrumbs_controller.rb
+++ b/features/fixtures/rails3/app/app/controllers/breadcrumbs_controller.rb
@@ -1,3 +1,4 @@
+require 'pp'
 class BreadcrumbsController < ApplicationController
   def handled
     Bugsnag.notify("Request breadcrumb")
@@ -5,7 +6,7 @@ class BreadcrumbsController < ApplicationController
   end
 
   def sql_breadcrumb
-    User.take
+    User.where(:email => "foo").as_json
     Bugsnag.notify("SQL breadcrumb")
     render json: {}
   end

--- a/features/fixtures/rails3/app/config/initializers/bugsnag.rb
+++ b/features/fixtures/rails3/app/config/initializers/bugsnag.rb
@@ -11,4 +11,10 @@ Bugsnag.configure do |config|
   config.release_stage = ENV["BUGSNAG_RELEASE_STAGE"] if ENV.include? "BUGSNAG_RELEASE_STAGE"
   config.send_code = ENV["BUGSNAG_SEND_CODE"] != "false"
   config.send_environment = ENV["BUGSNAG_SEND_ENVIRONMENT"] == "true"
+
+  if ENV["SQL_ONLY_BREADCRUMBS"] == "true"
+    config.before_breadcrumb_callbacks << Proc.new do |breadcrumb|
+      breadcrumb.ignore! unless breadcrumb.meta_data[:event_name] == "sql.active_record" && breadcrumb.meta_data[:name] == "User Load"
+    end
+  end
 end

--- a/features/fixtures/rails4/app/Gemfile
+++ b/features/fixtures/rails4/app/Gemfile
@@ -42,3 +42,5 @@ gem 'bugsnag', path: '/bugsnag'
 gem 'devise'
 
 gem "mongoid", '~> 5.4.0'
+
+gem "nokogiri", "1.6.8"

--- a/features/fixtures/rails4/app/app/controllers/breadcrumbs_controller.rb
+++ b/features/fixtures/rails4/app/app/controllers/breadcrumbs_controller.rb
@@ -5,7 +5,7 @@ class BreadcrumbsController < ApplicationController
   end
 
   def sql_breadcrumb
-    User.where(:email => "foo")
+    User.find_by(email: "foo")
     Bugsnag.notify("SQL breadcrumb")
     render json: {}
   end

--- a/features/fixtures/rails4/app/app/controllers/breadcrumbs_controller.rb
+++ b/features/fixtures/rails4/app/app/controllers/breadcrumbs_controller.rb
@@ -5,10 +5,8 @@ class BreadcrumbsController < ApplicationController
   end
 
   def sql_breadcrumb
-    Thread.new {
-      User.take
-      Bugsnag.notify("SQL breadcrumb")
-    }.join
+    User.where(:email => "foo")
+    Bugsnag.notify("SQL breadcrumb")
     render json: {}
   end
 

--- a/features/fixtures/rails4/app/config/initializers/bugsnag.rb
+++ b/features/fixtures/rails4/app/config/initializers/bugsnag.rb
@@ -11,4 +11,10 @@ Bugsnag.configure do |config|
   config.release_stage = ENV["BUGSNAG_RELEASE_STAGE"] if ENV.include? "BUGSNAG_RELEASE_STAGE"
   config.send_code = ENV["BUGSNAG_SEND_CODE"] != "false"
   config.send_environment = ENV["BUGSNAG_SEND_ENVIRONMENT"] == "true"
+
+  if ENV["SQL_ONLY_BREADCRUMBS"] == "true"
+    config.before_breadcrumb_callbacks << Proc.new do |breadcrumb|
+      breadcrumb.ignore! unless breadcrumb.meta_data[:event_name] == "sql.active_record" && breadcrumb.meta_data[:name] == "User Load"
+    end
+  end
 end

--- a/features/fixtures/rails5/app/Gemfile
+++ b/features/fixtures/rails5/app/Gemfile
@@ -47,3 +47,5 @@ gem 'bugsnag', path: '/bugsnag'
 gem "clearance", "~> 1.16"
 
 gem "mongoid"
+
+gem "nokogiri", "1.6.8"

--- a/features/fixtures/rails5/app/app/controllers/breadcrumbs_controller.rb
+++ b/features/fixtures/rails5/app/app/controllers/breadcrumbs_controller.rb
@@ -5,7 +5,7 @@ class BreadcrumbsController < ApplicationController
   end
 
   def sql_breadcrumb
-    User.where(:email => "foo")
+    User.find_by(email: "foo")
     Bugsnag.notify("SQL breadcrumb")
     render json: {}
   end

--- a/features/fixtures/rails5/app/app/controllers/breadcrumbs_controller.rb
+++ b/features/fixtures/rails5/app/app/controllers/breadcrumbs_controller.rb
@@ -5,7 +5,7 @@ class BreadcrumbsController < ApplicationController
   end
 
   def sql_breadcrumb
-    User.take
+    User.where(:email => "foo")
     Bugsnag.notify("SQL breadcrumb")
     render json: {}
   end

--- a/features/fixtures/rails5/app/config/initializers/bugsnag.rb
+++ b/features/fixtures/rails5/app/config/initializers/bugsnag.rb
@@ -11,4 +11,10 @@ Bugsnag.configure do |config|
   config.release_stage = ENV["BUGSNAG_RELEASE_STAGE"] if ENV.include? "BUGSNAG_RELEASE_STAGE"
   config.send_code = ENV["BUGSNAG_SEND_CODE"] != "false"
   config.send_environment = ENV["BUGSNAG_SEND_ENVIRONMENT"] == "true"
+
+  if ENV["SQL_ONLY_BREADCRUMBS"] == "true"
+    config.before_breadcrumb_callbacks << Proc.new do |breadcrumb|
+      breadcrumb.ignore! unless breadcrumb.meta_data[:event_name] == "sql.active_record" && breadcrumb.meta_data[:name] == "User Load"
+    end
+  end
 end

--- a/features/rails_features/breadcrumbs.feature
+++ b/features/rails_features/breadcrumbs.feature
@@ -38,8 +38,9 @@ Scenario Outline: Request breadcrumb
     | 2.5          | 3             |
     | 2.5          | 5             |
 
-Scenario Outline: SQL Breadcrumb
+Scenario Outline: SQL Breadcrumb without bindings
   Given I set environment variable "RUBY_VERSION" to "<ruby_version>"
+  And I set environment variable "SQL_ONLY_BREADCRUMBS" to "true"
   And I start the service "rails<rails_version>"
   And I wait for the app to respond on port "6128<rails_version>"
   When I navigate to the route "/breadcrumbs/sql_breadcrumb" on port "6128<rails_version>"
@@ -48,6 +49,11 @@ Scenario Outline: SQL Breadcrumb
   And the request used the "Ruby Bugsnag Notifier" notifier
   And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
   And the event has a "process" breadcrumb named "ActiveRecord SQL query"
+  And the event "breadcrumbs.0.timestamp" is a timestamp
+  And the event "breadcrumbs.0.metaData.name" equals "User Load"
+  And the event "breadcrumbs.0.metaData.connection_id" is not null
+  And the event "breadcrumbs.0.metaData.event_name" equals "sql.active_record"
+  And the event "breadcrumbs.0.metaData.event_id" is not null
 
   Examples:
     | ruby_version | rails_version |
@@ -55,13 +61,34 @@ Scenario Outline: SQL Breadcrumb
     | 2.1          | 3             |
     | 2.2          | 3             |
     | 2.2          | 4             |
-    | 2.2          | 5             |
     | 2.3          | 3             |
     | 2.3          | 4             |
-    | 2.3          | 5             |
     | 2.4          | 3             |
-    | 2.4          | 5             |
     | 2.5          | 3             |
+
+Scenario Outline: SQL Breadcrumb with bindings
+  Given I set environment variable "RUBY_VERSION" to "<ruby_version>"
+  And I set environment variable "SQL_ONLY_BREADCRUMBS" to "true"
+  And I start the service "rails<rails_version>"
+  And I wait for the app to respond on port "6128<rails_version>"
+  When I navigate to the route "/breadcrumbs/sql_breadcrumb" on port "6128<rails_version>"
+  Then I should receive a request
+  And the request is a valid for the error reporting API
+  And the request used the "Ruby Bugsnag Notifier" notifier
+  And the request contained the api key "a35a2a72bd230ac0aa0f52715bbdc6aa"
+  And the event has a "process" breadcrumb named "ActiveRecord SQL query"
+  And the event "breadcrumbs.0.timestamp" is a timestamp
+  And the event "breadcrumbs.0.metaData.name" equals "User Load"
+  And the event "breadcrumbs.0.metaData.connection_id" is not null
+  And the event "breadcrumbs.0.metaData.event_name" equals "sql.active_record"
+  And the event "breadcrumbs.0.metaData.event_id" is not null
+  And the event "breadcrumbs.0.metaData.bindings" equals "{"email":"?","LIMIT":"?"}"
+
+  Examples:
+    | ruby_version | rails_version |
+    | 2.2          | 5             |
+    | 2.3          | 5             |
+    | 2.4          | 5             |
     | 2.5          | 5             |
 
 Scenario Outline: Active job breadcrumb

--- a/features/rails_features/breadcrumbs.feature
+++ b/features/rails_features/breadcrumbs.feature
@@ -21,6 +21,7 @@ Scenario Outline: Request breadcrumb
   And the event "breadcrumbs.0.metaData.method" equals "GET"
   And the event "breadcrumbs.0.metaData.path" equals "/breadcrumbs/handled"
   And the event "breadcrumbs.0.metaData.event_name" equals "start_processing.action_controller"
+  And the event "breadcrumbs.0.metaData.event_id" is not null
 
   Examples:
     | ruby_version | rails_version |
@@ -75,6 +76,7 @@ Scenario Outline: Active job breadcrumb
   And the event has a "process" breadcrumb named "Start perform ActiveJob"
   And the event "breadcrumbs.0.timestamp" is a timestamp
   And the event "breadcrumbs.0.metaData.event_name" equals "perform_start.active_job"
+  And the event "breadcrumbs.0.metaData.event_id" is not null
 
   Examples:
     | ruby_version | rails_version |

--- a/features/rails_features/breadcrumbs.feature
+++ b/features/rails_features/breadcrumbs.feature
@@ -82,7 +82,7 @@ Scenario Outline: SQL Breadcrumb with bindings
   And the event "breadcrumbs.0.metaData.connection_id" is not null
   And the event "breadcrumbs.0.metaData.event_name" equals "sql.active_record"
   And the event "breadcrumbs.0.metaData.event_id" is not null
-  And the event "breadcrumbs.0.metaData.bindings" equals "{"email":"?","LIMIT":"?"}"
+  And the event "breadcrumbs.0.metaData.binds" equals "{"email":"?","LIMIT":"?"}"
 
   Examples:
     | ruby_version | rails_version |

--- a/lib/bugsnag/integrations/rails/rails_breadcrumbs.rb
+++ b/lib/bugsnag/integrations/rails/rails_breadcrumbs.rb
@@ -40,7 +40,6 @@ module Bugsnag::Rails
       :message => "ActiveRecord SQL query",
       :type => Bugsnag::Breadcrumbs::PROCESS_BREADCRUMB_TYPE,
       :allowed_data => [
-        :sql,
         :name,
         :connection_id,
         :cached

--- a/lib/bugsnag/integrations/rails/rails_breadcrumbs.rb
+++ b/lib/bugsnag/integrations/rails/rails_breadcrumbs.rb
@@ -40,6 +40,7 @@ module Bugsnag::Rails
       :message => "ActiveRecord SQL query",
       :type => Bugsnag::Breadcrumbs::PROCESS_BREADCRUMB_TYPE,
       :allowed_data => [
+        :sql,
         :name,
         :connection_id,
         :cached

--- a/lib/bugsnag/integrations/railtie.rb
+++ b/lib/bugsnag/integrations/railtie.rb
@@ -82,7 +82,6 @@ module Bugsnag
           binds = data[:binds].map { |bind| defined?(bind.name) ? [bind.name, '?'] : nil }
           binds.select! { |bind| bind }
           filtered_data[:bindings] = JSON.dump(binds.to_h) unless binds.empty?
-          filtered_data[:sql] = data[:sql].gsub(/(=|>|<|=>|=<|IN) (\S+)/, '\1 "?"')
         end
         Bugsnag.leave_breadcrumb(
           event[:message],

--- a/lib/bugsnag/integrations/railtie.rb
+++ b/lib/bugsnag/integrations/railtie.rb
@@ -1,5 +1,6 @@
 # Rails 3.x hooks
 
+require "json"
 require "rails"
 require "bugsnag"
 require "bugsnag/middleware/rails3_request"
@@ -77,6 +78,11 @@ module Bugsnag
         filtered_data = data.slice(*event[:allowed_data])
         filtered_data[:event_name] = event[:id]
         filtered_data[:event_id] = event_id
+        if event[:id] == "sql.active_record"
+          binds = data[:binds].map { |bind| defined?(bind.name) ? [bind.name, '?'] : nil }
+          binds.select! { |bind| bind }
+          filtered_data[:bindings] = JSON.dump(binds.to_h)
+        end
         Bugsnag.leave_breadcrumb(
           event[:message],
           filtered_data,

--- a/lib/bugsnag/integrations/railtie.rb
+++ b/lib/bugsnag/integrations/railtie.rb
@@ -79,9 +79,8 @@ module Bugsnag
         filtered_data[:event_name] = event[:id]
         filtered_data[:event_id] = event_id
         if event[:id] == "sql.active_record"
-          binds = data[:binds].map { |bind| defined?(bind.name) ? [bind.name, '?'] : nil }
-          binds.select! { |bind| bind }
-          filtered_data[:bindings] = JSON.dump(binds.to_h) unless binds.empty?
+          binds = data[:binds].each_with_object({}) { |bind, output| output[bind.name] = '?' if defined?(bind.name) }
+          filtered_data[:binds] = JSON.dump(binds) unless binds.empty?
         end
         Bugsnag.leave_breadcrumb(
           event[:message],

--- a/lib/bugsnag/integrations/railtie.rb
+++ b/lib/bugsnag/integrations/railtie.rb
@@ -81,7 +81,8 @@ module Bugsnag
         if event[:id] == "sql.active_record"
           binds = data[:binds].map { |bind| defined?(bind.name) ? [bind.name, '?'] : nil }
           binds.select! { |bind| bind }
-          filtered_data[:bindings] = JSON.dump(binds.to_h)
+          filtered_data[:bindings] = JSON.dump(binds.to_h) unless binds.empty?
+          filtered_data[:sql] = data[:sql].gsub(/(=|>|<|=>|=<|IN) (\S+)/, '\1 "?"')
         end
         Bugsnag.leave_breadcrumb(
           event[:message],

--- a/lib/bugsnag/integrations/railtie.rb
+++ b/lib/bugsnag/integrations/railtie.rb
@@ -73,9 +73,10 @@ module Bugsnag
     # @api private
     # @param event [Hash] details of the event to subscribe to
     def event_subscription(event)
-      ActiveSupport::Notifications.subscribe(event[:id]) do |*, data|
+      ActiveSupport::Notifications.subscribe(event[:id]) do |*, event_id, data|
         filtered_data = data.slice(*event[:allowed_data])
         filtered_data[:event_name] = event[:id]
+        filtered_data[:event_id] = event_id
         Bugsnag.leave_breadcrumb(
           event[:message],
           filtered_data,


### PR DESCRIPTION
## Goal
- Adds the capture of the `event_id` for each event
- Captures the SQL string of ActiveRecord queries <- Now split out into separate (later) task.
- Captures binding keys of ActiveRecord queries, with values explicitly redacted