### PR TITLE
Loosen restriction on Delayed Job version in MR tests

### DIFF
--- a/features/delayed_job.feature
+++ b/features/delayed_job.feature
@@ -18,7 +18,7 @@ Scenario: An unhandled RuntimeError sends a report with arguments
   And the event "metaData.job.payload.display_name" equals "TestModel.fail_with_args"
   And the event "metaData.job.payload.method_name" equals "fail_with_args"
   And the payload field "events.0.metaData.job.payload.args.0" equals "Test"
-  And the event "device.runtimeVersions.delayed_job" equals "4.1.8"
+  And the event "device.runtimeVersions.delayed_job" matches "\d+\.\d+\.\d+"
 
 Scenario: A handled exception sends a report
   Given I run the service "delayed_job" with the command "bundle exec rake delayed_job_tests:notify_with_args"
@@ -37,7 +37,7 @@ Scenario: A handled exception sends a report
   And the event "metaData.job.payload.display_name" equals "TestModel.notify_with_args"
   And the event "metaData.job.payload.method_name" equals "notify_with_args"
   And the payload field "events.0.metaData.job.payload.args.0" equals "Test"
-  And the event "device.runtimeVersions.delayed_job" equals "4.1.8"
+  And the event "device.runtimeVersions.delayed_job" matches "\d+\.\d+\.\d+"
 
 Scenario: The report context uses the class name if no display name is available
   Given I run the service "delayed_job" with the command "bundle exec rake delayed_job_tests:report_context"
@@ -55,4 +55,4 @@ Scenario: The report context uses the class name if no display name is available
   And the event "metaData.job.max_attempts" equals 1
   And the event "metaData.job.payload.display_name" is null
   And the event "metaData.job.payload.method_name" is null
-  And the event "device.runtimeVersions.delayed_job" equals "4.1.8"
+  And the event "device.runtimeVersions.delayed_job" matches "\d+\.\d+\.\d+"


### PR DESCRIPTION
## Goal

Our DelayedJob MR tests currently check for a specific version of DelayedJob but have no restrictions on which version is installed. Version 4.1.9 released recently and our tests now pick up that version, but we're still checking for the old version number

This PR changes the version test to use a regex instead, so DelayedJob releases don't break things spuriously