### PR TITLE
Pin Rubocop version more strictly

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,7 +32,7 @@ group :coverage, optional: true do
 end
 
 group :rubocop, optional: true do
-  gem 'rubocop', '~> 0.83'
+  gem 'rubocop', '~> 0.88.0'
 end
 
 group :sidekiq, optional: true do


### PR DESCRIPTION
Rubocop keeps breaking the build at inconvenient times because our version restriction is quite loose

The new 0.89.0 release has replaced a cop that's in our todo file, which [broke linting for the upcoming release](https://buildkite.com/bugsnag/ruby-bugsnag-notifier/builds/321#e942b7b5-edc6-4e62-9a34-f0134cbdb86e). I think we're better off pinning this much more tightly and updating it at specific times instead, so that it doesn't block us from releasing