### PR TITLE
Expand upon the API docs

### DIFF
--- a/lib/bugsnag.rb
+++ b/lib/bugsnag.rb
@@ -44,7 +44,10 @@ module Bugsnag
     ##
     # Configure the Bugsnag notifier application-wide settings.
     #
-    # Yields a configuration object to use to set application settings.
+    # Yields a {Configuration} object to use to set application settings.
+    #
+    # @yieldparam configuration [Configuration]
+    # @return [void]
     def configure(validate_api_key=true)
       yield(configuration) if block_given?
 
@@ -125,7 +128,9 @@ module Bugsnag
     end
 
     ##
-    # Registers an at_exit function to automatically catch errors on exit
+    # Registers an at_exit function to automatically catch errors on exit.
+    #
+    # @return [void]
     def register_at_exit
       return if at_exit_handler_installed?
       @exit_handler_added = true
@@ -142,14 +147,19 @@ module Bugsnag
     end
 
     ##
-    # Checks if an at_exit handler has been added
+    # Checks if an at_exit handler has been added.
+    #
+    # The {Bugsnag#configure} method will add this automatically, but it can be
+    # added manually using {Bugsnag#register_at_exit}.
+    #
+    # @return [Boolean]
     def at_exit_handler_installed?
       @exit_handler_added ||= false
     end
 
-    # Configuration getters
     ##
     # Returns the client's Configuration object, or creates one if not yet created.
+    #
     # @return [Configuration]
     def configuration
       @configuration = nil unless defined?(@configuration)
@@ -158,6 +168,8 @@ module Bugsnag
 
     ##
     # Returns the client's SessionTracker object, or creates one if not yet created.
+    #
+    # @return [SessionTracker]
     def session_tracker
       @session_tracker = nil unless defined?(@session_tracker)
       @session_tracker || LOCK.synchronize { @session_tracker ||= Bugsnag::SessionTracker.new}
@@ -181,7 +193,10 @@ module Bugsnag
       Bugsnag.configuration.request_data[:before_callbacks] ||= []
     end
 
-    # Attempts to load all integrations through auto-discovery
+    ##
+    # Attempts to load all integrations through auto-discovery.
+    #
+    # @return [void]
     def load_integrations
       require "bugsnag/integrations/railtie" if defined?(Rails::Railtie)
       INTEGRATIONS.each do |integration|
@@ -192,7 +207,11 @@ module Bugsnag
       end
     end
 
-    # Load a specific integration
+    ##
+    # Load a specific integration.
+    #
+    # @param integration [Symbol] One of the integrations in {INTEGRATIONS}
+    # @return [void]
     def load_integration(integration)
       integration = :railtie if integration == :rails
       if INTEGRATIONS.include?(integration) || integration == :railtie
@@ -209,6 +228,7 @@ module Bugsnag
     # @param meta_data [Hash] String, Numeric, or Boolean meta data to attach
     # @param type [String] the breadcrumb type, from Bugsnag::Breadcrumbs::VALID_BREADCRUMB_TYPES
     # @param auto [Symbol] set to :auto if the breadcrumb is automatically created
+    # @return [void]
     def leave_breadcrumb(name, meta_data={}, type=Bugsnag::Breadcrumbs::MANUAL_BREADCRUMB_TYPE, auto=:manual)
       breadcrumb = Bugsnag::Breadcrumbs::Breadcrumb.new(name, type, meta_data, auto)
       validator = Bugsnag::Breadcrumbs::Validator.new(configuration)

--- a/lib/bugsnag/configuration.rb
+++ b/lib/bugsnag/configuration.rb
@@ -15,64 +15,134 @@ require "bugsnag/breadcrumbs/breadcrumbs"
 
 module Bugsnag
   class Configuration
+    # Your Integration API Key
+    # @return [String, nil]
     attr_accessor :api_key
+
+    # The current stage of the release process, e.g. 'development', production'
+    # @return [String, nil]
     attr_accessor :release_stage
+
+    # A list of which release stages should cause notifications to be sent
+    # @return [Array<String>, nil]
     attr_accessor :notify_release_stages
+
+    # Whether notifications should automatically be sent
+    # @return [Boolean]
     attr_accessor :auto_notify
+
+    # @return [String, nil]
     attr_accessor :ca_file
+
+    # Whether to automatically attach the Rack environment to notifications
+    # @return [Boolean]
     attr_accessor :send_environment
+
+    # Whether code snippets from the exception stacktrace should be sent with notifications
+    # @return [Boolean]
     attr_accessor :send_code
+
+    # Any stacktrace lines that match this path will be marked as 'in project'
+    # @return [String, nil]
     attr_accessor :project_root
+
+    # The current version of your application
+    # @return [String, nil]
     attr_accessor :app_version
