### PR TITLE
Add 'on_error' callbacks, to eventually replace 'before_notify_callbacks'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,17 @@
 Changelog
 =========
 
+## TBD
+
+### Enhancements
+
+* Add `on_error` callbacks to replace `before_notify_callbacks`
+  | [#608](https://github.com/bugsnag/bugsnag-ruby/pull/608)
+
+### Deprecated
+
+* `before_notify_callbacks` have been deprecated in favour of `on_error` and will be removed in the next major release
+
 ## 6.14.0 (20 July 2020)
 
 ### Enhancements

--- a/lib/bugsnag.rb
+++ b/lib/bugsnag.rb
@@ -169,6 +169,8 @@ module Bugsnag
     # Allow access to "before notify" callbacks as an array.
     #
     # These callbacks will be called whenever an error notification is being made.
+    #
+    # @deprecated Use {Bugsnag#add_on_error} instead
     def before_notify_callbacks
       Bugsnag.configuration.request_data[:before_callbacks] ||= []
     end
@@ -225,6 +227,33 @@ module Bugsnag
 
       # Add to breadcrumbs buffer if still valid
       configuration.breadcrumbs << breadcrumb unless breadcrumb.ignore?
+    end
+
+    ##
+    # Add the given callback to the list of on_error callbacks
+    #
+    # The on_error callbacks will be called when an error is captured or reported
+    # and are passed a {Bugsnag::Report} object
+    #
+    # Returning false from an on_error callback will cause the error to be ignored
+    # and will prevent any remaining callbacks from being called
+    #
+    # @param callback [Proc]
+    # @return [void]
+    def add_on_error(callback)
+      configuration.add_on_error(callback)
+    end
+
+    ##
+    # Remove the given callback from the list of on_error callbacks
+    #
+    # Note that this must be the same Proc instance that was passed to
+    # {Bugsnag#add_on_error}, otherwise it will not be removed
+    #
+    # @param callback [Proc]
+    # @return [void]
+    def remove_on_error(callback)
+      configuration.remove_on_error(callback)
     end
 
     ##

--- a/lib/bugsnag/configuration.rb
+++ b/lib/bugsnag/configuration.rb
@@ -318,6 +318,33 @@ module Bugsnag
       @enable_sessions = false
     end
 
+    ##
+    # Add the given callback to the list of on_error callbacks
+    #
+    # The on_error callbacks will be called when an error is captured or reported
+    # and are passed a {Bugsnag::Report} object
+    #
+    # Returning false from an on_error callback will cause the error to be ignored
+    # and will prevent any remaining callbacks from being called
+    #
+    # @param callback [Proc]
+    # @return [void]
+    def add_on_error(callback)
+      middleware.use(callback)
+    end
+
+    ##
+    # Remove the given callback from the list of on_error callbacks
+    #
+    # Note that this must be the same Proc instance that was passed to
+    # {#add_on_error}, otherwise it will not be removed
+    #
+    # @param callback [Proc]
+    # @return [void]
+    def remove_on_error(callback)
+      middleware.remove(callback)
+    end
+
     private
 
     attr_writer :scopes_to_filter

--- a/lib/bugsnag/on_error_callbacks.rb
+++ b/lib/bugsnag/on_error_callbacks.rb
@@ -1,0 +1,33 @@
+module Bugsnag
+  # @api private
+  class OnErrorCallbacks
+    def initialize(next_middleware, callbacks)
+      @next_middleware = next_middleware
+      @callbacks = callbacks
+    end
+
+    ##
+    # @param report [Report]
+    def call(report)
+      @callbacks.each do |callback|
+        begin
+          should_continue = callback.call(report)
+        rescue StandardError => e
+          Bugsnag.configuration.warn("Error occurred in on_error callback: '#{e}'")
+          Bugsnag.configuration.warn("on_error callback stacktrace: #{e.backtrace.inspect}")
+        end
+
+        # If a callback returns false, we ignore the report and stop running callbacks
+        # Note that we explicitly check for 'false' so that callbacks don't need
+        # to return anything (i.e. can return 'nil') and we still continue
+        next unless should_continue == false
+
+        report.ignore!
+
+        break
+      end
+
+      @next_middleware.call(report)
+    end
+  end
+end

--- a/spec/on_error_spec.rb
+++ b/spec/on_error_spec.rb
@@ -1,0 +1,332 @@
+require "spec_helper"
+
+describe "on_error callbacks" do
+  it "runs callbacks on notify" do
+    callback1 = proc {|report| report.add_tab(:important, { hello: "world" }) }
+    callback2 = proc {|report| report.add_tab(:significant, { hey: "earth" }) }
+
+    Bugsnag.add_on_error(callback1)
+    Bugsnag.add_on_error(callback2)
+
+    Bugsnag.notify(RuntimeError.new("Oh no!"))
+
+    expect(Bugsnag).to(have_sent_notification do |payload, _headers|
+      event = get_event_from_payload(payload)
+
+      expect(event["metaData"]["important"]).to eq({ "hello" => "world" })
+      expect(event["metaData"]["significant"]).to eq({ "hey" => "earth" })
+    end)
+  end
+
+  it "can add callbacks in a configure block" do
+    callback1 = proc {|report| report.add_tab(:important, { hello: "world" }) }
+    callback2 = proc {|report| report.add_tab(:significant, { hey: "earth" }) }
+
+    Bugsnag.configure do |config|
+      config.add_on_error(callback1)
+      config.add_on_error(callback2)
+    end
+
+    Bugsnag.notify(RuntimeError.new("Oh no!"))
+
+    expect(Bugsnag).to(have_sent_notification do |payload, _headers|
+      event = get_event_from_payload(payload)
+
+      expect(event["metaData"]["important"]).to eq({ "hello" => "world" })
+      expect(event["metaData"]["significant"]).to eq({ "hey" => "earth" })
+    end)
+  end
+
+  it "can remove an already registered callback" do
+    callback1 = proc {|report| report.add_tab(:important, { hello: "world" }) }
+    callback2 = proc {|report| report.add_tab(:significant, { hey: "earth" }) }
+
+    Bugsnag.add_on_error(callback1)
+    Bugsnag.add_on_error(callback2)
+
+    Bugsnag.remove_on_error(callback1)
+
+    Bugsnag.notify(RuntimeError.new("Oh no!"))
+
+    expect(Bugsnag).to(have_sent_notification do |payload, _headers|
+      event = get_event_from_payload(payload)
+
+      expect(event["metaData"]["important"]).to be_nil
+      expect(event["metaData"]["significant"]).to eq({ "hey" => "earth" })
+    end)
+  end
+
+  it "can remove all registered callbacks" do
+    callback1 = proc {|report| report.add_tab(:important, { hello: "world" }) }
+    callback2 = proc {|report| report.add_tab(:significant, { hey: "earth" }) }
+
+    Bugsnag.add_on_error(callback1)
+    Bugsnag.add_on_error(callback2)
+
+    Bugsnag.remove_on_error(callback2)
+    Bugsnag.remove_on_error(callback1)
+
+    Bugsnag.notify(RuntimeError.new("Oh no!"))
+
+    expect(Bugsnag).to(have_sent_notification do |payload, _headers|
+      event = get_event_from_payload(payload)
+
+      expect(event["metaData"]["important"]).to be_nil
+      expect(event["metaData"]["significant"]).to be_nil
+    end)
+  end
+
+  it "does not remove an identical callback if it is not the same Proc" do
+    callback1 = proc {|report| report.add_tab(:important, { hello: "world" }) }
+    callback1_duplicate = proc {|report| report.add_tab(:important, { hello: "world" }) }
+
+    Bugsnag.add_on_error(callback1)
+    Bugsnag.remove_on_error(callback1_duplicate)
+
+    Bugsnag.notify(RuntimeError.new("Oh no!"))
+
+    expect(Bugsnag).to(have_sent_notification do |payload, _headers|
+      event = get_event_from_payload(payload)
+
+      expect(event["metaData"]["important"]).to eq({ "hello" => "world" })
+    end)
+  end
+
+  it "can re-add callbacks that have previously been removed" do
+    callback1 = proc {|report| report.add_tab(:important, { hello: "world" }) }
+    callback2 = proc {|report| report.add_tab(:significant, { hey: "earth" }) }
+
+    Bugsnag.add_on_error(callback1)
+    Bugsnag.add_on_error(callback2)
+
+    Bugsnag.remove_on_error(callback1)
+
+    Bugsnag.add_on_error(callback1)
+
+    Bugsnag.notify(RuntimeError.new("Oh no!"))
+
+    expect(Bugsnag).to(have_sent_notification do |payload, _headers|
+      event = get_event_from_payload(payload)
+
+      expect(event["metaData"]["important"]).to eq({ "hello" => "world" })
+      expect(event["metaData"]["significant"]).to eq({ "hey" => "earth" })
+    end)
+  end
+
+  it "will only add a callback once" do
+    called_count = 0
+
+    callback = proc do |report|
+      called_count += 1
+
+      report.add_tab(:important, { called: called_count })
+    end
+
+    1.upto(10) do |i|
+      Bugsnag.add_on_error(callback)
+    end
+
+    Bugsnag.notify(RuntimeError.new("Oh no!"))
+
+    expect(Bugsnag).to(have_sent_notification do |payload, _headers|
+      event = get_event_from_payload(payload)
+
+      expect(called_count).to be(1)
+      expect(event["metaData"]["important"]).to eq({ "called" => 1 })
+    end)
+  end
+
+  it "will ignore the report and stop calling callbacks if one returns false" do
+    logger = spy('logger')
+    Bugsnag.configuration.logger = logger
+
+    called_count = 0
+
+    callback1 = proc { called_count += 1 }
+    callback2 = proc { called_count += 1 }
+    callback3 = proc { false }
+    callback4 = proc { called_count += 1 }
+    callback5 = proc { called_count += 1 }
+
+    Bugsnag.add_on_error(callback1)
+    Bugsnag.add_on_error(callback2)
+    Bugsnag.add_on_error(callback3)
+    Bugsnag.add_on_error(callback4)
+    Bugsnag.add_on_error(callback5)
+
+    Bugsnag.notify(RuntimeError.new("Oh no!"))
+
+    expect(Bugsnag).not_to have_sent_notification
+    expect(called_count).to be(2)
+
+    expect(logger).to have_received(:debug).with("[Bugsnag]") do |&block|
+      expect(block.call).to eq("Not notifying RuntimeError due to ignore being signified in user provided middleware")
+    end
+  end
+
+  it "callbacks are called in the same order they are added (FIFO)" do
+    callback1 = proc do |report|
+      expect(report.meta_data[:important]).to be_nil
+
+      report.add_tab(:important, { magic_number: 9 })
+    end
+
+    callback2 = proc do |report|
+      expect(report.meta_data[:important]).to eq({ magic_number: 9 })
+
+      report.add_tab(:important, { magic_number: 99 })
+    end
+
+    callback3 = proc do |report|
+      expect(report.meta_data[:important]).to eq({ magic_number: 99 })
+
+      report.add_tab(:important, { magic_number: 999 })
+    end
+
+    Bugsnag.add_on_error(callback1)
+    Bugsnag.add_on_error(callback2)
+    Bugsnag.add_on_error(callback3)
+
+    Bugsnag.notify(RuntimeError.new("Oh no!"))
+
+    expect(Bugsnag).to(have_sent_notification do |payload, _headers|
+      event = get_event_from_payload(payload)
+
+      expect(event["metaData"]["important"]).to eq({ "magic_number" => 999 })
+    end)
+  end
+
+  it "callbacks continue being called after a callback raises" do
+    logger = spy('logger')
+    Bugsnag.configuration.logger = logger
+
+    callback1 = proc {|report| report.add_tab(:important, { a: "b" }) }
+    callback2 = proc {|_report| raise "bad things" }
+    callback3 = proc {|report| report.add_tab(:important, { c: "d" }) }
+
+    Bugsnag.add_on_error(callback1)
+    Bugsnag.add_on_error(callback2)
+    Bugsnag.add_on_error(callback3)
+
+    Bugsnag.notify(RuntimeError.new("Oh no!"))
+
+    expect(Bugsnag).to(have_sent_notification do |payload, _headers|
+      event = get_event_from_payload(payload)
+
+      expect(event["metaData"]["important"]).to eq({ "a" => "b", "c" => "d" })
+    end)
+
+    message_index = 0
+    expected_messages = [
+      /^Error occurred in on_error callback: 'bad things'$/,
+      /^on_error callback stacktrace:/
+    ]
+
+    expect(logger).to have_received(:warn).with("[Bugsnag]").twice do |&block|
+      expect(block.call).to match(expected_messages[message_index])
+      message_index += 1
+    end
+  end
+
+  it "runs callbacks even if no other middleware is registered" do
+    # Reset the middleware stack so any default middleware are removed
+    Bugsnag.configuration.middleware = Bugsnag::MiddlewareStack.new
+
+    callback1 = proc {|report| report.add_tab(:important, { hello: "world" }) }
+    callback2 = proc {|report| report.add_tab(:significant, { hey: "earth" }) }
+
+    Bugsnag.add_on_error(callback1)
+    Bugsnag.add_on_error(callback2)
+
+    Bugsnag.notify(RuntimeError.new("Oh no!"))
+
+    expect(Bugsnag).to(have_sent_notification do |payload, _headers|
+      event = get_event_from_payload(payload)
+
+      expect(event["metaData"]["important"]).to eq({ "hello" => "world" })
+      expect(event["metaData"]["significant"]).to eq({ "hey" => "earth" })
+    end)
+  end
+
+  describe "using callbacks across threads" do
+    it "runs callbacks that are added in different threads" do
+      callback1 = proc {|report| report.add_tab(:important, { hello: "world" }) }
+      callback2 = proc {|report| report.add_tab(:significant, { hey: "earth" }) }
+      callback3 = proc {|report| report.add_tab(:crucial, { magic_number: 999 }) }
+
+      Bugsnag.add_on_error(callback1)
+
+      threads = [
+        Thread.new { Bugsnag.add_on_error(callback2) },
+        Thread.new { Bugsnag.add_on_error(callback3) }
+      ]
+
+      threads.each(&:join)
+
+      Bugsnag.notify(RuntimeError.new("Oh no!"))
+
+      expect(Bugsnag).to(have_sent_notification do |payload, _headers|
+        event = get_event_from_payload(payload)
+
+        expect(event["metaData"]["important"]).to eq({ "hello" => "world" })
+        expect(event["metaData"]["significant"]).to eq({ "hey" => "earth" })
+        expect(event["metaData"]["crucial"]).to eq({ "magic_number" => 999 })
+      end)
+    end
+
+    it "can remove callbacks that are added in different threads" do
+      callback1 = proc {|report| report.add_tab(:important, { hello: "world" }) }
+      callback2 = proc {|report| report.add_tab(:significant, { hey: "earth" }) }
+
+      # We need to create & join these one at a time so that callback1 has
+      # definitely been added before it is removed, otherwise this test will fail
+      # at random
+      Thread.new { Bugsnag.add_on_error(callback1) }.join
+      Thread.new { Bugsnag.remove_on_error(callback1) }.join
+      Thread.new { Bugsnag.add_on_error(callback2) }.join
+
+      Bugsnag.notify(RuntimeError.new("Oh no!"))
+
+      expect(Bugsnag).to(have_sent_notification do |payload, _headers|
+        event = get_event_from_payload(payload)
+
+        expect(event["metaData"]["important"]).to be_nil
+        expect(event["metaData"]["significant"]).to eq({ "hey" => "earth" })
+      end)
+    end
+
+    it "callbacks are called in FIFO order when added in separate threads" do
+      callback1 = proc do |report|
+        expect(report.meta_data[:important]).to be_nil
+
+        report.add_tab(:important, { magic_number: 9 })
+      end
+
+      callback2 = proc do |report|
+        expect(report.meta_data[:important]).to eq({ magic_number: 9 })
+
+        report.add_tab(:important, { magic_number: 99 })
+      end
+
+      callback3 = proc do |report|
+        expect(report.meta_data[:important]).to eq({ magic_number: 99 })
+
+        report.add_tab(:important, { magic_number: 999 })
+      end
+
+      # As above, we need to create & join these one at a time so that each
+      # callback is added in sequence
+      Thread.new { Bugsnag.add_on_error(callback1) }.join
+      Thread.new { Bugsnag.add_on_error(callback2) }.join
+      Thread.new { Bugsnag.add_on_error(callback3) }.join
+
+      Bugsnag.notify(RuntimeError.new("Oh no!"))
+
+      expect(Bugsnag).to(have_sent_notification do |payload, _headers|
+        event = get_event_from_payload(payload)
+
+        expect(event["metaData"]["important"]).to eq({ "magic_number" => 999 })
+      end)
+    end
+  end
+end


### PR DESCRIPTION
## Goal

The main problem these solve is that they are global, rather than being scoped to the current thread. This means you can add a callback in a Rails initializer and it will run as expected. With the current `before_notify_callbacks`, they only run in the same thread as they are added and so won't run if created in an initializer (this is a problem in most frameworks, not just Rails)

The `before_notify_callbacks` cause a lot of confusion because they are scoped to a single thread, e.g. see #487, #417. Typically callbacks are intended to be global to the application rather than specific to a route/worker, so the new `on_error` mechanism should be a lot more intuitive. This is also how callbacks work in our libraries for other platforms, like [JavaScript](https://docs.bugsnag.com/platforms/javascript/react/customizing-error-reports/#updating-events-using-callbacks) and [Android](https://docs.bugsnag.com/platforms/android/#attaching-custom-diagnostics)

```ruby
Bugsnag.configure do |config|
  # Using 'before_notify_callbacks':
  config.before_notify_callbacks << proc do |report|
    report.add_tab(:diagnostics, { hello: "world" })
  end

  # Using 'on_error' callbacks:
  config.add_on_error(proc do |report|
    report.add_tab(:diagnostics, { world: "hello" })
  end)
end
```

The new callbacks can also be removed if necessary:

```ruby
custom_callback = proc {|report| report.add_tab(:foo, { bar: "baz" }) }

Bugsnag.add_on_error(custom_callback)
Bugsnag.remove_on_error(custom_callback)
```

You can also ignore an error and stop calling any subsequent callbacks by returning `false`:

```ruby
callback1 = proc {|report| report.add_tab(:foo, { bar: "baz" }) }
callback2 = proc {|report| false }
callback3 = proc {|report| "this will never be called because 'callback2' returns false" }

Bugsnag.add_on_error(callback1)
Bugsnag.add_on_error(callback2)
Bugsnag.add_on_error(callback3)
```

## Tests

Most of the implementation is based on middleware, which is already covered by existing tests. I've added a bunch of tests for the new callbacks specifically and checking that they work as expected across threads. Some Maze Runner tests will be added in a separate PR

## Review

<!-- When submitting for review, consider the points for self-review and the
     criteria which will be used for secondary review -->

For the submitter, initial self-review:

- [x] Commented on code changes inline explain the reasoning behind the approach
- [x] Reviewed the test cases added for completeness and possible points for discussion
- [x] A changelog entry was added for the goal of this pull request
- [x] Check the scope of the changeset - is everything in the diff required for the pull request?
- This pull request is ready for:
  - [ ] Initial review of the intended approach, not yet feature complete
  - [ ] Structural review of the classes, functions, and properties modified
  - [x] Final review

For the pull request reviewer(s), this changeset has been reviewed for:

- [ ] Consistency across platforms for structures or concepts added or modified
- [ ] Consistency between the changeset and the goal stated above
- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [ ] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [ ] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [ ] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language
