### PR TITLE
Add tests targeting Ruby 2.7

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -249,8 +249,8 @@ steps:
     env:
       RUBY_TEST_VERSION: "2.6"
     command: features/plain_features/ --tags "not @wip"
-    concurreny: 8
-    concurreny_group: 'rails-tests'
+    concurrency: 8
+    concurrency_group: 'rails-tests'
 
   - label: ':ruby: Sidekiq 2 tests'
     plugins:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -20,41 +20,41 @@ steps:
     env:
       RUBY_TEST_VERSION: "1.9.3"
 
-  - label: ':ruby: Ruby 2.6 unit tests'
+  - label: ':ruby: Ruby 2.7 unit tests'
     plugins:
       docker-compose#v2.6.0:
         run: ruby-unit-tests
         use-aliases: true
     env:
-      RUBY_TEST_VERSION: "2.6"
+      RUBY_TEST_VERSION: "2.7"
       GEMSETS: "test sidekiq coverage"
 
-  - label: ':ruby: Ruby 2.6 linting'
+  - label: ':ruby: Ruby 2.7 linting'
     plugins:
       docker-compose#v2.6.0:
         run: ruby-unit-tests
         use-aliases: true
     env:
-      RUBY_TEST_VERSION: "2.6"
+      RUBY_TEST_VERSION: "2.7"
       GEMSETS: "test rubocop"
     command: "bundle exec ./bin/rubocop lib/"
 
-  - label: ':ruby: Ruby 2.6 plain tests'
+  - label: ':ruby: Ruby 2.7 plain tests'
     plugins:
       docker-compose#v2.6.0:
         run: ruby-maze-runner
         use-aliases: true
     env:
-      RUBY_TEST_VERSION: "2.6"
+      RUBY_TEST_VERSION: "2.7"
     command: features/plain_features/ --tags "not @wip"
 
-  - label: ':rails: Rails 6 Ruby 2.6 tests'
+  - label: ':rails: Rails 6 Ruby 2.7 tests'
     plugins:
       docker-compose#v2.6.0:
         run: ruby-maze-runner
         use-aliases: true
     env:
-      RUBY_TEST_VERSION: "2.6"
+      RUBY_TEST_VERSION: "2.7"
       RAILS_VERSION: "6"
     command: features/rails_features/ --tags "@rails6 and not @wip"
 
@@ -153,6 +153,17 @@ steps:
     concurrency: 8
     concurrency_group: 'rails-tests'
 
+  - label: ':ruby: Ruby 2.6 unit tests'
+    plugins:
+      docker-compose#v2.6.0:
+        run: ruby-unit-tests
+        use-aliases: true
+    env:
+      RUBY_TEST_VERSION: "2.6"
+      GEMSETS: "test sidekiq"
+    concurrency: 8
+    concurrency_group: 'rails-tests'
+
   - label: ':ruby: Ruby 1.9.3 plain tests'
     plugins:
       docker-compose#v2.6.0:
@@ -229,6 +240,17 @@ steps:
     command: features/plain_features --tags "not @wip"
     concurrency: 8
     concurrency_group: 'rails-tests'
+
+  - label: ':ruby: Ruby 2.6 plain tests'
+    plugins:
+      docker-compose#v2.6.0:
+        run: ruby-maze-runner
+        use-aliases: true
+    env:
+      RUBY_TEST_VERSION: "2.6"
+    command: features/plain_features/ --tags "not @wip"
+    concurreny: 8
+    concurreny_group: 'rails-tests'
 
   - label: ':ruby: Sidekiq 2 tests'
     plugins:
@@ -429,6 +451,18 @@ steps:
         use-aliases: true
     env:
       RUBY_TEST_VERSION: "2.5"
+      RAILS_VERSION: "6"
+    command: features/rails_features/ --tags "@rails6 and not @wip"
+    concurrency: 8
+    concurrency_group: 'rails-tests'
+
+  - label: ':rails: Rails 6 Ruby 2.6 tests'
+    plugins:
+      docker-compose#v2.6.0:
+        run: ruby-maze-runner
+        use-aliases: true
+    env:
+      RUBY_TEST_VERSION: "2.6"
       RAILS_VERSION: "6"
     command: features/rails_features/ --tags "@rails6 and not @wip"
     concurrency: 8

--- a/Gemfile
+++ b/Gemfile
@@ -15,7 +15,9 @@ group :test, optional: true do
   end
   gem 'webmock', ruby_version <= Gem::Version.new('1.9.3') ? '2.3.2': '>2.3.2'
   gem 'hashdiff', ruby_version <= Gem::Version.new('1.9.3') ? '0.3.8': '>0.3.8'