+
+    # A list of keys that should be filtered out from the report and breadcrumb
+    # metadata before sending them to Bugsnag
+    # @return [Set<String, Regexp>]
     attr_accessor :meta_data_filters
+
+    # The logger to use for Bugsnag log messages
+    # @return [Logger]
     attr_accessor :logger
+
+    # The middleware stack that will run on every notification
+    # @return [MiddlewareStack]
     attr_accessor :middleware
+
+    # @api private
+    # @return [MiddlewareStack]
     attr_accessor :internal_middleware
+
+    # The host address of the HTTP proxy that should be used when making requests
+    # @see parse_proxy
+    # @return [String, nil]
     attr_accessor :proxy_host
+
+    # The port number of the HTTP proxy that should be used when making requests
+    # @see parse_proxy
+    # @return [Integer, nil]
     attr_accessor :proxy_port
+
+    # The user that should be used when making requests via a HTTP proxy
+    # @see parse_proxy
+    # @return [String, nil]
     attr_accessor :proxy_user
+
+    # The password for the user that should be used when making requests via a HTTP proxy
+    # @see parse_proxy
+    # @return [String, nil]
     attr_accessor :proxy_password
+
+    # The HTTP request timeout, defaults to 15 seconds
+    # @return [Integer]
     attr_accessor :timeout
+
+    # The name or descriptor of the Ruby server host
+    # @return [String]
     attr_accessor :hostname
+
+    # @api private
+    # @return [Hash{String => String}]
     attr_accessor :runtime_versions
+
+    # Exception classes that will be discarded and not sent to Bugsnag
+    # @return [Set<String, Regexp>]
     attr_accessor :discard_classes
+
+    # Whether Bugsnag should automatically record sessions
+    # @return [Boolean]
     attr_accessor :auto_capture_sessions
 
-    ##
     # @deprecated Use {#discard_classes} instead
+    # @return [Set<Class, Proc>]
     attr_accessor :ignore_classes
 
-    ##
-    # @return [String] URL error notifications will be delivered to
+    # The URL error notifications will be delivered to
+    # @return [String]
     attr_reader :notify_endpoint
     alias :endpoint :notify_endpoint
 
-    ##
-    # @return [String] URL session notifications will be delivered to
+    # The URL session notifications will be delivered to
+    # @return [String]
     attr_reader :session_endpoint
 
-    ##
-    # @return [Boolean] whether any sessions types will be delivered
+    # Whether sessions will be delivered
+    # @return [Boolean]
     attr_reader :enable_sessions
 
-    ##
-    # @return [Array<String>] strings indicating allowable automatic breadcrumb types
+    # A list of strings indicating allowable automatic breadcrumb types
+    # @see Bugsnag::Breadcrumbs::VALID_BREADCRUMB_TYPES
+    # @return [Array<String>]
     attr_accessor :enabled_automatic_breadcrumb_types
 
-    ##
-    # @return [Array<#call>] callables to be run before a breadcrumb is logged
+    # Callables to be run before a breadcrumb is logged
+    # @return [Array<#call>]
     attr_accessor :before_breadcrumb_callbacks
 
-    ##
-    # @return [Integer] the maximum allowable amount of breadcrumbs per thread
+    # The maximum allowable amount of breadcrumbs per thread
+    # @return [Integer]
     attr_reader :max_breadcrumbs
 
-    ##
-    # @return [Regexp] matching file paths out of project
+    #
+    # @return [Regexp]
     attr_accessor :vendor_path
 
-    ##
-    # @return [Array]
+    # @api private
+    # @return [Array<String>]
     attr_reader :scopes_to_filter
 
     API_KEY_REGEX = /[0-9a-f]{32}/i
@@ -96,6 +166,7 @@ module Bugsnag
     # Path to vendored code. Used to mark file paths as out of project.
     DEFAULT_VENDOR_PATH = %r{^(vendor/|\.bundle/)}
 
+    # @api private
     DEFAULT_SCOPES_TO_FILTER = ['events.metaData', 'events.breadcrumbs.metaData'].freeze
 
     alias :track_sessions :auto_capture_sessions
@@ -177,6 +248,7 @@ module Bugsnag
     # Gets the delivery_method that Bugsnag will use to communicate with the
     # notification endpoint.
     #
+    # @return [Symbol]
     def delivery_method
       @delivery_method || @default_delivery_method || :thread_queue
     end
@@ -185,6 +257,10 @@ module Bugsnag
     # Sets the delivery_method that Bugsnag will use to communicate with the
     # notification endpoint.
     #
+    # The default delivery methods are ':thread_queue' and ':synchronous'.
+    #
+    # @param delivery_method [Symbol]
+    # @return [void]
     def delivery_method=(delivery_method)
       @delivery_method = delivery_method
     end
