### PR TITLE
Use thread queue delivery method for Resque, when it's safe to do so

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Changelog
 * Sidekiq now uses `thread_queue` delivery by default
   | [#626](https://github.com/bugsnag/bugsnag-ruby/pull/626)
 
+* Rescue now uses `thread_queue` delivery when `at_exit` hooks are enabled
+  | [#629](https://github.com/bugsnag/bugsnag-ruby/pull/629)
+
 ## 6.16.0 (12 August 2020)
 
 ### Enhancements

--- a/features/fixtures/docker-compose.yml
+++ b/features/fixtures/docker-compose.yml
@@ -258,6 +258,7 @@ services:
       - DB_PASSWORD=test_password
       - DB_HOST=postgres
       - REDIS_URL=redis://redis:6379
+      - RUN_AT_EXIT_HOOKS
     restart: "no"
 
   sidekiq:

--- a/features/fixtures/rails_integrations/app/config/initializers/bugsnag.rb
+++ b/features/fixtures/rails_integrations/app/config/initializers/bugsnag.rb
@@ -2,4 +2,10 @@ Bugsnag.configure do |config|
   config.api_key = ENV['BUGSNAG_API_KEY']
   config.endpoint = ENV['BUGSNAG_ENDPOINT']
   config.session_endpoint = ENV['BUGSNAG_ENDPOINT']
+
+  config.add_on_error(proc do |report|
+    report.add_tab(:config, {
+      delivery_method: config.delivery_method.to_s,
+    })
+  end)
 end

--- a/lib/bugsnag/integrations/resque.rb
+++ b/lib/bugsnag/integrations/resque.rb
@@ -58,16 +58,23 @@ Resque::Failure::Bugsnag = Bugsnag::Resque
 # Auto-load the failure backend
 Bugsnag::Resque.add_failure_backend
 
-if Resque::Worker.new(:bugsnag_fork_check).fork_per_job?
+worker = Resque::Worker.new(:bugsnag_fork_check)
+
+# If at_exit hooks are not enabled then we can't use the thread queue delivery
+# method because it relies on an at_exit hook to ensure the queue is flushed
+can_use_thread_queue = worker.respond_to?(:run_at_exit_hooks) && worker.run_at_exit_hooks
+default_delivery_method = can_use_thread_queue ? :thread_queue : :synchronous
+
+if worker.fork_per_job?
   Resque.after_fork do
     Bugsnag.configuration.detected_app_type = "resque"
-    Bugsnag.configuration.default_delivery_method = :synchronous
+    Bugsnag.configuration.default_delivery_method = default_delivery_method
     Bugsnag.configuration.runtime_versions["resque"] = ::Resque::VERSION
   end
 else
   Resque.before_first_fork do
     Bugsnag.configuration.detected_app_type = "resque"
-    Bugsnag.configuration.default_delivery_method = :synchronous
+    Bugsnag.configuration.default_delivery_method = default_delivery_method
     Bugsnag.configuration.runtime_versions["resque"] = ::Resque::VERSION
   end
 end


### PR DESCRIPTION
## Goal

Our thread queue delivery relies on an `at_exit` hook to flush the queue before the thread exits. Unfortunately this doesn't work with Resque as it does not run `on_exit` hooks by default. There is a `run_at_exit_hooks` setting, which can be used to enable `on_exit` hooks and so we can safely use thread queue delivery when this is enabled

Related to #593

## Changeset

- Detect if `run_at_exit_hooks` is enabled and, if so, use thread queue delivery (otherwise stick with synchronous)
- Updated the Resque Maze Runner test to enable `run_at_exit_hooks`

## Testing

I've manually tested that delivery succeeds with thread queue delivery and `on_exit` hooks (and that it fails with `on_exit` hooks disabled) and there's a new Maze Runner test to ensure this doesn't regress