### PR TITLE
Fix dead link in "set project_root"-warning

### DIFF
--- a/lib/bugsnag/integrations/rack.rb
+++ b/lib/bugsnag/integrations/rack.rb
@@ -20,7 +20,7 @@ module Bugsnag
           if defined?(settings)
             config.project_root = settings.root
           else
-            config.warn("You should set your app's project_root (see https://bugsnag.com/docs/notifiers/ruby#project_root).")
+            config.warn("You should set your app's project_root (see https://docs.bugsnag.com/platforms/ruby/rails/configuration-options/#project_root).")
           end
         end
 


### PR DESCRIPTION
## Goal

Fix dead link in warning:

```
** [Bugsnag] 2019-05-27 23:05:04 +0000: You should set your app's project_root (see https://bugsnag.com/docs/notifiers/ruby#project_root).
```

## Design


## Changeset

### Added

### Removed

### Changed


## Tests

## Discussion

### Alternative Approaches

### Outstanding Questions


### Linked issues


## Review

<!-- When submitting for review, consider the points for self-review and the
     criteria which will be used for secondary review -->

For the submitter, initial self-review:

- [ ] Commented on code changes inline explain the reasoning behind the approach
- [ ] Reviewed the test cases added for completeness and possible points for discussion
- [ ] A changelog entry was added for the goal of this pull request
- [ ] Check the scope of the changeset - is everything in the diff required for the pull request?
- This pull request is ready for:
  - [ ] Initial review of the intended approach, not yet feature complete
  - [ ] Structural review of the classes, functions, and properties modified
  - [ ] Final review

For the pull request reviewer(s), this changeset has been reviewed for:

- [ ] Consistency across platforms for structures or concepts added or modified
- [ ] Consistency between the changeset and the goal stated above
- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [ ] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [ ] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [ ] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language