### PR TITLE
Add discard_classes option to support strings & regular expressions and deprecate ignore_classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 Changelog
 =========
 
+## TBD
+
+### Enhancements
+
+* Add configurable `discard_classes` option to allow filtering errors using either a `String` or `Regexp` matched against the error's class name
+  | [#597](https://github.com/bugsnag/bugsnag-ruby/pull/597)
+
+### Deprecated
+* The `ignore_classes` configuration option has been deprecated in favour of `discard_classes`. `ignore_classes` will be removed in the next major release
+
 ## 6.13.1 (11 May 2020)
 
 ### Fixes

--- a/lib/bugsnag.rb
+++ b/lib/bugsnag.rb
@@ -147,6 +147,7 @@ module Bugsnag
     # Configuration getters
     ##
     # Returns the client's Configuration object, or creates one if not yet created.
+    # @return [Configuration]
     def configuration
       @configuration = nil unless defined?(@configuration)
       @configuration || LOCK.synchronize { @configuration ||= Bugsnag::Configuration.new }

--- a/lib/bugsnag/configuration.rb
+++ b/lib/bugsnag/configuration.rb
@@ -127,8 +127,10 @@ module Bugsnag
 
       # SystemExit and SignalException are common Exception types seen with
       # successful exits and are not automatically reported to Bugsnag
+      # TODO move these defaults into `discard_classes` when `ignore_classes`
+      #      is removed
       self.ignore_classes = Set.new([SystemExit, SignalException])
-      self.discard_classes = Set.new(["SystemExit", "SignalException"])
+      self.discard_classes = Set.new([])
 
       # Read the API key from the environment
       self.api_key = ENV["BUGSNAG_API_KEY"]

--- a/lib/bugsnag/configuration.rb
+++ b/lib/bugsnag/configuration.rb
@@ -3,6 +3,7 @@ require "socket"
 require "logger"
 require "bugsnag/middleware_stack"
 require "bugsnag/middleware/callbacks"
+require "bugsnag/middleware/discard_error_class"
 require "bugsnag/middleware/exception_meta_data"
 require "bugsnag/middleware/ignore_error_class"
 require "bugsnag/middleware/suggestion_data"
@@ -36,6 +37,7 @@ module Bugsnag
     attr_accessor :hostname
     attr_accessor :runtime_versions
     attr_accessor :ignore_classes
+    attr_accessor :discard_classes
     attr_accessor :auto_capture_sessions
 
     ##
@@ -123,6 +125,7 @@ module Bugsnag
       # SystemExit and SignalException are common Exception types seen with
       # successful exits and are not automatically reported to Bugsnag
       self.ignore_classes = Set.new([SystemExit, SignalException])
+      self.discard_classes = Set.new(["SystemExit", "SignalException"])
 
       # Read the API key from the environment
       self.api_key = ENV["BUGSNAG_API_KEY"]
@@ -147,6 +150,7 @@ module Bugsnag
       # Configure the bugsnag middleware stack
       self.internal_middleware = Bugsnag::MiddlewareStack.new
       self.internal_middleware.use Bugsnag::Middleware::ExceptionMetaData
+      self.internal_middleware.use Bugsnag::Middleware::DiscardErrorClass
       self.internal_middleware.use Bugsnag::Middleware::IgnoreErrorClass
       self.internal_middleware.use Bugsnag::Middleware::SuggestionData
       self.internal_middleware.use Bugsnag::Middleware::ClassifyError

--- a/lib/bugsnag/configuration.rb
+++ b/lib/bugsnag/configuration.rb
@@ -36,9 +36,12 @@ module Bugsnag
     attr_accessor :timeout
     attr_accessor :hostname
     attr_accessor :runtime_versions
-    attr_accessor :ignore_classes
     attr_accessor :discard_classes
     attr_accessor :auto_capture_sessions
+
+    ##
+    # @deprecated Use {#discard_classes} instead
+    attr_accessor :ignore_classes
 
     ##
     # @return [String] URL error notifications will be delivered to

--- a/lib/bugsnag/middleware/discard_error_class.rb
+++ b/lib/bugsnag/middleware/discard_error_class.rb
@@ -1,0 +1,30 @@
+module Bugsnag::Middleware
+  ##
+  # Determines if the exception should be ignored based on the configured
+  # `discard_classes`
+  class DiscardErrorClass
+    ##
+    # @param middleware [#call] The next middleware to call
+    def initialize(middleware)
+      @middleware = middleware
+    end
+
+    ##
+    # @param report [Report]
+    def call(report)
+      ignore_error_class = report.raw_exceptions.any? do |ex|
+        report.configuration.discard_classes.any? do |to_ignore|
+          case to_ignore
+          when String then to_ignore == ex.class.name
+          when Regexp then to_ignore =~ ex.class.name
+          else false
+          end
+        end
+      end
+
+      report.ignore! if ignore_error_class
+
+      @middleware.call(report)
+    end
+  end
+end

--- a/lib/bugsnag/middleware/discard_error_class.rb
+++ b/lib/bugsnag/middleware/discard_error_class.rb
@@ -12,7 +12,7 @@ module Bugsnag::Middleware
     ##
     # @param report [Report]
     def call(report)
-      ignore_error_class = report.raw_exceptions.any? do |ex|
+      should_discard = report.raw_exceptions.any? do |ex|
         report.configuration.discard_classes.any? do |to_ignore|
           case to_ignore
           when String then to_ignore == ex.class.name
@@ -22,7 +22,7 @@ module Bugsnag::Middleware
         end
       end
 
-      report.ignore! if ignore_error_class
+      report.ignore! if should_discard
 
       @middleware.call(report)
     end

--- a/lib/bugsnag/middleware/ignore_error_class.rb
+++ b/lib/bugsnag/middleware/ignore_error_class.rb
@@ -2,6 +2,8 @@ module Bugsnag::Middleware
   ##
   # Determines if the exception should be ignored based on the configured
   # `ignore_classes`
+  #
+  # @deprecated Use {DiscardErrorClass} instead
   class IgnoreErrorClass
     def initialize(bugsnag)
       @bugsnag = bugsnag

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -336,8 +336,8 @@ describe Bugsnag::Configuration do
     expect(subject.ignore_classes).to eq(Set.new([SystemExit, SignalException]))
   end
 
-  it "should have exit exception classes in discard_classes by default" do
-    expect(subject.discard_classes).to eq(Set.new(["SystemExit", "SignalException"]))
+  it "should have nothing in discard_classes by default" do
+    expect(subject.discard_classes).to eq(Set.new([]))
   end
 
   describe "#breadcrumbs" do

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -332,8 +332,12 @@ describe Bugsnag::Configuration do
     end
   end
 
-  it "should have exit exception classes ignored by default" do
+  it "should have exit exception classes in ignore_classes by default" do
     expect(subject.ignore_classes).to eq(Set.new([SystemExit, SignalException]))
+  end
+
+  it "should have exit exception classes in discard_classes by default" do
+    expect(subject.discard_classes).to eq(Set.new(["SystemExit", "SignalException"]))
   end
 
   describe "#breadcrumbs" do

--- a/spec/report_spec.rb
+++ b/spec/report_spec.rb
@@ -803,6 +803,19 @@ describe Bugsnag::Report do
           expect(exception["message"]).to eq("It crashed")
         }
       end
