### PR TITLE
Specify redis gem version for Ruby 2.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,16 +3,16 @@ source "https://rubygems.org"
 ruby_version = Gem::Version.new(RUBY_VERSION)
 
 group :test, optional: true do
-    gem 'rake', RUBY_VERSION <= '1.9.3' ? '~> 11.3.0' : '~> 12.3.0'
-    gem 'rspec'
-    gem 'rspec-mocks'
-    gem 'rdoc', '~> 5.1.0'
-    gem 'pry'
-    gem 'addressable', '~> 2.3.8'
-    gem 'delayed_job' if RUBY_VERSION >= '2.2.2'
-    gem 'i18n', RUBY_VERSION <= '2.3.0' ? '1.4.0': '>1.4.0' if RUBY_VERSION >= '2.2.2'
-    gem 'webmock', RUBY_VERSION <= '1.9.3' ? '2.3.2': '>2.3.2'
-    gem 'hashdiff', RUBY_VERSION <= '1.9.3' ? '0.3.8': '>0.3.8'
+  gem 'rake', ruby_version <= Gem::Version.new('1.9.3') ? '~> 11.3.0' : '~> 12.3.0'
+  gem 'rspec'
+  gem 'rspec-mocks'
+  gem 'rdoc', '~> 5.1.0'
+  gem 'pry'
+  gem 'addressable', '~> 2.3.8'
+  gem 'delayed_job' if ruby_version >= Gem::Version.new('2.2.2')
+  gem 'i18n', ruby_version <= Gem::Version.new('2.3.0') ? '1.4.0': '>1.4.0' if ruby_version >= Gem::Version.new('2.2.2')
+  gem 'webmock', ruby_version <= Gem::Version.new('1.9.3') ? '2.3.2': '>2.3.2'
+  gem 'hashdiff', ruby_version <= Gem::Version.new('1.9.3') ? '0.3.8': '>0.3.8'
 end
 
 group :coverage, optional: true do
@@ -26,6 +26,7 @@ end
 
 group :sidekiq, optional: true do
   gem 'sidekiq', '~> 5.0.4'
+  # redis 4.1.2 dropped support for Ruby 2.2
   gem 'redis', ruby_version < Gem::Version.new('2.3.0') ? '4.1.1' : '>= 4.1.2'
 end
 
@@ -34,7 +35,7 @@ group :doc, optional: true do
 end
 
 group :maze, optional: true do
-  gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner' if RUBY_VERSION >= '2.0.0'
+  gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner' if ruby_version >= Gem::Version.new('2.0.0')
 end
 
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source "https://rubygems.org"
 
+ruby_version = Gem::Version.new(RUBY_VERSION)
+
 group :test, optional: true do
     gem 'rake', RUBY_VERSION <= '1.9.3' ? '~> 11.3.0' : '~> 12.3.0'
     gem 'rspec'
@@ -24,6 +26,7 @@ end
 
 group :sidekiq, optional: true do
   gem 'sidekiq', '~> 5.0.4'
+  gem 'redis', ruby_version < Gem::Version.new('2.3.0') ? '4.1.1' : '>= 4.1.2'
 end
 
 group :doc, optional: true do


### PR DESCRIPTION
## Goal

Fix the Travis build for Ruby 2.2 and Sidekiq. I also started using `Gem::Version` as that seems to be more accurate, especially when version components are more than one digit.


## Review

<!-- When submitting for review, consider the points for self-review and the
     criteria which will be used for secondary review -->

For the submitter, initial self-review:

- [x] Commented on code changes inline explain the reasoning behind the approach
- [ ] Reviewed the test cases added for completeness and possible points for discussion
- [ ] A changelog entry was added for the goal of this pull request
- [ ] Check the scope of the changeset - is everything in the diff required for the pull request?
- This pull request is ready for:
  - [x] Initial review of the intended approach, not yet feature complete
  - [x] Structural review of the classes, functions, and properties modified
  - [x] Final review

For the pull request reviewer(s), this changeset has been reviewed for:

- [ ] Consistency across platforms for structures or concepts added or modified
- [ ] Consistency between the changeset and the goal stated above
- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [ ] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [ ] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [ ] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language
