### PR TITLE
Use IO.open for logger integration tests

### DIFF
--- a/spec/integrations/logger_spec.rb
+++ b/spec/integrations/logger_spec.rb
@@ -83,18 +83,14 @@ describe 'Configuration.logger' do
     key_warning = /\[Bugsnag\] .* No valid API key has been set, notifications will not be sent/
 
     def run_app(name)
-      out_reader, out_writer = IO.pipe
+      output = ''
       Dir.chdir(File.join(File.dirname(__FILE__), "../fixtures/apps/scripts")) do
         Bundler.with_clean_env do
-          pid = Process.spawn(@env, "bundle exec ruby #{name}.rb",
-                              out: out_writer.fileno,
-                              err: out_writer.fileno)
-          Process.waitpid(pid, 0)
+          IO.popen([@env, 'bundle', 'exec', 'ruby', "#{name}.rb", err: [:child, :out]]) do |io|
+            output << io.read
+          end
         end
       end
-      out_writer.close
-      output = ""
-      output << out_reader.gets until out_reader.eof?
       output
     end
 


### PR DESCRIPTION
It looks like the previous code worked on Java 8 on Travis CI, but stopped working on Java 11.

This along with https://github.com/bugsnag/bugsnag-ruby/pull/557 should fix the build on Travis CI.