### PR TITLE
Upgrade sidekiq in Gemfile to 5.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ group :rubocop, optional: true do
 end
 
 group :sidekiq, optional: true do
-  gem 'sidekiq', '~> 5.0.4'
+  gem 'sidekiq', '~> 5.2.7'
   # redis 4.1.2 dropped support for Ruby 2.2
   gem 'redis', ruby_version < Gem::Version.new('2.3.0') ? '4.1.1' : '>= 4.1.2'
 end


### PR DESCRIPTION
The Travis CI build is failing on Ruby 2.2 due to a version check bug in Sidekiq. Sidekiq 5.1.3 has a fix for this.

See https://github.com/mperham/sidekiq/pull/3808

Example of a build failure: https://travis-ci.com/bugsnag/bugsnag-ruby/jobs/221513135

Other (likely unrelated) tests are failing too, but I didn't get to investigating them yet.