### PR TITLE
[PLAT-3702] Report runtime versions for Delayed Job, Mailman and Shoryuken

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ Changelog
 * The `BUGSNAG_RELEASE_STAGE` environment variable can now be used to set the release stage. Previously this was only used in Rails applications
   | [#613](https://github.com/bugsnag/bugsnag-ruby/pull/613)
 
+* Add support for runtime versions to Delayed Job, Mailman and Shoryuken integrations
+  | [#620](https://github.com/bugsnag/bugsnag-ruby/pull/620)
+
 ## Fixes
 
 * The `app_type` configuration option should no longer be overwritten by Bugsnag and integrations should set this more consistently

--- a/features/delayed_job.feature
+++ b/features/delayed_job.feature
@@ -17,6 +17,7 @@ Scenario: An unhandled RuntimeError sends a report with arguments
   And the event "metaData.job.payload.display_name" equals "TestModel.fail_with_args"
   And the event "metaData.job.payload.method_name" equals "fail_with_args"
   And the payload field "events.0.metaData.job.payload.args.0" equals "Test"
+  And the event "device.runtimeVersions.delayed_job" equals "4.1.8"
 
 Scenario: A handled exception sends a report
   Given I run the service "delayed_job" with the command "bundle exec rake delayed_job_tests:notify_with_args"
@@ -34,6 +35,7 @@ Scenario: A handled exception sends a report
   And the event "metaData.job.payload.display_name" equals "TestModel.notify_with_args"
   And the event "metaData.job.payload.method_name" equals "notify_with_args"
   And the payload field "events.0.metaData.job.payload.args.0" equals "Test"
+  And the event "device.runtimeVersions.delayed_job" equals "4.1.8"
 
 Scenario: The report context uses the class name if no display name is available
   Given I run the service "delayed_job" with the command "bundle exec rake delayed_job_tests:report_context"
@@ -51,3 +53,4 @@ Scenario: The report context uses the class name if no display name is available
   And the event "metaData.job.max_attempts" equals 1
   And the event "metaData.job.payload.display_name" is null
   And the event "metaData.job.payload.method_name" is null
+  And the event "device.runtimeVersions.delayed_job" equals "4.1.8"

--- a/lib/bugsnag/integrations/mailman.rb
+++ b/lib/bugsnag/integrations/mailman.rb
@@ -12,6 +12,7 @@ module Bugsnag
     def initialize
       Bugsnag.configuration.internal_middleware.use(Bugsnag::Middleware::Mailman)
       Bugsnag.configuration.detected_app_type = "mailman"
+      Bugsnag.configuration.runtime_versions["mailman"] = ::Mailman::VERSION
     end
 
     ##

--- a/lib/bugsnag/integrations/shoryuken.rb
+++ b/lib/bugsnag/integrations/shoryuken.rb
@@ -13,6 +13,7 @@ module Bugsnag
       Bugsnag.configure do |config|
         config.detected_app_type = "shoryuken"
         config.default_delivery_method = :synchronous
+        config.runtime_versions["shoryuken"] = ::Shoryuken::VERSION
       end
     end
 

--- a/spec/integrations/shoryuken_spec.rb
+++ b/spec/integrations/shoryuken_spec.rb
@@ -5,7 +5,8 @@ describe 'Bugsnag::Shoryuken', :order => :defined do
   before do
     unless defined?(::Shoryuken)
       @mocked_shoryuken = true
-      class ::Shoryuken
+      class Shoryuken
+        VERSION = '1.2.3'
       end
       module Kernel
         alias_method :old_require, :require
@@ -27,36 +28,40 @@ describe 'Bugsnag::Shoryuken', :order => :defined do
   end
 
   it "calls configure when initialised" do
-    config = double("config")
-
-    expect(config).to receive(:detected_app_type=).with("shoryuken")
-    expect(config).to receive(:default_delivery_method=).with(:synchronous)
-    expect(Bugsnag).to receive(:configure).and_yield(config)
     Bugsnag::Shoryuken.new
+
+    expect(Bugsnag.configuration.app_type).to eq("shoryuken")
+    expect(Bugsnag.configuration.delivery_method).to eq(:synchronous)
+    expect(Bugsnag.configuration.runtime_versions["shoryuken"]).to eq(Shoryuken::VERSION)
   end
 
   it "calls correct sequence when called" do
-    queue = 'queue'
-    body = 'body'
+    queue = 'a queue name'
+    body = 'the body of a queued message'
+    exception = RuntimeError.new('oops')
 
-    callbacks = double('callbacks')
-    expect(callbacks).to receive(:<<) do |func|
-      report = double('report')
-      expect(report).to receive(:add_tab).with(:shoryuken, {
-        queue: queue,
-        body: body
+    expect {
+      Bugsnag::Shoryuken.new.call('_', queue, '_', body) { raise exception }
+    }.to raise_error(exception)
+
+    expect(Bugsnag).to have_sent_notification { |payload, headers|
+      event = get_event_from_payload(payload)
+
+      expect(event['unhandled']).to be(true)
+      expect(event['severity']).to eq('error')
+      expect(event['app']['type']).to eq('shoryuken')
+      expect(event['device']['runtimeVersions']['shoryuken']).to eq(Shoryuken::VERSION)
+
+      expect(event['metaData']['shoryuken']).to eq({
+        'body' => body,
+        'queue' => queue,
       })
-      func.call(report)
-    end
-    config = double('config')
-    allow(config).to receive(:detected_app_type=).with("shoryuken")
-    allow(config).to receive(:default_delivery_method=).with(:synchronous)
-    allow(config).to receive(:clear_request_data)
-    expect(Bugsnag).to receive(:before_notify_callbacks).and_return(callbacks)
-    allow(Bugsnag).to receive(:configure).and_yield(config)
-    allow(Bugsnag).to receive(:configuration).and_return(config)
-    shoryuken = Bugsnag::Shoryuken.new
-    expect { |b| shoryuken.call('_', queue, '_', body, &b )}.to yield_control
+
+      expect(event['severityReason']).to eq({
+        'type' => Bugsnag::Report::UNHANDLED_EXCEPTION_MIDDLEWARE,
+        'attributes' => { 'framework' => 'Shoryuken' }
+      })
+    }
   end
 
   after do


### PR DESCRIPTION
## Goal

This PR adds runtime versions for:

- Delayed Job
- Mailman
- Shoryuken

Mailman & Shoryuken are straightforward, but Delayed Job doesn't have a constant with its version in so instead we have to read it from the loaded Gems

## Review

<!-- When submitting for review, consider the points for self-review and the
     criteria which will be used for secondary review -->

For the submitter, initial self-review:

- [x] Commented on code changes inline explain the reasoning behind the approach
- [x] Reviewed the test cases added for completeness and possible points for discussion
- [x] A changelog entry was added for the goal of this pull request
- [x] Check the scope of the changeset - is everything in the diff required for the pull request?
- This pull request is ready for:
  - [ ] Initial review of the intended approach, not yet feature complete
  - [ ] Structural review of the classes, functions, and properties modified
  - [x] Final review

For the pull request reviewer(s), this changeset has been reviewed for:

- [ ] Consistency across platforms for structures or concepts added or modified
- [ ] Consistency between the changeset and the goal stated above
- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [ ] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [ ] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [ ] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language