@@ -193,6 +269,10 @@ module Bugsnag
     # Used to set a new default delivery method that will be used if one is not
     # set with #delivery_method.
     #
+    # @api private
+    #
+    # @param delivery_method [Symbol]
+    # @return [void]
     def default_delivery_method=(delivery_method)
       @default_delivery_method = delivery_method
     end
@@ -248,12 +328,16 @@ module Bugsnag
     ##
     # Indicates whether the notifier should send a notification based on the
     # configured release stage.
+    #
+    # @return [Boolean]
     def should_notify_release_stage?
       @release_stage.nil? || @notify_release_stages.nil? || @notify_release_stages.include?(@release_stage)
     end
 
     ##
     # Tests whether the configured API key is valid.
+    #
+    # @return [Boolean]
     def valid_api_key?
       !api_key.nil? && api_key =~ API_KEY_REGEX
     end
@@ -261,48 +345,68 @@ module Bugsnag
     ##
     # Returns the array of data that will be automatically attached to every
     # error notification.
+    #
+    # @return [Hash]
     def request_data
       Thread.current[THREAD_LOCAL_NAME] ||= {}
     end
 
     ##
     # Sets an entry in the array of data attached to every error notification.
+    #
+    # @param key [String, #to_s]
+    # @param value [Object]
+    # @return [void]
     def set_request_data(key, value)
       self.request_data[key] = value
     end
 
     ##
     # Unsets an entry in the array of data attached to every error notification.
+    #
+    # @param (see set_request_data)
+    # @return [void]
     def unset_request_data(key, value)
       self.request_data.delete(key)
     end
 
     ##
     # Clears the array of data attached to every error notification.
+    #
+    # @return [void]
     def clear_request_data
       Thread.current[THREAD_LOCAL_NAME] = nil
     end
 
     ##
     # Logs an info level message
+    #
+    # @param message [String, #to_s] The message to log
     def info(message)
       logger.info(PROG_NAME) { message }
     end
 
     ##
     # Logs a warning level message
+    #
+    # @param (see info)
     def warn(message)
       logger.warn(PROG_NAME) { message }
     end
 
     ##
     # Logs a debug level message
+    #
+    # @param (see info)
     def debug(message)
       logger.debug(PROG_NAME) { message }
     end
 
     ##
     # Parses and sets proxy from a uri
+    #
+    # @param uri [String, #to_s] The URI to parse and extract proxy details from
+    # @return [void]
     def parse_proxy(uri)
       proxy = URI.parse(uri)
       self.proxy_host = proxy.host
@@ -315,6 +419,7 @@ module Bugsnag
     # Sets the maximum allowable amount of breadcrumbs
     #
     # @param new_max_breadcrumbs [Integer] the new maximum breadcrumb limit
+    # @return [void]
     def max_breadcrumbs=(new_max_breadcrumbs)
       @max_breadcrumbs = new_max_breadcrumbs
       breadcrumbs.max_items = new_max_breadcrumbs
@@ -330,9 +435,10 @@ module Bugsnag
 
     # Sets the notification endpoint
     #
-    # @param new_notify_endpoint [String] The URL to deliver error notifications to
-    #
     # @deprecated Use {#set_endpoints} instead
+    #
+    # @param new_notify_endpoint [String] The URL to deliver error notifications to
+    # @return [void]
     def endpoint=(new_notify_endpoint)
       warn("The 'endpoint' configuration option is deprecated. The 'set_endpoints' method should be used instead")
       set_endpoints(new_notify_endpoint, session_endpoint) # Pass the existing session_endpoint through so it doesn't get overwritten
@@ -341,9 +447,10 @@ module Bugsnag
     ##
     # Sets the sessions endpoint
     #
-    # @param new_session_endpoint [String] The URL to deliver session notifications to
-    #
     # @deprecated Use {#set_endpoints} instead
+    #
+    # @param new_session_endpoint [String] The URL to deliver session notifications to
+    # @return [void]
     def session_endpoint=(new_session_endpoint)
       warn("The 'session_endpoint' configuration option is deprecated. The 'set_endpoints' method should be used instead")
       set_endpoints(notify_endpoint, new_session_endpoint) # Pass the existing notify_endpoint through so it doesn't get overwritten
@@ -354,13 +461,16 @@ module Bugsnag
     #
     # @param new_notify_endpoint [String] The URL to deliver error notifications to
     # @param new_session_endpoint [String] The URL to deliver session notifications to
+    # @return [void]
     def set_endpoints(new_notify_endpoint, new_session_endpoint)
       @notify_endpoint = new_notify_endpoint
       @session_endpoint = new_session_endpoint
     end
 
     ##
