### PR TITLE
Workaround Bundler's friendly errors swallowing error reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## TBD
+
+### Enhancements
+
+* Bugsnag should now report uncaught exceptions inside Bundler's 'friendly errors'
+  | [#634](https://github.com/bugsnag/bugsnag-ruby/pull/634)
+
 ## 6.17.0 (27 August 2020)
 
 ### Enhancements

--- a/features/fixtures/plain/app/unhandled/custom_error.rb
+++ b/features/fixtures/plain/app/unhandled/custom_error.rb
@@ -1,7 +1,7 @@
-require './app'
+#!/usr/bin/env ruby
+require_relative '../app'
 
 configure_basics
-add_at_exit
 
 class CustomError < RuntimeError
 end

--- a/features/fixtures/plain/app/unhandled/exit_after_exception.rb
+++ b/features/fixtures/plain/app/unhandled/exit_after_exception.rb
@@ -1,0 +1,10 @@
+#!/usr/bin/env ruby
+require_relative '../app'
+
+configure_basics
+
+begin
+  raise 'oh no'
+rescue
+  exit
+end

--- a/features/fixtures/plain/app/unhandled/interrupt.rb
+++ b/features/fixtures/plain/app/unhandled/interrupt.rb
@@ -1,6 +1,6 @@
-require './app'
+#!/usr/bin/env ruby
+require_relative '../app'
 
 configure_basics
-add_at_exit
 
 Process.kill("INT", Process.pid)

--- a/features/fixtures/plain/app/unhandled/load_error.rb
+++ b/features/fixtures/plain/app/unhandled/load_error.rb
@@ -1,6 +1,6 @@
-require './app'
+#!/usr/bin/env ruby
+require_relative '../app'
 
 configure_basics
-add_at_exit
 
 require 'abc/def/ghi'

--- a/features/fixtures/plain/app/unhandled/local_jump_error.rb
+++ b/features/fixtures/plain/app/unhandled/local_jump_error.rb
@@ -1,7 +1,7 @@
-require './app'
+#!/usr/bin/env ruby
+require_relative '../app'
 
 configure_basics
-add_at_exit
 
 def call_block
   yield 50

--- a/features/fixtures/plain/app/unhandled/name_error.rb
+++ b/features/fixtures/plain/app/unhandled/name_error.rb
@@ -1,6 +1,6 @@
-require './app'
+#!/usr/bin/env ruby
+require_relative '../app'
 
 configure_basics
-add_at_exit
 
 foo

--- a/features/fixtures/plain/app/unhandled/no_method_error.rb
+++ b/features/fixtures/plain/app/unhandled/no_method_error.rb
@@ -1,6 +1,6 @@
-require './app'
+#!/usr/bin/env ruby
+require_relative '../app'
 
 configure_basics
-add_at_exit
 
 Kernel.foo

--- a/features/fixtures/plain/app/unhandled/runtime_error.rb
+++ b/features/fixtures/plain/app/unhandled/runtime_error.rb
@@ -1,6 +1,6 @@
-require './app'
+#!/usr/bin/env ruby
+require_relative '../app'
 
 configure_basics
-add_at_exit
 
 fail

--- a/features/fixtures/plain/app/unhandled/syntax_error.rb
+++ b/features/fixtures/plain/app/unhandled/syntax_error.rb
@@ -1,6 +1,6 @@
-require './app'
+#!/usr/bin/env ruby
+require_relative '../app'
 
 configure_basics
-add_at_exit
 
 require './unhandled/bad_syntax.rb'

--- a/features/fixtures/plain/app/unhandled/system_call_error.rb
+++ b/features/fixtures/plain/app/unhandled/system_call_error.rb
@@ -1,6 +1,6 @@
-require './app'
+#!/usr/bin/env ruby
+require_relative '../app'
 
 configure_basics
-add_at_exit
 
 File.open("abc/def/ghi")

--- a/features/fixtures/plain/app/unhandled/system_exit.rb
+++ b/features/fixtures/plain/app/unhandled/system_exit.rb
@@ -1,6 +1,6 @@
-require './app'
+#!/usr/bin/env ruby
+require_relative '../app'
 
 configure_basics
-add_at_exit
 
 exit

--- a/features/plain_features/unhandled_errors.feature
+++ b/features/plain_features/unhandled_errors.feature
@@ -36,8 +36,10 @@ Scenario Outline: An unhandled error doesn't send a report
   Then I should receive no requests
 
   Examples:
-  | file          | command          |
-  | interrupt     | bundle exec      |
-  | system_exit   | bundle exec      |
-  | interrupt     | bundle exec ruby |
-  | system_exit   | bundle exec ruby |
+  | file                 | command          |
+  | interrupt            | bundle exec      |
+  | system_exit          | bundle exec      |
+  | exit_after_exception | bundle exec      |
+  | interrupt            | bundle exec ruby |
+  | system_exit          | bundle exec ruby |
+  | exit_after_exception | bundle exec ruby |

--- a/features/plain_features/unhandled_errors.feature
+++ b/features/plain_features/unhandled_errors.feature
@@ -1,7 +1,7 @@
 Feature: Plain unhandled errors
 
 Scenario Outline: An unhandled error sends a report
-  Given I run the service "plain-ruby" with the command "bundle exec ruby unhandled/<file>.rb"
+  Given I run the service "plain-ruby" with the command "<command> unhandled/<file>.rb"
   And I wait to receive a request
   Then the request is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier"
   And the event "unhandled" is true
@@ -12,22 +12,32 @@ Scenario Outline: An unhandled error sends a report
   And the "lineNumber" of stack frame 0 equals <lineNumber>
 
   Examples:
-  | file              | error          | lineNumber |
-  | runtime_error     | RuntimeError   | 6          |
-  | load_error        | LoadError      | 6          |
-  | syntax_error      | SyntaxError    | 6          |
-  | local_jump_error  | LocalJumpError | 7          |
-  | name_error        | NameError      | 6          |
-  | no_method_error   | NoMethodError  | 6          |
-  | system_call_error | Errno::ENOENT  | 6          |
-  | custom_error      | CustomError    | 9          |
+  | file              | error          | lineNumber | command          |
+  | runtime_error     | RuntimeError   | 6          | bundle exec      |
+  | load_error        | LoadError      | 6          | bundle exec      |
+  | syntax_error      | SyntaxError    | 6          | bundle exec      |
+  | local_jump_error  | LocalJumpError | 7          | bundle exec      |
+  | name_error        | NameError      | 6          | bundle exec      |
+  | no_method_error   | NoMethodError  | 6          | bundle exec      |
+  | system_call_error | Errno::ENOENT  | 6          | bundle exec      |
+  | custom_error      | CustomError    | 9          | bundle exec      |
+  | runtime_error     | RuntimeError   | 6          | bundle exec ruby |
+  | load_error        | LoadError      | 6          | bundle exec ruby |
+  | syntax_error      | SyntaxError    | 6          | bundle exec ruby |
+  | local_jump_error  | LocalJumpError | 7          | bundle exec ruby |
+  | name_error        | NameError      | 6          | bundle exec ruby |
+  | no_method_error   | NoMethodError  | 6          | bundle exec ruby |
+  | system_call_error | Errno::ENOENT  | 6          | bundle exec ruby |
+  | custom_error      | CustomError    | 9          | bundle exec ruby |
 
 Scenario Outline: An unhandled error doesn't send a report
-  When I run the service "plain-ruby" with the command "bundle exec ruby unhandled/<file>.rb"
+  When I run the service "plain-ruby" with the command "<command> unhandled/<file>.rb"
   And I wait for 1 second
   Then I should receive no requests
 
   Examples:
-  | file          |
-  | interrupt     |
-  | system_exit   |
+  | file          | command          |
+  | interrupt     | bundle exec      |
+  | system_exit   | bundle exec      |
+  | interrupt     | bundle exec ruby |
+  | system_exit   | bundle exec ruby |


### PR DESCRIPTION
## Goal

When running a script with `bundle exec <file>` or `bundle exec ruby <file>`, Bundler will wrap any uncaught exceptions in a `SystemExit` — see https://github.com/rubygems/rubygems/issues/3368 and [`friendly_errors.rb`](https://github.com/rubygems/rubygems/blob/44388bfd7abad56f0f882fb9bc3f6c7c480f10bd/bundler/lib/bundler/friendly_errors.rb#L116-L123)

This means that the uncaught exceptions are ignored by default, as we don't report `SystemExit` exceptions, which can lead to real errors not being reported

This PR attempts to workaround this behaviour by trying to "unwrap" the original exception from the `SystemExit`. This is made more complicated by it being possible to have _two_ levels of `SystemExit` exceptions, if an executable script is run directly with `bundle exec <file>`. In this case we unwrap the "friendly errors" `SystemExit` and then unwrap the original exception

It's also important that we don't unwrap other `SystemExit` exceptions, because then we will report any time an exit is used in a `rescue` block, e.g.

```ruby
begin
  abc
  xyz
rescue
  exit
end
```

## Design

I'm not a huge fan of inspecting the backtrace for specific files, but they have stayed consistent for years so it should be fairly safe. I wasn't able to find another way to do this that didn't also result in reporting legitimate exits

## Changeset

- added `unwrap_bundler_exception` which is used in the `at_exit` hook
- reworked plain ruby maze runner tests

## Testing

The maze runner tests run the same files with the same results using both `bundle exec` and `bundle exec ruby`, which proves we can unwrap 1 or 2 levels of exceptions as needed

The new `exit_after_exception` test ensures we don't report exits outside of Bundler