### PR TITLE
Handle cases where job is nil in Que error notifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 Changelog
 =========
 
+## TBD
+
+### Fixes
+
+* Handle `nil` values for the `job` block parameter for the Que error notifier.
+  This occurs under some conditions such as database connection failures.
+  | [#545](https://github.com/bugsnag/bugsnag-ruby/issues/545)
+  | [#548](https://github.com/bugsnag/bugsnag-ruby/pull/548)
+
 ## 6.11.1 (22 Jan 2019)
 
 ### Fixes


### PR DESCRIPTION
## Goal

To handle cases where the `job` block parameter is `nil`. According to https://github.com/chanks/que/blob/master/docs/error_handling.md#error-notifications this occurs on database connection failures and similar errors.

## Changeset

### Added
`nil`/false check in lib/bugsnag/integrations/que.rb

### Linked issues

Fixes #545 

## Review

For the submitter, initial self-review:

- [ ] Commented on code changes inline explain the reasoning behind the approach
- [x] Reviewed the test cases added for completeness and possible points for discussion
- [x] A changelog entry was added for the goal of this pull request
- [ ] Check the scope of the changeset - is everything in the diff required for the pull request?
- This pull request is ready for:
  - [ ] Initial review of the intended approach, not yet feature complete
  - [ ] Structural review of the classes, functions, and properties modified
  - [x] Final review

For the pull request reviewer(s), this changeset has been reviewed for:

- [ ] Consistency across platforms for structures or concepts added or modified
- [ ] Consistency between the changeset and the goal stated above
- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [ ] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [ ] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [ ] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language
