### PR TITLE
Allow symbols in breadcrumb meta data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ Changelog
   | [#545](https://github.com/bugsnag/bugsnag-ruby/issues/545)
   | [#548](https://github.com/bugsnag/bugsnag-ruby/pull/548)
 
+* Allow symbols in breadcrumb meta data.
+  | [#563](https://github.com/bugsnag/bugsnag-ruby/pull/563)
+
 ## 6.11.1 (22 Jan 2019)
 
 ### Fixes

--- a/lib/bugsnag/breadcrumbs/validator.rb
+++ b/lib/bugsnag/breadcrumbs/validator.rb
@@ -53,7 +53,7 @@ module Bugsnag::Breadcrumbs
     #
     # @param value [Object] the object to be type checked
     def valid_meta_data_type?(value)
-      value.nil? || value.is_a?(String) || value.is_a?(Numeric) || value.is_a?(FalseClass) || value.is_a?(TrueClass)
+      value.nil? || value.is_a?(String) || value.is_a?(Symbol) || value.is_a?(Numeric) || value.is_a?(FalseClass) || value.is_a?(TrueClass)
     end
   end
 end

--- a/lib/bugsnag/breadcrumbs/validator.rb
+++ b/lib/bugsnag/breadcrumbs/validator.rb
@@ -49,7 +49,7 @@ module Bugsnag::Breadcrumbs
     ##
     # Tests whether the meta_data types are non-complex objects.
     #
-    # Acceptable types are String, Numeric, TrueClass, FalseClass, and nil.
+    # Acceptable types are String, Symbol, Numeric, TrueClass, FalseClass, and nil.
     #
     # @param value [Object] the object to be type checked
     def valid_meta_data_type?(value)

--- a/spec/breadcrumbs/validator_spec.rb
+++ b/spec/breadcrumbs/validator_spec.rb
@@ -64,6 +64,7 @@ RSpec.describe Bugsnag::Breadcrumbs::Validator do
 
         meta_data = {
           :string => "This is a string",
+          :symbol => :this_is_a_symbol,
           :integer => 12345,
           :float => 12345.6789,
           :false => false,


### PR DESCRIPTION
## Goal

Complex types are currently disallowed as values of metadata on breadcrumbs, however Symbols can be allowed as they will serialise to string without issue.

## Changeset

### Changed

* `validator.rb` - add Symbol type to list of allowed types

## Tests

* Added symbol as part of existing `validator_spec.rb` test

## Review

<!-- When submitting for review, consider the points for self-review and the
     criteria which will be used for secondary review -->

For the submitter, initial self-review:

- [x] Commented on code changes inline explain the reasoning behind the approach
- [x] Reviewed the test cases added for completeness and possible points for discussion
- [x] A changelog entry was added for the goal of this pull request
- [x] Check the scope of the changeset - is everything in the diff required for the pull request?
- This pull request is ready for:
  - [ ] Initial review of the intended approach, not yet feature complete
  - [ ] Structural review of the classes, functions, and properties modified
  - [x] Final review

For the pull request reviewer(s), this changeset has been reviewed for:

- [ ] Consistency across platforms for structures or concepts added or modified
- [ ] Consistency between the changeset and the goal stated above
- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [ ] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [ ] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [ ] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language
