### PR TITLE
Set consistent context in delayed_job integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+## TBD
+
+### Enhancements
+
+* Set default Delayed Job error context to job class
+  | [#499](https://github.com/bugsnag/bugsnag-ruby/pull/499)
+  | [Mike Stewart](https://github.com/mike-stewart)
+
 ## 6.15.0 (27 July 2020)
 
 ### Enhancements

--- a/features/delayed_job.feature
+++ b/features/delayed_job.feature
@@ -34,3 +34,20 @@ Scenario: A handled exception sends a report
   And the event "metaData.job.payload.display_name" equals "TestModel.notify_with_args"
   And the event "metaData.job.payload.method_name" equals "notify_with_args"
   And the payload field "events.0.metaData.job.payload.args.0" equals "Test"
+
+Scenario: The report context uses the class name if no display name is available
+  Given I run the service "delayed_job" with the command "bundle exec rake delayed_job_tests:report_context"
+  And I wait to receive a request
+  Then the request is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier"
+  And the event "unhandled" is true
+  And the event "severity" equals "error"
+  And the event "context" equals "TestReportContextJob"
+  And the event "severityReason.type" equals "unhandledExceptionMiddleware"
+  And the event "severityReason.attributes.framework" equals "DelayedJob"
+  And the exception "errorClass" equals "RuntimeError"
+  And the event "metaData.job.class" equals "Delayed::Backend::ActiveRecord::Job"
+  And the event "metaData.job.id" is not null
+  And the event "metaData.job.attempt" equals 1
+  And the event "metaData.job.max_attempts" equals 1
+  And the event "metaData.job.payload.display_name" is null
+  And the event "metaData.job.payload.method_name" is null

--- a/features/fixtures/delayed_job/app/Rakefile
+++ b/features/fixtures/delayed_job/app/Rakefile
@@ -13,6 +13,10 @@ namespace :delayed_job_tests do
   task :notify_with_args do
     run_delayed_job_test('"TestModel.delay.notify_with_args(\"Test\")"')
   end
+
+  task :report_context do
+    run_delayed_job_test('"Delayed::Job.enqueue TestReportContextJob.new"')
+  end
 end
 
 def run_delayed_job_test(command)

--- a/features/fixtures/delayed_job/app/app/jobs/test_report_context_job.rb
+++ b/features/fixtures/delayed_job/app/app/jobs/test_report_context_job.rb
@@ -1,0 +1,7 @@
+class TestReportContextJob < ApplicationJob
+  queue_as :default
+
+  def perform(*)
+    raise "oh dear"
+  end
+end

--- a/lib/bugsnag/middleware/delayed_job.rb
+++ b/lib/bugsnag/middleware/delayed_job.rb
@@ -24,6 +24,7 @@ module Bugsnag::Middleware
           job_data[:active_job] = job.payload_object.job_data if job.payload_object.respond_to?(:job_data)
           payload_data = construct_job_payload(job.payload_object)
           report.context = payload_data[:display_name] if payload_data.include?(:display_name)
+          report.context ||= payload_data[:class] if payload_data.include?(:class)
           job_data[:payload] = payload_data
         end
 


### PR DESCRIPTION
## Goal

https://github.com/bugsnag/bugsnag-ruby/pull/499 with conflicts from `next` fixed and a Maze Runner test added

### Linked issues

Closes #499 

<!--

Fixes #
Related to #

-->

## Review

<!-- When submitting for review, consider the points for self-review and the
     criteria which will be used for secondary review -->

For the submitter, initial self-review:

- [x] Commented on code changes inline explain the reasoning behind the approach
- [x] Reviewed the test cases added for completeness and possible points for discussion
- [x] A changelog entry was added for the goal of this pull request
- [x] Check the scope of the changeset - is everything in the diff required for the pull request?
- This pull request is ready for:
  - [ ] Initial review of the intended approach, not yet feature complete
  - [ ] Structural review of the classes, functions, and properties modified
  - [x] Final review

For the pull request reviewer(s), this changeset has been reviewed for:

- [ ] Consistency across platforms for structures or concepts added or modified
- [ ] Consistency between the changeset and the goal stated above
- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [ ] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [ ] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [ ] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language
