### PR TITLE
Allow symbols in breadcrumbs

### DIFF
--- a/lib/bugsnag/breadcrumbs/validator.rb
+++ b/lib/bugsnag/breadcrumbs/validator.rb
@@ -53,7 +53,7 @@ module Bugsnag::Breadcrumbs
     #
     # @param value [Object] the object to be type checked
     def valid_meta_data_type?(value)
-      value.nil? || value.is_a?(String) || value.is_a?(Numeric) || value.is_a?(FalseClass) || value.is_a?(TrueClass)
+      value.nil? || value.is_a?(String) || value.is_a?(Symbol) || value.is_a?(Numeric) || value.is_a?(FalseClass) || value.is_a?(TrueClass)
     end
   end
 end


### PR DESCRIPTION
Validate Symbol as an allowed type to breadcrumbs. I can't tell if this will have break something else, I can't trace everywhere it's used. 

Fixes https://github.com/bugsnag/bugsnag-ruby/issues/539

