### PR TITLE
Increase timestamp resolution to include milliseconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Changelog
 * Bugsnag should now report uncaught exceptions inside Bundler's 'friendly errors'
   | [#634](https://github.com/bugsnag/bugsnag-ruby/pull/634)
 
+* Improve the display of breadrumbs in the Bugsnag app by including milliseconds in timestamps
+  | [#639](https://github.com/bugsnag/bugsnag-ruby/pull/639)
+
 ## 6.17.0 (27 August 2020)
 
 ### Enhancements

--- a/lib/bugsnag/breadcrumbs/breadcrumb.rb
+++ b/lib/bugsnag/breadcrumbs/breadcrumb.rb
@@ -69,7 +69,7 @@ module Bugsnag::Breadcrumbs
         :name => @name,
         :type => @type,
         :metaData => @meta_data,
-        :timestamp => @timestamp.iso8601
+        :timestamp => @timestamp.iso8601(3)
       }
     end
   end

--- a/lib/bugsnag/delivery/synchronous.rb
+++ b/lib/bugsnag/delivery/synchronous.rb
@@ -58,7 +58,7 @@ module Bugsnag
         def default_headers
           {
             "Content-Type" => "application/json",
-            "Bugsnag-Sent-At" =>  Time.now().utc().strftime('%Y-%m-%dT%H:%M:%S')
+            "Bugsnag-Sent-At" => Time.now.utc.iso8601(3)
           }
         end
       end

--- a/lib/bugsnag/report.rb
+++ b/lib/bugsnag/report.rb
@@ -209,7 +209,7 @@ module Bugsnag
       {
         "Bugsnag-Api-Key" => api_key,
         "Bugsnag-Payload-Version" => CURRENT_PAYLOAD_VERSION,
-        "Bugsnag-Sent-At" => Time.now().utc().strftime('%Y-%m-%dT%H:%M:%S')
+        "Bugsnag-Sent-At" => Time.now.utc.iso8601(3)
       }
     end
 

--- a/spec/breadcrumbs/breadcrumb_spec.rb
+++ b/spec/breadcrumbs/breadcrumb_spec.rb
@@ -74,20 +74,26 @@ RSpec.describe Bugsnag::Breadcrumbs::Breadcrumb do
 
   describe "#to_h" do
     it "outputs as a hash" do
-      breadcrumb = Bugsnag::Breadcrumbs::Breadcrumb.new("my message", "test type", {:a => 1, :b => 2}, :manual)
-      output = breadcrumb.to_h
+      fake_now = Time.gm(2020, 1, 2, 3, 4, 5, 123456)
+      expect(Time).to receive(:now).and_return(fake_now)
 
-      timestamp_regex = /^\d{4}\-\d{2}\-\d{2}T\d{2}:\d{2}:[\d\.]+Z$/
-
-      expect(output).to match(
-        :name => "my message",
-        :type => "test type",
-        :metaData => {
-          :a => 1,
-          :b => 2
-        },
-        :timestamp => eq(breadcrumb.timestamp.iso8601)
+      breadcrumb = Bugsnag::Breadcrumbs::Breadcrumb.new(
+        "my message",
+        "test type",
+        { a: 1, b: 2 },
+        :manual
       )
+
+      expect(breadcrumb.to_h).to eq({
+        name: "my message",
+        type: "test type",
+        metaData: {
+          a: 1,
+          b: 2
+        },
+        # This matches the time we stubbed earlier (fake_now)
+        timestamp: "2020-01-02T03:04:05.123Z"
+      })
     end
   end
 end

--- a/spec/bugsnag_spec.rb
+++ b/spec/bugsnag_spec.rb
@@ -363,4 +363,18 @@ describe Bugsnag do
       Bugsnag.leave_breadcrumb("TestName")
     end
   end
+
+  describe "request headers" do
+    it "Bugsnag-Sent-At should use the current time" do
+      fake_now = Time.gm(2020, 1, 2, 3, 4, 5, 123456)
+      expect(Time).to receive(:now).at_most(5).times.and_return(fake_now)
+
+      Bugsnag.notify(BugsnagTestException.new("It crashed"))
+
+      expect(Bugsnag).to have_sent_notification{ |payload, headers|
+        # This matches the time we stubbed earlier (fake_now)
+        expect(headers["Bugsnag-Sent-At"]).to eq("2020-01-02T03:04:05.123Z")
+      }
+    end
+  end
 end

--- a/spec/report_spec.rb
+++ b/spec/report_spec.rb
@@ -92,6 +92,23 @@ describe Bugsnag::Report do
     }
   end
 
+  it "#headers should return the correct request headers" do
+    fake_now = Time.gm(2020, 1, 2, 3, 4, 5, 123456)
+    expect(Time).to receive(:now).and_return(fake_now)
+
+    report = Bugsnag::Report.new(
+      BugsnagTestException.new("It crashed"),
+      Bugsnag.configuration
+    )
+
+    expect(report.headers).to eq({
+      "Bugsnag-Api-Key" => "c9d60ae4c7e70c4b6c4ebd3e8056d2b8",
+      "Bugsnag-Payload-Version" => "4.0",
+      # This matches the time we stubbed earlier (fake_now)
+      "Bugsnag-Sent-At" => "2020-01-02T03:04:05.123Z"
+    })
+  end
+
   it "has the right exception class" do
     Bugsnag.notify(BugsnagTestException.new("It crashed"))
 


### PR DESCRIPTION
## Goal

In order for the Bugsnag app to report breadcrumb times more accurately, we need to send timestamps with milliseconds. Other timestamps have also been updated for consistency, but shouldn't have any impact. The session tracker has not been updated as it intentionally rounds to the minute

## Testing

Additional unit tests added to check the timestamps are as expected. Existing MR tests also check the timestamps against a regex, which didn't need to be updated