### PR TITLE
Fix v6 regression in Resque integration by setting context explicitly

### DIFF
--- a/lib/bugsnag/integrations/resque.rb
+++ b/lib/bugsnag/integrations/resque.rb
@@ -43,7 +43,8 @@ module Bugsnag
           :type => Bugsnag::Report::UNHANDLED_EXCEPTION_MIDDLEWARE,
           :attributes => FRAMEWORK_ATTRIBUTES
         }
-        report.meta_data.merge!({:context => "#{payload['class']}@#{queue}", :payload => payload})
+        report.context = "#{payload['class']}@#{queue}"
+        report.meta_data[:payload] = payload
       end
     end
   end

--- a/lib/bugsnag/integrations/resque.rb
+++ b/lib/bugsnag/integrations/resque.rb
@@ -43,8 +43,10 @@ module Bugsnag
           :type => Bugsnag::Report::UNHANDLED_EXCEPTION_MIDDLEWARE,
           :attributes => FRAMEWORK_ATTRIBUTES
         }
-        report.context = "#{payload['class']}@#{queue}"
-        report.meta_data[:payload] = payload
+
+        context = "#{payload['class']}@#{queue}"
+        report.meta_data.merge!({:context => context, :payload => payload})
+        report.context = context
       end
     end
   end

--- a/spec/integrations/resque_spec.rb
+++ b/spec/integrations/resque_spec.rb
@@ -71,12 +71,16 @@ describe 'Bugsnag::Resque', :order => :defined do
       :type => Bugsnag::Report::UNHANDLED_EXCEPTION_MIDDLEWARE,
       :attributes => Bugsnag::Resque::FRAMEWORK_ATTRIBUTES
     })
-    expect(report).to receive(:context=).with("class@queue")
+    expected_context = "class@queue"
     meta_data = double('meta_data')
     expect(report).to receive(:meta_data).and_return(meta_data)
-    expect(meta_data).to receive(:[]=).with(:payload, {
-      "class" => "class"
+    expect(meta_data).to receive(:merge!).with({
+      :context => expected_context,
+      :payload => {
+        "class" => "class"
+      }
     })
+    expect(report).to receive(:context=).with(expected_context)
     expect(Bugsnag).to receive(:notify).with(exception, true).and_yield(report)
     resque.save
   end

--- a/spec/integrations/resque_spec.rb
+++ b/spec/integrations/resque_spec.rb
@@ -71,13 +71,11 @@ describe 'Bugsnag::Resque', :order => :defined do
       :type => Bugsnag::Report::UNHANDLED_EXCEPTION_MIDDLEWARE,
       :attributes => Bugsnag::Resque::FRAMEWORK_ATTRIBUTES
     })
+    expect(report).to receive(:context=).with("class@queue")
     meta_data = double('meta_data')
     expect(report).to receive(:meta_data).and_return(meta_data)
-    expect(meta_data).to receive(:merge!).with({
-      :context => "class@queue",
-      :payload => {
-        "class" => "class"
-      }
+    expect(meta_data).to receive(:[]=).with(:payload, {
+      "class" => "class"
     })
     expect(Bugsnag).to receive(:notify).with(exception, true).and_yield(report)
     resque.save


### PR DESCRIPTION
## Goal

- fix a regression introduced in v6.0 (Notification -> Report refactor) where the Resque job class and queue were no longer being set and shown in the Bugsnag dashboard
   - in v5, Resque context was sent to `auto_notify` as one of the `@overrides`, and was eventually set on the Notification during `deliver`: https://github.com/bugsnag/bugsnag-ruby/blob/v5.5.0/lib/bugsnag/notification.rb#L242-L242
   - in v6, however, Resque context is set in the `meta_data`, and meta_data keys do not override public Report setters in the same way
- the goal of this PR is fixing what seems like a regression in the Bugsnag Resque integration and showing a more helpful context in the Bugsnag dashboard than `resque:work` 

## Design

- this change is intended to be minimally invasive and keeps the context as part of the meta_data, while also setting it explicitly

## Changeset

- changed only `Bugsnag::Resque#save`

## Tests

- updated specs
- test locally using our own application's Bugsnag integration
   - asserted that after the change, the Bugsnag dashboard showed the Resque task name and queue as context rather than `resque:work`

Before (example):
![Screen Shot 2019-03-29 at 21 03 09](https://user-images.githubusercontent.com/721402/55271216-74ba0280-5266-11e9-8fb2-fa8ae378a900.png)

After (admittedly a different example, but it still shows the change):
![Screen Shot 2019-03-29 at 21 02 44](https://user-images.githubusercontent.com/721402/55271219-7aafe380-5266-11e9-9913-ccb3996352d1.png)



## Discussion

- n/a, but please LMK if this is too breaking, in that it does change the v6 context for Resque (admittedly fixing it back to what it was in v5)

### Linked issues

- n/a, but please LMK if you want me to file an issue for the regression

## Review

<!-- When submitting for review, consider the points for self-review and the
     criteria which will be used for secondary review -->

For the submitter, initial self-review:

- [x] Commented on code changes inline explain the reasoning behind the approach
- [x] Reviewed the test cases added for completeness and possible points for discussion
- [ ] A changelog entry was added for the goal of this pull request
- [x] Check the scope of the changeset - is everything in the diff required for the pull request?
- This pull request is ready for:
  - [ ] Initial review of the intended approach, not yet feature complete
  - [ ] Structural review of the classes, functions, and properties modified
  - [x] Final review

For the pull request reviewer(s), this changeset has been reviewed for:

- [ ] Consistency across platforms for structures or concepts added or modified
- [ ] Consistency between the changeset and the goal stated above
- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [ ] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [ ] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [ ] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language