-    # Disables session tracking and delivery.  Cannot be undone
+    # Disables session tracking and delivery. Cannot be undone
+    #
+    # @return [void]
     def disable_sessions
       self.auto_capture_sessions = false
       @enable_sessions = false

--- a/lib/bugsnag/report.rb
+++ b/lib/bugsnag/report.rb
@@ -19,24 +19,87 @@ module Bugsnag
 
     CURRENT_PAYLOAD_VERSION = "4.0"
 
-    attr_reader   :unhandled
+    # Whether this report is for a handled or unhandled error
+    # @return [Boolean]
+    attr_reader :unhandled
+
+    # Your Integration API Key
+    # @see Configuration#api_key
+    # @return [String, nil]
     attr_accessor :api_key
+
+    # The type of application executing the current code
+    # @see Configuration#app_type
+    # @return [String, nil]
     attr_accessor :app_type
+
+    # The current version of your application
+    # @return [String, nil]
     attr_accessor :app_version
+
+    # The list of breadcrumbs attached to this report
+    # @return [Array<Breadcrumb>]
     attr_accessor :breadcrumbs
+
+    # @api private
+    # @return [Configuration]
     attr_accessor :configuration
+
+    # Additional context for this report
+    # @return [String, nil]
     attr_accessor :context
+
+    # The delivery method that will be used for this report
+    # @see Configuration#delivery_method
+    # @return [Symbol]
     attr_accessor :delivery_method
+
+    # The list of exceptions in this report
+    # @return [Array<Hash>]
     attr_accessor :exceptions
+
+    # @see Configuration#hostname
+    # @return [String]
     attr_accessor :hostname
+
+    # @api private
+    # @see Configuration#runtime_versions
+    # @return [Hash{String => String}]
     attr_accessor :runtime_versions
+
+    # All errors with the same grouping hash will be grouped in the Bugsnag app
+    # @return [String]
     attr_accessor :grouping_hash
+
+    # Arbitrary metadata attached to this report
+    # @return [Hash]
     attr_accessor :meta_data
+
+    # The raw Exception instances for this report
+    # @see #exceptions
+    # @return [Array<Exception>]
     attr_accessor :raw_exceptions
+
+    # The current stage of the release process, e.g. 'development', production'
+    # @see Configuration#release_stage
+    # @return [String, nil]
     attr_accessor :release_stage
+
+    # The session that active when this report was generated
+    # @see SessionTracker#get_current_session
+    # @return [Hash]
     attr_accessor :session
+
+    # The severity of this report, e.g. 'error', 'warning'
+    # @return [String]
     attr_accessor :severity
+
+    # @api private
+    # @return [Hash]
     attr_accessor :severity_reason
+
+    # The current user when this report was generated
+    # @return [Hash]
     attr_accessor :user
 
     ##
@@ -66,6 +129,12 @@ module Bugsnag
 
     ##
     # Add a new metadata tab to this notification.
+    #
+    # @param name [String, #to_s] The name of the tab to add
+    # @param value [Hash, Object] The value to add to the tab. If the tab already
+    #   exists, this will be merged with the existing values. If a Hash is not
+    #   given, the value will be placed into the 'custom' tab
+    # @return [void]
     def add_tab(name, value)
       return if name.nil?
 
@@ -81,6 +150,9 @@ module Bugsnag
 
     ##
     # Removes a metadata tab from this notification.
+    #
+    # @param name [String]
+    # @return [void]
     def remove_tab(name)
       return if name.nil?
 
@@ -89,6 +161,8 @@ module Bugsnag
 
     ##
     # Builds and returns the exception payload for this notification.
+    #
+    # @return [Hash]
     def as_json
       # Build the payload's exception event
       payload_event = {
@@ -129,6 +203,8 @@ module Bugsnag
 
     ##
     # Returns the headers required for the notification.
+    #
+    # @return [Hash{String => String}]
     def headers
       {
         "Bugsnag-Api-Key" => api_key,
@@ -139,18 +215,24 @@ module Bugsnag
 
     ##
     # Whether this report should be ignored and not sent.
+    #
+    # @return [Boolean]
     def ignore?
       @should_ignore
     end
 
     ##
     # Data set on the configuration to be attached to every error notification.
+    #
+    # @return [Hash]
     def request_data
       configuration.request_data
     end
 
     ##
     # Tells the client this report should not be sent.
+    #
+    # @return [void]
     def ignore!
       @should_ignore = true
     end


### PR DESCRIPTION
## Goal

This PR expands upon the API docs for the public API of our most commonly used classes (`Bugsnag`, `Configuration` and `Report`)

This should give better type information and autocomplete to users, as well as improving the [written documentation hosted by ruby docs](https://www.rubydoc.info/gems/bugsnag/)