### PR TITLE
If a custom object responds to `id` method, show the id and class value, instead of showing "[OBJECT]" in error reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ Changelog
   | [#602](https://github.com/bugsnag/bugsnag-ruby/pull/602)
   | [#603](https://github.com/bugsnag/bugsnag-ruby/pull/603)
 
+* If a custom object responds to `id` method, show the id and class in error reports
+  | [#531](https://github.com/bugsnag/bugsnag-ruby/pull/531)
+  | [manojmj92](https://github.com/manojmj92)
+
 ### Deprecated
 
 * The `ignore_classes` configuration option has been deprecated in favour of `discard_classes`. `ignore_classes` will be removed in the next major release

--- a/lib/bugsnag/cleaner.rb
+++ b/lib/bugsnag/cleaner.rb
@@ -7,7 +7,7 @@ module Bugsnag
     RECURSION = '[RECURSION]'.freeze
     OBJECT = '[OBJECT]'.freeze
     RAISED = '[RAISED]'.freeze
-    OBJECT_WITH_ID_AND_CLASS = '[OBJECT]: [Class]: %{class_name} [ID]: %{id}'.freeze
+    OBJECT_WITH_ID_AND_CLASS = '[OBJECT]: [Class]: %<class_name>s [ID]: %<id>d'.freeze
 
     ##
     # @param configuration [Configuration]
@@ -124,7 +124,7 @@ module Bugsnag
         if str =~ /#<.*>/
           # Use id of the object if available
           if obj.respond_to?(:id)
-            OBJECT_WITH_ID_AND_CLASS % { class_name: obj.class, id: obj.id }
+            format(OBJECT_WITH_ID_AND_CLASS, class_name: obj.class, id: obj.id)
           else
             OBJECT
           end

--- a/lib/bugsnag/cleaner.rb
+++ b/lib/bugsnag/cleaner.rb
@@ -7,6 +7,7 @@ module Bugsnag
     RECURSION = '[RECURSION]'.freeze
     OBJECT = '[OBJECT]'.freeze
     RAISED = '[RAISED]'.freeze
+    OBJECT_WITH_ID_AND_CLASS = '[OBJECT]: [Class]: %{class_name} [ID]: %{id}'.freeze
 
     ##
     # @param configuration [Configuration]
@@ -121,7 +122,12 @@ module Bugsnag
 
         # avoid leaking potentially sensitive data from objects' #inspect output
         if str =~ /#<.*>/
-          OBJECT
+          # Use id of the object if available
+          if obj.respond_to?(:id)
+            OBJECT_WITH_ID_AND_CLASS % { class_name: obj.class, id: obj.id }
+          else
+            OBJECT
+          end
         else
           clean_string(str)
         end

--- a/spec/cleaner_spec.rb
+++ b/spec/cleaner_spec.rb
@@ -135,12 +135,13 @@ describe Bugsnag::Cleaner do
     end
 
     it "cleans custom objects to show the id of the object if object responds to id method" do
-      class Macaron
+      class MacaronWithId
         def id
           10
         end
       end
-      a = Macaron.new
+
+      a = MacaronWithId.new
       expect(subject.clean_object(a)).to eq("[OBJECT]: [Class]: #{a.class.name} [ID]: #{a.id}")
     end
 

--- a/spec/cleaner_spec.rb
+++ b/spec/cleaner_spec.rb
@@ -134,6 +134,16 @@ describe Bugsnag::Cleaner do
       expect(subject.clean_object(object)).to eq("[RECURSION]")
     end
 
+    it "cleans custom objects to show the id of the object if object responds to id method" do
+      class Macaron
+        def id
+          10
+        end
+      end
+      a = Macaron.new
+      expect(subject.clean_object(a)).to eq("[OBJECT]: [Class]: #{a.class.name} [ID]: #{a.id}")
+    end
+
     it "cleans up binary strings properly" do
       if RUBY_VERSION > "1.9"
         obj = "Andr\xc7\xff"


### PR DESCRIPTION
**This is PR https://github.com/bugsnag/bugsnag-ruby/pull/531 rebased onto `next`**

---

## Goal

When bugsnag prints out the arguments passed to a job, if the arguments are custom objects (like a Struct, or an ActiveRecord object), Bugsnag only prints out "[OBJECT]" in its place, instead of providing any details, like

```json
{
  "class": "SubcriptionRenewalJob",
  "args": {
    "user": "[OBJECT]",
    "account": "[OBJECT]",
    "setting": "[OBJECT]",
    "subscription": "[OBJECT]"
  }
}
```

While bugsnag does this for the right reason (we should not show details of the whole object using `inspect`, because of PII), for developers who have not written a `to_s` in the model, just seeing `"[OBJECT]"` in place of the actual object details becomes a nightmare. Such errors become practically impossible to debug because, well, you do not know which object caused the issue.

This PR is aimed at solving this problem to some extent, ie, at least in case of ActiveRecord objects.

## Design

All ActiveRecord objects have an `id` method on it by default. If the custom object does not respond to `to_s` and we cannot show it on bugsnag due to data-sensitivity issue, we can still show the `id` of the object.

Reasons:

1. ID is technically not a sensitive data point, like say `email` or `address` (which could be exposed if we give out the whole value of `inspect` on an object)
2. For developers debugging the issue, just knowing the ID of the object should suffice to go back and fetch the record from the database, for debugging purposes.

## Result

Bugsnag will now show arguments as

```json
{
  "class": "SubcriptionRenewalJob",
  "args": {
    "user": "[OBJECT]: [Class]: User [ID]: 23",
    "account": "[OBJECT]: [Class]: Account [ID]: 18",
    "setting": "[OBJECT]: [Class]: Setting [ID]: 7",
    "subscription": "[OBJECT]: [Class]: Subscription [ID]: 88",
  }
}
```
## Changeset


### Added

Added condition to check if the object responds to `id` method. If so, the `id` of the object is being returned as the value of the argument.

### Removed

### Changed


## Tests

Added tests to assert that for custom objects that respond to the `id` method, the `id` of the object is returned as the value of the object, rather than the string `"[OBJECT]"`

## Discussion

### Alternative Approaches

<!-- What other approaches were considered or discussed? -->

### Outstanding Questions

<!-- Are there any parts of the design or the implementation which seem
     less than ideal and that could require additional discussion?
     List here: -->

### Linked issues

<!--

Fixes #
Related to #

-->

## Review

<!-- When submitting for review, consider the points for self-review and the
     criteria which will be used for secondary review -->

For the submitter, initial self-review:

- [x] Commented on code changes inline explain the reasoning behind the approach
- [x] Reviewed the test cases added for completeness and possible points for discussion
- [ ] A changelog entry was added for the goal of this pull request
- [x] Check the scope of the changeset - is everything in the diff required for the pull request?
- This pull request is ready for:
  - [ ] Initial review of the intended approach, not yet feature complete
  - [ ] Structural review of the classes, functions, and properties modified
  - [x] Final review

For the pull request reviewer(s), this changeset has been reviewed for:

- [ ] Consistency across platforms for structures or concepts added or modified
- [ ] Consistency between the changeset and the goal stated above
- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [ ] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [ ] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [ ] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language