-  if ruby_version >= Gem::Version.new('2.5.0')
+  if ruby_version >= Gem::Version.new('2.7.0')
+    gem 'did_you_mean', '~> 1.4.0'
+  elsif ruby_version >= Gem::Version.new('2.5.0')
     gem 'did_you_mean', '~> 1.3.1'
   elsif ruby_version >= Gem::Version.new('2.4.0')
     gem 'did_you_mean', '~> 1.1.0'

--- a/lib/bugsnag/cleaner.rb
+++ b/lib/bugsnag/cleaner.rb
@@ -60,9 +60,9 @@ module Bugsnag
     def clean_string(str)
       if defined?(str.encoding) && defined?(Encoding::UTF_8)
         if str.encoding == Encoding::UTF_8
-          str.valid_encoding? ? str : str.encode('utf-16', ENCODING_OPTIONS).encode('utf-8')
+          str.valid_encoding? ? str : str.encode('utf-16', **ENCODING_OPTIONS).encode('utf-8')
         else
-          str.encode('utf-8', ENCODING_OPTIONS)
+          str.encode('utf-8', **ENCODING_OPTIONS)
         end
       elsif defined?(Iconv)
         Iconv.conv('UTF-8//IGNORE', 'UTF-8', str) || str

--- a/lib/bugsnag/cleaner.rb
+++ b/lib/bugsnag/cleaner.rb
@@ -60,9 +60,9 @@ module Bugsnag
     def clean_string(str)
       if defined?(str.encoding) && defined?(Encoding::UTF_8)
         if str.encoding == Encoding::UTF_8
-          str.valid_encoding? ? str : str.encode('utf-16', **ENCODING_OPTIONS).encode('utf-8')
+          str.valid_encoding? ? str : str.encode('utf-16', ENCODING_OPTIONS).encode('utf-8')
         else
-          str.encode('utf-8', **ENCODING_OPTIONS)
+          str.encode('utf-8', ENCODING_OPTIONS)
         end
       elsif defined?(Iconv)
         Iconv.conv('UTF-8//IGNORE', 'UTF-8', str) || str

--- a/spec/fixtures/apps/rails-initializer-config/Gemfile
+++ b/spec/fixtures/apps/rails-initializer-config/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 ruby_version = Gem::Version.new(RUBY_VERSION.dup)
 
-gem 'railties', '4.2.10', require: %w(action_controller rails)
+gem 'railties', ruby_version <= Gem::Version.new('2.6') ? '4.2.10' : '~> 6.0.2', require: %w(action_controller rails)
 gem 'rake', ruby_version <= Gem::Version.new('1.9.3') ? '~> 11.3.0' : '~> 12.3.0'
 gem 'minitest', ruby_version <= Gem::Version.new('2.2') ? '5.11.3' : '~> 5.13.0'
 gem 'nokogiri', '1.6.8'

--- a/spec/fixtures/apps/rails-invalid-initializer-config/Gemfile
+++ b/spec/fixtures/apps/rails-invalid-initializer-config/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 ruby_version = Gem::Version.new(RUBY_VERSION.dup)
 
-gem 'railties', '4.2.10', require: %w(action_controller rails)
+gem 'railties', ruby_version <= Gem::Version.new('2.6') ? '4.2.10' : '~> 6.0.2', require: %w(action_controller rails)
 gem 'rake', ruby_version <= Gem::Version.new('1.9.3') ? '~> 11.3.0' : '~> 12.3.0'
 gem 'minitest', ruby_version <= Gem::Version.new('2.2') ? '5.11.3' : '~> 5.13.0'
 gem 'nokogiri', '1.6.8'

--- a/spec/fixtures/apps/rails-no-config/Gemfile
+++ b/spec/fixtures/apps/rails-no-config/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 ruby_version = Gem::Version.new(RUBY_VERSION.dup)
 
-gem 'railties', '4.2.10', require: %w(action_controller rails)
+gem 'railties', ruby_version <= Gem::Version.new('2.6') ? '4.2.10' : '~> 6.0.2', require: %w(action_controller rails)
 gem 'rake', ruby_version <= Gem::Version.new('1.9.3') ? '~> 11.3.0' : '~> 12.3.0'
 gem 'minitest', ruby_version <= Gem::Version.new('2.2') ? '5.11.3' : '~> 5.13.0'
 gem 'nokogiri', '1.6.8'

--- a/spec/integrations/logger_spec.rb
+++ b/spec/integrations/logger_spec.rb
@@ -61,7 +61,7 @@ describe 'Configuration.logger' do
       end
     end
 
-    context 'sets an invalid API key using the BUGSNAG_API_KEY env var' do
+    context 'when the API key is invalid in the bugsnag initializer' do
       it 'logs a warning' do
         skip "Incompatible with Ruby <2.0 and JRuby" if incompatible
         output = run_app('rails-invalid-initializer-config')


### PR DESCRIPTION
## Goal

Updates the pipeline to run against Ruby 2.7, ensuring the notifier works in the latest release of Ruby.

Minor changes have been made to ensure the unit tests run correctly.