### PR TITLE
Delay JSON serialization until delivery when using the thread queue delivery method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ Changelog
   | [#571](https://github.com/bugsnag/bugsnag-ruby/pull/571)
   | [t-richards](https://github.com/t-richards)
 
+* Move serialization of Reports onto the background thread when using the thread_queue delivery method
+  | [#623](https://github.com/bugsnag/bugsnag-ruby/pull/623)
+
 ## Fixes
 
 * The `app_type` configuration option should no longer be overwritten by Bugsnag and integrations should set this more consistently


### PR DESCRIPTION
## Goal

This PR adds a new method that delivery methods can implement in order to delay serialization of the `Bugnsag::Report` object. This is used by the thread queue delivery method to shift some work off of the main thread

This works by passing a proc that will serialize the Report rather than the serialized Report itself, this way the delivery method doesn't have to know _how_ things are serialized only how to get the serialized value. This is a bit less flexible than passing the Report directly, but I don't think it makes sense for delivery methods to use different serialization

## Review

<!-- When submitting for review, consider the points for self-review and the
     criteria which will be used for secondary review -->

For the submitter, initial self-review:

- [x] Commented on code changes inline explain the reasoning behind the approach
- [x] Reviewed the test cases added for completeness and possible points for discussion
- [x] A changelog entry was added for the goal of this pull request
- [x] Check the scope of the changeset - is everything in the diff required for the pull request?
- This pull request is ready for:
  - [ ] Initial review of the intended approach, not yet feature complete
  - [ ] Structural review of the classes, functions, and properties modified
  - [x] Final review

For the pull request reviewer(s), this changeset has been reviewed for:

- [ ] Consistency across platforms for structures or concepts added or modified
- [ ] Consistency between the changeset and the goal stated above
- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [ ] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [ ] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [ ] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language
