### PR TITLE
Add Ruby 2.6 unit tests and coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,13 +53,18 @@ jobs:
   - stage: test
     env:
     - BUNDLE_VERSION=1.12.0
-    - GEMSETS="test sidekiq coverage"
+    - GEMSETS="test sidekiq"
     rvm: 2.5
   - stage: test
     env:
     - BUNDLE_VERSION=1.12.0
+    - GEMSETS="test sidekiq coverage"
+    rvm: 2.6
+  - stage: test
+    env:
+    - BUNDLE_VERSION=1.12.0
     - GEMSETS="test rubocop"
-    rvm: 2.5
+    rvm: 2.6
     script: bundle exec ./bin/rubocop lib/
   # - stage: test
   #   addons:


### PR DESCRIPTION
## Goal

Assures we have unit testing coverage on Ruby 2.6, and our coverage and doc tasks run against the latest Ruby version.

- Adds unit tests for Ruby 2.6
- Switches coverage to using Ruby 2.6
- Switches docs to using Ruby 2.6