### PR TITLE
fix(que): handle change in capitalisation of framework version constant for Que in v1.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 Changelog
 =========
 
+## 6.12.2 (TBC)
+
+### Fixes
+
+* Handle change in capitalisation of framework version constant for Que in v1.x
+  | [#570](https://github.com/bugsnag/bugsnag-ruby/pull/570)
+  | [#572](https://github.com/bugsnag/bugsnag-ruby/pull/572)
+  | [tommeier](https://github.com/tommeier)
+
 ## 6.12.1 (05 Sep 2019)
 
 ### Fixes

--- a/lib/bugsnag/integrations/que.rb
+++ b/lib/bugsnag/integrations/que.rb
@@ -37,13 +37,16 @@ if defined?(::Que)
     end
   end
 
-  if Que.respond_to?(:error_notifier=)
-    Bugsnag.configuration.app_type ||= "que"
+  Bugsnag.configuration.app_type ||= "que"
+  if defined?(::Que::Version)
     Bugsnag.configuration.runtime_versions["que"] = ::Que::Version
+  elsif defined?(::Que::VERSION)
+    Bugsnag.configuration.runtime_versions["que"] = ::Que::VERSION
+  end
+
+  if Que.respond_to?(:error_notifier=)
     Que.error_notifier = handler
   elsif Que.respond_to?(:error_handler=)
-    Bugsnag.configuration.app_type ||= "que"
-    Bugsnag.configuration.runtime_versions["que"] = ::Que::Version
     Que.error_handler = handler
   end
 end


### PR DESCRIPTION
## Goal

As per @tommieer's fix in #570 but preserving backwards compatibility.

The ::Que::Version constant was capitalised in the beta 1.x branch and so this breaks reporting for this Que release.

## Changeset

### Changed

* que.rb - conditionally tested for existence of version constants

## Tests

* Manually tested on v0.14.3 and v1.0.0-beta3
* No changes to tests as the original spec still stands for the non-beta release.

### Linked issues

Related to #570

## Review

<!-- When submitting for review, consider the points for self-review and the
     criteria which will be used for secondary review -->

For the submitter, initial self-review:

- [x] Commented on code changes inline explain the reasoning behind the approach
- [x] Reviewed the test cases added for completeness and possible points for discussion
- [x] A changelog entry was added for the goal of this pull request
- [x] Check the scope of the changeset - is everything in the diff required for the pull request?
- This pull request is ready for:
  - [ ] Initial review of the intended approach, not yet feature complete
  - [ ] Structural review of the classes, functions, and properties modified
  - [x] Final review

For the pull request reviewer(s), this changeset has been reviewed for:

- [ ] Consistency across platforms for structures or concepts added or modified
- [ ] Consistency between the changeset and the goal stated above
- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [ ] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [ ] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [ ] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language
