### PR TITLE
Truncate Exception Messages if needed.

### DIFF
--- a/spec/helper_spec.rb
+++ b/spec/helper_spec.rb
@@ -41,6 +41,22 @@ describe Bugsnag::Helpers do
     end
 
     context "payload length is greater than allowed" do
+      it "trims exception messages" do
+        payload = {
+          :events => [{
+            :exceptions => [{
+              :message => 50000.times.map {|i| "should truncate" }.join(""),
+              :preserved => "Foo"
+            }]
+          }]
+        }
+        expect(::JSON.dump(payload).length).to be > Bugsnag::Helpers::MAX_PAYLOAD_LENGTH
+        trimmed = Bugsnag::Helpers.trim_if_needed(payload)
+        expect(::JSON.dump(trimmed).length).to be <= Bugsnag::Helpers::MAX_PAYLOAD_LENGTH
+        expect(trimmed[:events][0][:exceptions][0][:message].length).to be <= Bugsnag::Helpers::MAX_STRING_LENGTH
+        expect(trimmed[:events][0][:exceptions][0][:preserved]).to eq("Foo")
+      end
+
       it "trims metadata strings" do
         payload = {
           :events => [{


### PR DESCRIPTION
## Goal

If an exception occurs, such as a `Mysql2::Error::ConnectionError`, where the query is extremely long, this can cause the payload to exceed what Bugsnag will accept and throw a `Errno::EPIPE: Broken pipe` error when trying to send the request to Bugsnag.

A number of elements are already trimmed when the payload is too large, including meta data, stacktrace code, etc. However, the exception messages were not being trimmed.

This commit adds exception message trimming to `Bugsnag::Helpers.trim_if_needed`, which should help reduce errors when the queries causing the errors are exceptionally long.

## Design

A number of elements are already trimmed when the payload is too large, including meta data, stacktrace code, etc. However, the exception messages were not being trimmed.

This commit adds exception message trimming to `Bugsnag::Helpers.trim_if_needed`, which should help reduce errors when the queries causing the errors are exceptionally long.

## Changeset

Added `truncate_exception_messages` to `Bugsnag::Helpers.trim_if_needed` method, which truncates the exception messages if necessary.

## Testing

Manually on our Rails 4.2 / Bugsnag 6.17.0 enterprise application. 

Added a spec to `helper_spec.rb` that tests this functionality specifically.

✅  All tests passing when running `bundle exec rake`. 