### PR TITLE
Use Module#prepend for Rake integration if Ruby version is new enough

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ Changelog
 
 ### Fixes
 
+* Use `Module#prepend` for Rake integration when on a new enough Ruby version
+  to avoid infinite mutual recursion issues when something else monkey patches
+  `Rake::Task`.
+  | [#556](https://github.com/bugsnag/bugsnag-ruby/issues/556)
+  | [#559](https://github.com/bugsnag/bugsnag-ruby/issues/559)
+
 * Handle `nil` values for the `job` block parameter for the Que error notifier.
   This occurs under some conditions such as database connection failures.
   | [#545](https://github.com/bugsnag/bugsnag-ruby/issues/545)

--- a/lib/bugsnag/integrations/rake.rb
+++ b/lib/bugsnag/integrations/rake.rb
@@ -2,36 +2,66 @@ require 'bugsnag'
 
 Rake::TaskManager.record_task_metadata = true
 
-class Rake::Task
-
-  FRAMEWORK_ATTRIBUTES = {
-    :framework => "Rake"
-  }
-
-  ##
-  # Executes the rake task with Bugsnag setup with contextual data.
-  def execute_with_bugsnag(args=nil)
-    Bugsnag.configuration.app_type ||= "rake"
-    old_task = Bugsnag.configuration.request_data[:bugsnag_running_task]
-    Bugsnag.configuration.set_request_data :bugsnag_running_task, self
-
-    execute_without_bugsnag(args)
-
-  rescue Exception => ex
-    Bugsnag.notify(ex, true) do |report|
-      report.severity = "error"
-      report.severity_reason = {
-        :type => Bugsnag::Report::UNHANDLED_EXCEPTION_MIDDLEWARE,
-        :attributes => FRAMEWORK_ATTRIBUTES
+if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.0')
+  module Bugsnag
+    module RakeTask
+      FRAMEWORK_ATTRIBUTES = {
+        framework: 'Rake'
       }
+
+      # Executes the rake task with Bugsnag setup with contextual data.
+      def execute(args = nil)
+        Bugsnag.configuration.app_type ||= "rake"
+        old_task = Bugsnag.configuration.request_data[:bugsnag_running_task]
+        Bugsnag.configuration.set_request_data :bugsnag_running_task, self
+
+        super
+      rescue Exception => ex
+        Bugsnag.notify(ex, true) do |report|
+          report.severity = "error"
+          report.severity_reason = {
+            type: Bugsnag::Report::UNHANDLED_EXCEPTION_MIDDLEWARE,
+            attributes: FRAMEWORK_ATTRIBUTES
+          }
+        end
+        raise
+      ensure
+        Bugsnag.configuration.set_request_data :bugsnag_running_task, old_task
+      end
     end
-    raise
-  ensure
-    Bugsnag.configuration.set_request_data :bugsnag_running_task, old_task
   end
 
-  alias_method :execute_without_bugsnag, :execute
-  alias_method :execute, :execute_with_bugsnag
+  Rake::Task.send(:prepend, Bugsnag::RakeTask)
+else
+  class Rake::Task
+    FRAMEWORK_ATTRIBUTES = {
+      framework: 'Rake'
+    }
+
+    ##
+    # Executes the rake task with Bugsnag setup with contextual data.
+    def execute_with_bugsnag(args=nil)
+      Bugsnag.configuration.app_type ||= "rake"
+      old_task = Bugsnag.configuration.request_data[:bugsnag_running_task]
+      Bugsnag.configuration.set_request_data :bugsnag_running_task, self
+
+      execute_without_bugsnag(args)
+    rescue Exception => ex
+      Bugsnag.notify(ex, true) do |report|
+        report.severity = "error"
+        report.severity_reason = {
+          type: Bugsnag::Report::UNHANDLED_EXCEPTION_MIDDLEWARE,
+          attributes: FRAMEWORK_ATTRIBUTES
+        }
+      end
+      raise
+    ensure
+      Bugsnag.configuration.set_request_data :bugsnag_running_task, old_task
+    end
+
+    alias_method :execute_without_bugsnag, :execute
+    alias_method :execute, :execute_with_bugsnag
+  end
 end
 
 Bugsnag.configuration.internal_middleware.use(Bugsnag::Middleware::Rake)

--- a/spec/fixtures/tasks/Rakefile
+++ b/spec/fixtures/tasks/Rakefile
@@ -1,3 +1,15 @@
+if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.0')
+  # Mixing Module#prepend with alias_method can sometimes lead to infinite
+  # mutual recursion, so this is to test that it doesn't happen.
+  mod = Module.new do
+    def execute(args = nil)
+      puts 'In module prepended to Rake::Task'
+      super
+    end
+  end
+  Rake::Task.send(:prepend, mod)
+end
+
 require "bugsnag/integrations/rake"
 
 namespace :test do

--- a/spec/integrations/rake_spec.rb
+++ b/spec/integrations/rake_spec.rb
@@ -55,18 +55,15 @@ describe "Bugsnag Rake integration" do
     let(:request) { JSON.parse(queue.pop) }
 
     it 'should run the rake middleware when rake tasks crash' do
-      #Skips this test in ruby 1.9.3 with travis
-      unless ENV['TRAVIS'] && RUBY_VERSION == "1.9.3"
-        ENV['BUGSNAG_TEST_SERVER_PORT'] = server.config[:Port].to_s
-        task_fixtures_path = File.join(File.dirname(__FILE__), '../fixtures', 'tasks')
-        Dir.chdir(task_fixtures_path) do
-          system("bundle exec rake test:crash > /dev/null 2>&1")
-        end
-
-        result = request()
-        expect(result["events"][0]["metaData"]["rake_task"]).not_to be_nil
-        expect(result["events"][0]["metaData"]["rake_task"]["name"]).to eq("test:crash")
+      ENV['BUGSNAG_TEST_SERVER_PORT'] = server.config[:Port].to_s
+      task_fixtures_path = File.join(File.dirname(__FILE__), '../fixtures', 'tasks')
+      Dir.chdir(task_fixtures_path) do
+        system("bundle exec rake test:crash > /dev/null 2>&1")
       end
+
+      result = request()
+      expect(result["events"][0]["metaData"]["rake_task"]).not_to be_nil
+      expect(result["events"][0]["metaData"]["rake_task"]["name"]).to eq("test:crash")
     end
   end
 end


### PR DESCRIPTION
## Goal

To fix https://github.com/bugsnag/bugsnag-ruby/issues/556 (an infinite mutual recursion issue when something else monkey patches `Rake::Task` with `Module#prepend`)

## Changeset

### Changed
lib/bugsnag/integrations/rake.rb was updated to use `Module#prepend` if it was available on the currently running Ruby version.

## Tests

* spec/fixtures/tasks/Rakefile was changed so that the code previous to my lib changes would cause an infinite loop in some versions of Ruby
* The user who reported the issue mentioned that he no longer encounters the issue with my branch

## Discussion

### Alternative Approaches

Another approach might be to use a global or thread-local variable to keep track of Rake task names that are running and to return early if you encounter the same task name again, but that seems error-prone and possibly messy.

### Outstanding Questions

The duplicate logic is bad, but trying to figure out a way to refactor it with metaprogramming seemed bad too.

### Linked issues

Fixes #556

## Review

<!-- When submitting for review, consider the points for self-review and the
     criteria which will be used for secondary review -->

For the submitter, initial self-review:

- [ ] Commented on code changes inline explain the reasoning behind the approach
- [x] Reviewed the test cases added for completeness and possible points for discussion
- [x] A changelog entry was added for the goal of this pull request
- [x] Check the scope of the changeset - is everything in the diff required for the pull request?
- This pull request is ready for:
  - [ ] Initial review of the intended approach, not yet feature complete
  - [ ] Structural review of the classes, functions, and properties modified
  - [x] Final review

For the pull request reviewer(s), this changeset has been reviewed for:

- [ ] Consistency across platforms for structures or concepts added or modified
- [ ] Consistency between the changeset and the goal stated above
- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [ ] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [ ] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [ ] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language
