### PR TITLE
Error loading with Que integration due to capitalised VERSION

### DIFF
--- a/lib/bugsnag/integrations/que.rb
+++ b/lib/bugsnag/integrations/que.rb
@@ -39,11 +39,11 @@ if defined?(::Que)
 
   if Que.respond_to?(:error_notifier=)
     Bugsnag.configuration.app_type ||= "que"
-    Bugsnag.configuration.runtime_versions["que"] = ::Que::Version
+    Bugsnag.configuration.runtime_versions["que"] = ::Que::VERSION
     Que.error_notifier = handler
   elsif Que.respond_to?(:error_handler=)
     Bugsnag.configuration.app_type ||= "que"
-    Bugsnag.configuration.runtime_versions["que"] = ::Que::Version
+    Bugsnag.configuration.runtime_versions["que"] = ::Que::VERSION
     Que.error_handler = handler
   end
 end

--- a/spec/integrations/que_spec.rb
+++ b/spec/integrations/que_spec.rb
@@ -6,7 +6,7 @@ describe 'Bugsnag::Que', :order => :defined do
     unless defined?(::Que)
       @mocked_que = true
       class ::Que
-        Version = '9.9.9'
+        VERSION = '9.9.9'
         class << self
           attr_accessor :error_notifier
         end
@@ -63,7 +63,7 @@ describe 'Bugsnag::Que', :order => :defined do
 
     #Kick off
     load './lib/bugsnag/integrations/que.rb'
-    
+
     expect(runtime).to eq("que" => "9.9.9")
   end
 


### PR DESCRIPTION
## Goal

Initialising bugsnag fails with `Que` due to titlecase `Version` expected, when `Que` uses uppercase `VERSION`

  * https://github.com/que-rb/que/blob/master/lib/que/version.rb#L4

<img width="694" alt="Screen Shot 2019-10-22 at 8 40 16 am" src="https://user-images.githubusercontent.com/19973/67245402-99e2bc80-f4a7-11e9-832e-b700e7ebd611.png">
