### PR TITLE
Replace keys with safe values when to_s fails

### DIFF
--- a/spec/helper_spec.rb
+++ b/spec/helper_spec.rb
@@ -50,6 +50,53 @@ describe Bugsnag::Helpers do
         value = Bugsnag::Helpers.trim_if_needed([1, 3, StringRaiser.new])
         expect(value[2]).to eq "[RAISED]"
       end
+
+      it "replaces hash key with '[RAISED]'" do
+        a = {}
+        a[StringRaiser.new] = 1
+
+        value = Bugsnag::Helpers.trim_if_needed(a)
+        expect(value).to eq({ "[RAISED]" => "[FILTERED]" })
+      end
+
+      it "uses a single '[RAISED]'key when multiple keys raise" do
+        a = {}
+        a[StringRaiser.new] = 1
+        a[StringRaiser.new] = 2
+
+        value = Bugsnag::Helpers.trim_if_needed(a)
+        expect(value).to eq({ "[RAISED]" => "[FILTERED]" })
+      end
+    end
+
+    context "an object will infinitely recurse if `to_s` is called" do
+      class StringRecurser
+        def to_s
+          to_s
+        end
+      end
+
+      it "uses the string '[RECURSION]' instead" do
+        value = Bugsnag::Helpers.trim_if_needed([1, 3, StringRecurser.new])
+        expect(value[2]).to eq "[RECURSION]"
+      end
+
+      it "replaces hash key with '[RECURSION]'" do
+        a = {}
+        a[StringRecurser.new] = 1
+
+        value = Bugsnag::Helpers.trim_if_needed(a)
+        expect(value).to eq({ "[RECURSION]" => "[FILTERED]" })
+      end
+
+      it "uses a single '[RECURSION]'key when multiple keys recurse" do
+        a = {}
+        a[StringRecurser.new] = 1
+        a[StringRecurser.new] = 2
+
+        value = Bugsnag::Helpers.trim_if_needed(a)
+        expect(value).to eq({ "[RECURSION]" => "[FILTERED]" })
+      end
     end
 
     context "payload length is less than allowed" do

--- a/spec/helper_spec.rb
+++ b/spec/helper_spec.rb
@@ -70,6 +70,8 @@ describe Bugsnag::Helpers do
     end
 
     context "an object will infinitely recurse if `to_s` is called" do
+      is_jruby = defined?(RUBY_ENGINE) && RUBY_ENGINE == 'jruby'
+
       class StringRecurser
         def to_s
           to_s
@@ -77,11 +79,15 @@ describe Bugsnag::Helpers do
       end
 
       it "uses the string '[RECURSION]' instead" do
+        skip "JRuby doesn't allow recovery from SystemStackErrors" if is_jruby
+
         value = Bugsnag::Helpers.trim_if_needed([1, 3, StringRecurser.new])
         expect(value[2]).to eq "[RECURSION]"
       end
 
       it "replaces hash key with '[RECURSION]'" do
+        skip "JRuby doesn't allow recovery from SystemStackErrors" if is_jruby
+
         a = {}
         a[StringRecurser.new] = 1
 
@@ -90,6 +96,8 @@ describe Bugsnag::Helpers do
       end
 
       it "uses a single '[RECURSION]'key when multiple keys recurse" do
+        skip "JRuby doesn't allow recovery from SystemStackErrors" if is_jruby
+
         a = {}
         a[StringRecurser.new] = 1
         a[StringRecurser.new] = 2


### PR DESCRIPTION
## Goal

<!-- What is the intent of this change?
e.g. "When initializing the Bugsnag client, it is currently difficult to (...)
      this change simplifies the process by (...)"

     "Improves the performance of data filtering"

     "Adds additional test coverage to multi-threaded use of Configuration
      objects"
-->

This PR fixes a issue with https://github.com/bugsnag/bugsnag-ruby/pull/591 where we filter the value of a hash if its key raises, but we leave the key alone. That means that code later on can cause the same issue we were trying to fix — if they run `to_s` on the key then it will raise or infinitely recurse


## Review

<!-- When submitting for review, consider the points for self-review and the
     criteria which will be used for secondary review -->

For the submitter, initial self-review:

- [x] Commented on code changes inline explain the reasoning behind the approach
- [x] Reviewed the test cases added for completeness and possible points for discussion
- [ ] A changelog entry was added for the goal of this pull request
- [x] Check the scope of the changeset - is everything in the diff required for the pull request?
- This pull request is ready for:
  - [ ] Initial review of the intended approach, not yet feature complete
  - [ ] Structural review of the classes, functions, and properties modified
  - [x] Final review

For the pull request reviewer(s), this changeset has been reviewed for:

- [ ] Consistency across platforms for structures or concepts added or modified
- [ ] Consistency between the changeset and the goal stated above
- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [ ] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [ ] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [ ] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language
