### PR TITLE
Reduce gem size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ Changelog
 * Add support for runtime versions to Delayed Job, Mailman and Shoryuken integrations
   | [#620](https://github.com/bugsnag/bugsnag-ruby/pull/620)
 
+* Reduce the size of the bundled gem
+  | [#571](https://github.com/bugsnag/bugsnag-ruby/pull/571)
+  | [t-richards](https://github.com/t-richards)
+
 ## Fixes
 
 * The `app_type` configuration option should no longer be overwritten by Bugsnag and integrations should set this more consistently

--- a/bugsnag.gemspec
+++ b/bugsnag.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.homepage = "https://github.com/bugsnag/bugsnag-ruby"
   s.licenses = ["MIT"]
 
-  s.files = `git ls-files -z lib`.split("\x0")
+  s.files = `git ls-files -z lib bugsnag.gemspec VERSION`.split("\x0")
   s.extra_rdoc_files = [
     "LICENSE.txt",
     "README.md",

--- a/bugsnag.gemspec
+++ b/bugsnag.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.homepage = "https://github.com/bugsnag/bugsnag-ruby"
   s.licenses = ["MIT"]
 
-  s.files = `git ls-files`.split("\n").reject {|file| file.start_with? "example/"}
+  s.files = `git ls-files -z lib`.split("\x0")
   s.extra_rdoc_files = [
     "LICENSE.txt",
     "README.md",


### PR DESCRIPTION
## Goal

This is https://github.com/bugsnag/bugsnag-ruby/pull/571 with CI passing — we need to include the gemspec file in order for our Docker setup to work

## Tests

This is tested by the Maze Runner tests as they build, unpack and install the Gem before running

## Review

<!-- When submitting for review, consider the points for self-review and the
     criteria which will be used for secondary review -->

For the submitter, initial self-review:

- [x] Commented on code changes inline explain the reasoning behind the approach
- [x] Reviewed the test cases added for completeness and possible points for discussion
- [x] A changelog entry was added for the goal of this pull request
- [x] Check the scope of the changeset - is everything in the diff required for the pull request?
- This pull request is ready for:
  - [ ] Initial review of the intended approach, not yet feature complete
  - [ ] Structural review of the classes, functions, and properties modified
  - [x] Final review

For the pull request reviewer(s), this changeset has been reviewed for:

- [ ] Consistency across platforms for structures or concepts added or modified
- [ ] Consistency between the changeset and the goal stated above
- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [ ] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [ ] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [ ] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language
