### PR TITLE
Add Note for installing test group gems.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,9 @@ Thank you!
     ```
     bundle exec rake spec
     ```
+    
+    _NOTE: You may need to install the bundle with the `test` group first by running `bundle install --with test`. Otherwise, you will get `can't find executable rake for gem rake` error._
+    
 * Further information on installing and running the tests can be found in [the testing guide](TESTING.md)
 
 ### Document

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,12 +15,15 @@ Thank you!
 
 ### Polish
 
+* Install the test dependencies
+    ```
+    bundle install --with test sidekiq --binstubs
+    ```
+
 * Run the tests with and make sure they all pass
     ```
     bundle exec rake spec
     ```
-    
-    _NOTE: You may need to install the bundle with the `test` group first by running `bundle install --with test`. Otherwise, you will get `can't find executable rake for gem rake` error._
     
 * Further information on installing and running the tests can be found in [the testing guide](TESTING.md)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ Thank you!
 
 * Run the tests with and make sure they all pass
     ```
-    bundle exec rake spec
+    bundle exec rake
     ```
     
 * Further information on installing and running the tests can be found in [the testing guide](TESTING.md)


### PR DESCRIPTION
Added a note that in order to run the specs, you may need to install the bundle with the `--with test` command line option in order to install the `test` group of gems, including `rake`. Otherwise you end up with an error like this: 

```bash
$ be rake spec

bundler: failed to load command: rake (/Users/joshuapinter/.rbenv/versions/2.6.5/bin/rake)
Gem::Exception: can't find executable rake for gem rake. rake is not currently included in the bundle, perhaps you meant to add it to your Gemfile?
```

Wasted 15 minutes figuring out what the issue was so this should help others contribute.