### PR TITLE
Update UPGRADING.md

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -67,3 +67,25 @@ guide](https://docs.bugsnag.com/api/deploy-tracking/capistrano/) for more inform
   + Bugsnag.configuration.logger.warn "Warn message"
   + Bugsnag.configuration.logger.debug "Debug message"
   ```
+
+#### Middleware
+
+* If you previously accessed objects directly through `notification.exceptions`, this has now moved to `notification.raw_exceptions`
+
+  ```diff
+  class ExampleMiddleware
+    def initialize(bugsnag)
+      @bugsnag = bugsnag
+    end
+
+    def call(report)
+  -   exception = report.exceptions.first
+  +   exception = report.raw_exceptions.first
+      status = report.response.status
+      
+      # do stuff
+      
+      @bugsnag.call(report)
+    end
+  end
+  ```


### PR DESCRIPTION
Hi there!

Forgive me not following the template; hopefully as this relates to documentation it's less relevant. 

I was just upgrading some of our apps from v5-6, and found a change that wasn't mentioned in this guide. We were using the `report.exceptions` objects to make various checks in a middleware, and I couldn't find this mentioned in the guide. 

Let me know if you want any changes!
Thanks,
Dan