### PR TITLE
Guard against exceptions in to_s when cleaning objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ Changelog
   | [#586](https://github.com/bugsnag/bugsnag-ruby/pull/586)
   | [stoivo](https://github.com/stoivo)
 
+### Fixes
+
+* Guard against exceptions in to_s when cleaning objects
+  | [#591](https://github.com/bugsnag/bugsnag-ruby/pull/591)
+
 ## 6.13.0 (30 Jan 2020)
 
 ### Enhancements

--- a/lib/bugsnag/cleaner.rb
+++ b/lib/bugsnag/cleaner.rb
@@ -43,7 +43,13 @@ module Bugsnag
       when String
         clean_string(obj)
       else
-        str = obj.to_s rescue RAISED
+        # guard against objects that raise or blow the stack when stringified
+        begin
+          str = obj.to_s rescue RAISED
+        rescue SystemStackError
+          str = RECURSION
+        end
+
         # avoid leaking potentially sensitive data from objects' #inspect output
         if str =~ /#<.*>/
           OBJECT
@@ -96,7 +102,13 @@ module Bugsnag
     private
 
     def filters_match?(key)
-      str = key.to_s
+      # If we can't stringify this key, we assume it needs to be filtered to
+      # avoid leaking things we shouldn't
+      begin
+        str = key.to_s
+      rescue StandardError, SystemStackError
+        return true
+      end
 
       @filters.any? do |f|
         case f

--- a/lib/bugsnag/cleaner.rb
+++ b/lib/bugsnag/cleaner.rb
@@ -45,7 +45,9 @@ module Bugsnag
       else
         # guard against objects that raise or blow the stack when stringified
         begin
-          str = obj.to_s rescue RAISED
+          str = obj.to_s
+        rescue StandardError
+          str = RAISED
         rescue SystemStackError
           str = RECURSION
         end

--- a/spec/cleaner_spec.rb
+++ b/spec/cleaner_spec.rb
@@ -6,6 +6,8 @@ describe Bugsnag::Cleaner do
   subject { described_class.new(nil) }
 
   describe "#clean_object" do
+    is_jruby = defined?(RUBY_ENGINE) && RUBY_ENGINE == 'jruby'
+
     it "cleans up recursive hashes" do
       a = {:a => {}}
       a[:a][:b] = a
@@ -13,6 +15,8 @@ describe Bugsnag::Cleaner do
     end
 
     it "cleans up hashes when keys infinitely recurse in to_s" do
+      skip "JRuby doesn't allow recovery from SystemStackErrors" if is_jruby
+
       class RecursiveHashKey
         def to_s
           to_s
@@ -79,6 +83,8 @@ describe Bugsnag::Cleaner do
     end
 
     it "cleans custom objects when they infinitely recurse" do
+      skip "JRuby doesn't allow recovery from SystemStackErrors" if is_jruby
+
       class RecursiveObject
         def to_s
           to_s


### PR DESCRIPTION
## Goal

<!-- What is the intent of this change?
e.g. "When initializing the Bugsnag client, it is currently difficult to (...)
      this change simplifies the process by (...)"

     "Improves the performance of data filtering"

     "Adds additional test coverage to multi-threaded use of Configuration
      objects"
-->

When sending notifications we run through a "cleaning" stage which does things like filter out any keys that we shouldn't send in the error report (e.g. passwords). This calls `to_s` in a couple of different places, which can cause issues as objects are free to implement any logic and can therefore throw exceptions or infinitely recurse, which means we end up crashing while trying to cleanup the object

In this PR we'll now recover from exceptions and stack overflows by replacing the values with one of our existing replacement strings:

1. `[RECURSION]` if we get a `SystemStackError` when stringifying a plain object
1. `[FILTERED]` if we get an exception when attempting to filter keys in a hash map — if an exception happens we can't tell if we should filter the key, so we have to assume we need to

This means the error report will have less information that intended, but this should be rare and if it does happen then the alternative is no report at all

<!-- For new features, include design documentation:

## Design

Why was this approach to the goal used?

-->

## Changeset

<!-- What structures or properties or functions were:

### Added

### Removed

### Changed

-->

### Changed

- Rescue `SystemStackError` as well as other exceptions when calling `to_s` on an object
- Rescue `StandardError` and `SystemStackError` when calling `to_s` on a key when filtering a hash map

## Tests

<!-- How was this change tested? What manual and automated tests were
     run/added? -->

Tests have been added for:
- hash keys that throw during `to_s`
- hash values that throw during `to_s`
- custom objects that infinitely recurse during `to_s`

## Discussion

### Alternative Approaches

<!-- What other approaches were considered or discussed? -->

### Outstanding Questions

<!-- Are there any parts of the design or the implementation which seem
     less than ideal and that could require additional discussion?
     List here: -->

### Linked issues

<!--

Fixes #
Related to #

-->

Related to #577

## Review

<!-- When submitting for review, consider the points for self-review and the
     criteria which will be used for secondary review -->

For the submitter, initial self-review:

- [x] Commented on code changes inline explain the reasoning behind the approach
- [x] Reviewed the test cases added for completeness and possible points for discussion
- [x] A changelog entry was added for the goal of this pull request
- [x] Check the scope of the changeset - is everything in the diff required for the pull request?
- This pull request is ready for:
  - [ ] Initial review of the intended approach, not yet feature complete
  - [ ] Structural review of the classes, functions, and properties modified
  - [x] Final review

For the pull request reviewer(s), this changeset has been reviewed for:

- [ ] Consistency across platforms for structures or concepts added or modified
- [ ] Consistency between the changeset and the goal stated above
- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [ ] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [ ] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [ ] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language