+
+      it "does not discard exception when its ancestor is discarded" do
+        Bugsnag.configuration.discard_classes << "BugsnagTestException"
+
+        Bugsnag.notify(BugsnagSubclassTestException.new("It crashed"))
+
+        expect(Bugsnag).to have_sent_notification { |payload, headers|
+          exception = get_exception_from_payload(payload)
+
+          expect(exception["errorClass"]).to eq("BugsnagSubclassTestException")
+          expect(exception["message"]).to eq("It crashed")
+        }
+      end
     end
 
     context "as a regexp" do
@@ -834,6 +847,19 @@ describe Bugsnag::Report do
           exception = get_exception_from_payload(payload)
 
           expect(exception["errorClass"]).to eq("BugsnagTestException")
+          expect(exception["message"]).to eq("It crashed")
+        }
+      end
+
+      it "does not discard exception when its ancestor is discarded" do
+        Bugsnag.configuration.discard_classes << /^BugsnagTest.*/
+
+        Bugsnag.notify(BugsnagSubclassTestException.new("It crashed"))
+
+        expect(Bugsnag).to have_sent_notification { |payload, headers|
+          exception = get_exception_from_payload(payload)
+
+          expect(exception["errorClass"]).to eq("BugsnagSubclassTestException")
           expect(exception["message"]).to eq("It crashed")
         }
       end

--- a/spec/report_spec.rb
+++ b/spec/report_spec.rb
@@ -148,13 +148,11 @@ describe Bugsnag::Report do
 
   it "sets correct severity and reason for specific error classes" do
     original_ignore_classes = Bugsnag.configuration.ignore_classes
-    original_discard_classes = Bugsnag.configuration.discard_classes
 
     begin
-      # The default ignore/discard classes includes SignalException, so we need
-      # to temporarily set them to something else.
+      # The default ignore classes includes SignalException, so we need to
+      # temporarily set it to something else.
       Bugsnag.configuration.ignore_classes = Set[SystemExit]
-      Bugsnag.configuration.discard_classes = Set["SystemExit"]
 
       Bugsnag.notify(SignalException.new("TERM"))
 
@@ -171,7 +169,6 @@ describe Bugsnag::Report do
       }
     ensure
       Bugsnag.configuration.ignore_classes = original_ignore_classes
-      Bugsnag.configuration.discard_classes = original_discard_classes
     end
   end
 


### PR DESCRIPTION
## Goal

<!-- What is the intent of this change?
e.g. "When initializing the Bugsnag client, it is currently difficult to (...)
      this change simplifies the process by (...)"

     "Improves the performance of data filtering"

     "Adds additional test coverage to multi-threaded use of Configuration
      objects"
-->

The `ignore_classes` option currently supports `Class` constants and `Proc`. Rails has recently deprecated autoloading in initialization (where Bugsnag is usually configured) which makes `Class` constants unusable. Support for `Proc` is powerful but un-ergonomic when simply trying to ignore an error by class name

In order to help bring the Ruby notifier in-line with other notifiers I've added `discard_classes` as a new option and deprecated the existing `ignore_classes` option. `discard_classes` works similarly to `ignore_classes`, with these differences:

1. It accepts `String` or `Regexp` rather than `Class` or `Proc`
2. It doesn't walk the ancestor chain

### Linked issues

Fixes #589

## Review

<!-- When submitting for review, consider the points for self-review and the
     criteria which will be used for secondary review -->

For the submitter, initial self-review:

- [x] Commented on code changes inline explain the reasoning behind the approach
- [x] Reviewed the test cases added for completeness and possible points for discussion
- [x] A changelog entry was added for the goal of this pull request
- [x] Check the scope of the changeset - is everything in the diff required for the pull request?
- This pull request is ready for:
  - [ ] Initial review of the intended approach, not yet feature complete
  - [ ] Structural review of the classes, functions, and properties modified
  - [x] Final review

For the pull request reviewer(s), this changeset has been reviewed for:

- [ ] Consistency across platforms for structures or concepts added or modified
- [ ] Consistency between the changeset and the goal stated above
- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [ ] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [ ] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [ ] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language
