### PR TITLE
[PLAT-3643] Ensure app_type is consistently resolved

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -480,7 +480,7 @@ Metrics/BlockNesting:
 # Offense count: 4
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 174
+  Max: 184
 
 # Offense count: 15
 # Configuration parameters: IgnoredMethods.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ Changelog
 * The `BUGSNAG_RELEASE_STAGE` environment variable can now be used to set the release stage. Previously this was only used in Rails applications
   | [#613](https://github.com/bugsnag/bugsnag-ruby/pull/613)
 
+## Fixes
+
+* The `app_type` configuration option should no longer be overwritten by Bugsnag and integrations should set this more consistently
+  | [#619](https://github.com/bugsnag/bugsnag-ruby/pull/619)
+
 ## 6.15.0 (27 July 2020)
 
 ### Enhancements

--- a/lib/bugsnag/configuration.rb
+++ b/lib/bugsnag/configuration.rb
@@ -24,7 +24,6 @@ module Bugsnag
     attr_accessor :send_code
     attr_accessor :project_root
     attr_accessor :app_version
-    attr_accessor :app_type
     attr_accessor :meta_data_filters
     attr_accessor :logger
     attr_accessor :middleware
@@ -196,6 +195,54 @@ module Bugsnag
     #
     def default_delivery_method=(delivery_method)
       @default_delivery_method = delivery_method
+    end
+
+    ##
+    # Get the type of application executing the current code
+    #
+    # This is usually used to represent if you are running in a Rails server,
+    # Sidekiq job, Rake task etc... Bugsnag will automatically detect most
+    # application types for you
+    #
+    # @return [String, nil]
+    def app_type
+      @app_type || @detected_app_type
+    end
+
+    ##
+    # Set the type of application executing the current code
+    #
+    # If an app_type is set, this will be used instead of the automatically
+    # detected app_type that Bugsnag would otherwise use
+    #
+    # @param app_type [String]
+    # @return [void]
+    def app_type=(app_type)
+      @app_type = app_type
+    end
+
+    ##
+    # Get the detected app_type, which is used when one isn't set explicitly
+    #
+    # @api private
+    #
+    # @return [String, nil]
+    def detected_app_type
+      @detected_app_type
+    end
+
+    ##
+    # Set the detected app_type, which is used when one isn't set explicitly
+    #
+    # This allows Bugsnag's integrations to say 'this is a Rails app' while
+    # allowing the user to overwrite this if they wish
+    #
+    # @api private
+    #
+    # @param app_type [String]
+    # @return [void]
+    def detected_app_type=(app_type)
+      @detected_app_type = app_type
     end
 
     ##

--- a/lib/bugsnag/integrations/delayed_job.rb
+++ b/lib/bugsnag/integrations/delayed_job.rb
@@ -13,7 +13,7 @@ module Delayed
       callbacks do |lifecycle|
         lifecycle.around(:invoke_job) do |job, *args, &block|
           begin
-            ::Bugsnag.configuration.app_type = 'delayed_job'
+            ::Bugsnag.configuration.detected_app_type = 'delayed_job'
             ::Bugsnag.configuration.set_request_data(:delayed_job, job)
             block.call(job, *args)
           rescue Exception => exception

--- a/lib/bugsnag/integrations/mailman.rb
+++ b/lib/bugsnag/integrations/mailman.rb
@@ -11,7 +11,7 @@ module Bugsnag
 
     def initialize
       Bugsnag.configuration.internal_middleware.use(Bugsnag::Middleware::Mailman)
-      Bugsnag.configuration.app_type = "mailman"
+      Bugsnag.configuration.detected_app_type = "mailman"
     end
 
     ##

--- a/lib/bugsnag/integrations/que.rb
+++ b/lib/bugsnag/integrations/que.rb
@@ -37,7 +37,8 @@ if defined?(::Que)
     end
   end
 
-  Bugsnag.configuration.app_type ||= "que"
+  Bugsnag.configuration.detected_app_type = "que"
+
   if defined?(::Que::Version)
     Bugsnag.configuration.runtime_versions["que"] = ::Que::Version
   elsif defined?(::Que::VERSION)

--- a/lib/bugsnag/integrations/rack.rb
+++ b/lib/bugsnag/integrations/rack.rb
@@ -30,7 +30,9 @@ module Bugsnag
         config.middleware.insert_before(Bugsnag::Middleware::Callbacks, Bugsnag::Middleware::ClearanceUser) if defined?(Clearance)
 
         # Set environment data for payload
-        config.app_type ||= "rack"
+        # Note we only set the detected app_type if it's not already set. This
+        # ensures we don't overwrite the value set by the Railtie
+        config.detected_app_type ||= "rack"
         config.runtime_versions["rack"] = ::Rack.release if defined?(::Rack)
         config.runtime_versions["sinatra"] = ::Sinatra::VERSION if defined?(::Sinatra)
       end

--- a/lib/bugsnag/integrations/railtie.rb
+++ b/lib/bugsnag/integrations/railtie.rb
@@ -43,7 +43,9 @@ module Bugsnag
 
       Bugsnag::Rails::DEFAULT_RAILS_BREADCRUMBS.each { |event| event_subscription(event) }
 
-      Bugsnag.configuration.app_type = "rails"
+      # Make sure we don't overwrite the value set by another integration because
+      # Rails is a less specific app_type (e.g. Que sets this earlier than us)
+      Bugsnag.configuration.detected_app_type ||= "rails"
     end
 
     # Configure meta_data_filters after initialization, so that rails initializers

--- a/lib/bugsnag/integrations/rake.rb
+++ b/lib/bugsnag/integrations/rake.rb
@@ -11,7 +11,8 @@ if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('2.0')
 
       # Executes the rake task with Bugsnag setup with contextual data.
       def execute(args = nil)
-        Bugsnag.configuration.app_type ||= "rake"
+        Bugsnag.configuration.detected_app_type = "rake"
+
         old_task = Bugsnag.configuration.request_data[:bugsnag_running_task]
         Bugsnag.configuration.set_request_data :bugsnag_running_task, self
         Bugsnag.configuration.runtime_versions["rake"] = ::Rake::VERSION
@@ -42,7 +43,8 @@ else
     ##
     # Executes the rake task with Bugsnag setup with contextual data.
     def execute_with_bugsnag(args=nil)
-      Bugsnag.configuration.app_type ||= "rake"
+      Bugsnag.configuration.detected_app_type = "rake"
+
       old_task = Bugsnag.configuration.request_data[:bugsnag_running_task]
       Bugsnag.configuration.set_request_data :bugsnag_running_task, self
       Bugsnag.configuration.runtime_versions["rake"] = ::Rake::VERSION

--- a/lib/bugsnag/integrations/resque.rb
+++ b/lib/bugsnag/integrations/resque.rb
@@ -60,13 +60,13 @@ Bugsnag::Resque.add_failure_backend
 
 if Resque::Worker.new(:bugsnag_fork_check).fork_per_job?
   Resque.after_fork do
-    Bugsnag.configuration.app_type = "resque"
+    Bugsnag.configuration.detected_app_type = "resque"
     Bugsnag.configuration.default_delivery_method = :synchronous
     Bugsnag.configuration.runtime_versions["resque"] = ::Resque::VERSION
   end
 else
   Resque.before_first_fork do
-    Bugsnag.configuration.app_type = "resque"
+    Bugsnag.configuration.detected_app_type = "resque"
     Bugsnag.configuration.default_delivery_method = :synchronous
     Bugsnag.configuration.runtime_versions["resque"] = ::Resque::VERSION
   end

--- a/lib/bugsnag/integrations/shoryuken.rb
+++ b/lib/bugsnag/integrations/shoryuken.rb
@@ -11,7 +11,7 @@ module Bugsnag
 
     def initialize
       Bugsnag.configure do |config|
-        config.app_type ||= "shoryuken"
+        config.detected_app_type = "shoryuken"
         config.default_delivery_method = :synchronous
       end
     end

--- a/lib/bugsnag/integrations/sidekiq.rb
+++ b/lib/bugsnag/integrations/sidekiq.rb
@@ -13,7 +13,7 @@ module Bugsnag
 
     def initialize
       Bugsnag.configuration.internal_middleware.use(Bugsnag::Middleware::Sidekiq)
-      Bugsnag.configuration.app_type = "sidekiq"
+      Bugsnag.configuration.detected_app_type = "sidekiq"
       Bugsnag.configuration.default_delivery_method = :synchronous
       Bugsnag.configuration.runtime_versions["sidekiq"] = ::Sidekiq::VERSION
     end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -39,6 +39,28 @@ describe Bugsnag::Configuration do
     end
   end
 
+  describe "app_type" do
+    it "should default to nil" do
+      expect(subject.app_type).to be_nil
+    end
+
+    it "should be settable directly" do
+      subject.app_type = :test
+      expect(subject.app_type).to eq(:test)
+    end
+
+    it "should allow a detected app_type to be set" do
+      subject.detected_app_type = :test
+      expect(subject.app_type).to eq(:test)
+    end
+
+    it "should allow the app_type to be set over a default" do
+      subject.detected_app_type = :test
+      subject.app_type = :wow
+      expect(subject.app_type).to eq(:wow)
+    end
+  end
+
   describe "#notify_endpoint" do
     it "defaults to DEFAULT_NOTIFY_ENDPOINT" do
       expect(subject.notify_endpoint).to eq(Bugsnag::Configuration::DEFAULT_NOTIFY_ENDPOINT)

--- a/spec/integrations/mailman_spec.rb
+++ b/spec/integrations/mailman_spec.rb
@@ -33,7 +33,7 @@ describe 'Bugsnag::Mailman', :order => :defined do
     int_middleware = double('internal_middleware')
     expect(config).to receive(:internal_middleware).and_return(int_middleware)
     expect(int_middleware).to receive(:use).with(Bugsnag::Middleware::Mailman)
-    expect(config).to receive(:app_type=).with("mailman")
+    expect(config).to receive(:detected_app_type=).with("mailman")
 
     integration = Bugsnag::Mailman.new
 

--- a/spec/integrations/que_spec.rb
+++ b/spec/integrations/que_spec.rb
@@ -52,8 +52,7 @@ describe 'Bugsnag::Que', :order => :defined do
     allow(Que).to receive(:respond_to?).with(:error_notifier=).and_return(true)
     config = double('config')
     allow(Bugsnag).to receive(:configuration).and_return(config)
-    expect(config).to receive(:app_type)
-    expect(config).to receive(:app_type=).with('que')
+    expect(config).to receive(:detected_app_type=).with('que')
     runtime = {}
     expect(config).to receive(:runtime_versions).and_return(runtime)
     allow(config).to receive(:clear_request_data)
@@ -63,7 +62,7 @@ describe 'Bugsnag::Que', :order => :defined do
 
     #Kick off
     load './lib/bugsnag/integrations/que.rb'
-    
+
     expect(runtime).to eq("que" => "9.9.9")
   end
 

--- a/spec/integrations/resque_spec.rb
+++ b/spec/integrations/resque_spec.rb
@@ -44,7 +44,7 @@ describe 'Bugsnag::Resque', :order => :defined do
     expect(::Resque::Worker).to receive(:new).with(:bugsnag_fork_check).and_return(fork_check)
     expect(fork_check).to receive(:fork_per_job?).and_return(true)
     expect(::Resque).to receive(:after_fork).and_yield
-    expect(Bugsnag.configuration).to receive(:app_type=).with("resque")
+    expect(Bugsnag.configuration).to receive(:detected_app_type=).with("resque")
     runtime = {}
     expect(Bugsnag.configuration).to receive(:runtime_versions).and_return(runtime)
     expect(Bugsnag.configuration).to receive(:default_delivery_method=).with(:synchronous)

--- a/spec/integrations/shoryuken_spec.rb
+++ b/spec/integrations/shoryuken_spec.rb
@@ -28,9 +28,8 @@ describe 'Bugsnag::Shoryuken', :order => :defined do
 
   it "calls configure when initialised" do
     config = double("config")
-    
-    expect(config).to receive(:app_type).and_return(nil)
-    expect(config).to receive(:app_type=).with("shoryuken")
+
+    expect(config).to receive(:detected_app_type=).with("shoryuken")
     expect(config).to receive(:default_delivery_method=).with(:synchronous)
     expect(Bugsnag).to receive(:configure).and_yield(config)
     Bugsnag::Shoryuken.new
@@ -50,8 +49,7 @@ describe 'Bugsnag::Shoryuken', :order => :defined do
       func.call(report)
     end
     config = double('config')
-    allow(config).to receive(:app_type).and_return(nil)
-    allow(config).to receive(:app_type=).with("shoryuken")
+    allow(config).to receive(:detected_app_type=).with("shoryuken")
     allow(config).to receive(:default_delivery_method=).with(:synchronous)
     allow(config).to receive(:clear_request_data)
     expect(Bugsnag).to receive(:before_notify_callbacks).and_return(callbacks)


### PR DESCRIPTION
## Goal

This fixes a couple of issues with `app_type` — we now always use the value set by a user (if one is set) and integrations should now always set the correct value

For example, before this change Que would have an app type of 'rails' when running in a rails app. This is because the Que integration has to run when it's loaded and so sets its app type before Rails does

Now we always use the new `detected_app_type` property internally (this should only be used within Bugsnag) so that we know any user provided value will be set as the regular `app_type`. Most integrations can then safely overwrite the `detected_app_type` with the exception of Rails and Rack — these integrations can run with other integrations (e.g. Que in Rails) and so need to make sure they don't overwrite an already set value

## Tests

Automated tests for the `app_type` exist in https://github.com/bugsnag/bugsnag-ruby/pull/616 and tests for `app_type` when integrations are run inside a Rails app exist in https://github.com/bugsnag/bugsnag-ruby/pull/618. This branch is separate so that we can fix the bug before those PRs are reviewed (they're pretty huge!)

Shoryuken is missing automated tests because it's a bit more complicated to setup (it needs a mock SQS server); I've tested this manually for now, but we'll add Maze Runner tests for this later

## Review

<!-- When submitting for review, consider the points for self-review and the
     criteria which will be used for secondary review -->

For the submitter, initial self-review:

- [x] Commented on code changes inline explain the reasoning behind the approach
- [x] Reviewed the test cases added for completeness and possible points for discussion
- [x] A changelog entry was added for the goal of this pull request
- [x] Check the scope of the changeset - is everything in the diff required for the pull request?
- This pull request is ready for:
  - [ ] Initial review of the intended approach, not yet feature complete
  - [ ] Structural review of the classes, functions, and properties modified
  - [x] Final review

For the pull request reviewer(s), this changeset has been reviewed for:

- [ ] Consistency across platforms for structures or concepts added or modified
- [ ] Consistency between the changeset and the goal stated above
- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [ ] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [ ] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [ ] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language