### PR TITLE
Use up-to-date Bundler versions

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -21,6 +21,7 @@ steps:
         use-aliases: true
     env:
       RUBY_TEST_VERSION: "1.9.3"
+      BUNDLE_VERSION: "1.12.0"
 
   - label: ':ruby: Ruby 2.7 unit tests'
     timeout_in_minutes: 30
@@ -115,6 +116,7 @@ steps:
         use-aliases: true
     env:
       RUBY_TEST_VERSION: "2.0"
+      BUNDLE_VERSION: "1.12.0"
     concurrency: 4
     concurrency_group: 'ruby/unit-tests'
 
@@ -126,6 +128,7 @@ steps:
         use-aliases: true
     env:
       RUBY_TEST_VERSION: "2.1"
+      BUNDLE_VERSION: "1.12.0"
     concurrency: 4
     concurrency_group: 'ruby/unit-tests'
 
@@ -137,6 +140,7 @@ steps:
         use-aliases: true
     env:
       RUBY_TEST_VERSION: "2.2"
+      BUNDLE_VERSION: "1.12.0"
       GEMSETS: "test sidekiq"
     concurrency: 4
     concurrency_group: 'ruby/unit-tests'
@@ -149,6 +153,7 @@ steps:
         use-aliases: true
     env:
       RUBY_TEST_VERSION: "2.3"
+      BUNDLE_VERSION: "1.12.0"
       GEMSETS: "test sidekiq"
     concurrency: 4
     concurrency_group: 'ruby/unit-tests'
@@ -198,6 +203,7 @@ steps:
         command: ["features/plain_features", "--tags", "not @wip"]
     env:
       RUBY_TEST_VERSION: "1.9.3"
+      BUNDLE_VERSION: "1.12.0"
     concurrency: 8
     concurrency_group: 'ruby/slow-maze-runner-tests'
 
@@ -210,6 +216,7 @@ steps:
         command: ["features/plain_features", "--tags", "not @wip"]
     env:
       RUBY_TEST_VERSION: "2.0"
+      BUNDLE_VERSION: "1.12.0"
     concurrency: 8
     concurrency_group: 'ruby/slow-maze-runner-tests'
 
@@ -222,6 +229,7 @@ steps:
         command: ["features/plain_features", "--tags", "not @wip"]
     env:
       RUBY_TEST_VERSION: "2.1"
+      BUNDLE_VERSION: "1.12.0"
     concurrency: 8
     concurrency_group: 'ruby/slow-maze-runner-tests'
 
@@ -234,6 +242,7 @@ steps:
         command: ["features/plain_features", "--tags", "not @wip"]
     env:
       RUBY_TEST_VERSION: "2.2"
+      BUNDLE_VERSION: "1.12.0"
     concurrency: 8
     concurrency_group: 'ruby/slow-maze-runner-tests'
 
@@ -334,6 +343,7 @@ steps:
     env:
       RUBY_TEST_VERSION: "2.0"
       RAILS_VERSION: "3"
+      BUNDLE_VERSION: "1.12.0"
     concurrency: 8
     concurrency_group: 'ruby/slow-maze-runner-tests'
 
@@ -347,6 +357,7 @@ steps:
     env:
       RUBY_TEST_VERSION: "2.1"
       RAILS_VERSION: "3"
+      BUNDLE_VERSION: "1.12.0"
     concurrency: 8
     concurrency_group: 'ruby/slow-maze-runner-tests'
 
@@ -360,6 +371,7 @@ steps:
     env:
       RUBY_TEST_VERSION: "2.2"
       RAILS_VERSION: "3"
+      BUNDLE_VERSION: "1.12.0"
     concurrency: 8
     concurrency_group: 'ruby/slow-maze-runner-tests'
 
@@ -412,6 +424,7 @@ steps:
     env:
       RUBY_TEST_VERSION: "2.2"
       RAILS_VERSION: "4"
+      BUNDLE_VERSION: "1.12.0"
     concurrency: 8
     concurrency_group: 'ruby/slow-maze-runner-tests'
 
@@ -438,6 +451,7 @@ steps:
     env:
       RUBY_TEST_VERSION: "2.2"
       RAILS_VERSION: "5"
+      BUNDLE_VERSION: "1.12.0"
     concurrency: 8
     concurrency_group: 'ruby/slow-maze-runner-tests'
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       args:
         - RUBY_TEST_VERSION
         - GEMSETS=${GEMSETS:-test}
-        - BUNDLE_VERSION=${BUNDLE_VERSION:-1.12.0}
+        - BUNDLE_VERSION=${BUNDLE_VERSION:-2.2.0}
     environment:
       COVERALLS_REPO_TOKEN:
       GEMSETS:
@@ -40,7 +40,7 @@ services:
       dockerfile: dockerfiles/Dockerfile.jruby-unit-tests
       args:
         - GEMSETS=${GEMSETS:-test}
-        - BUNDLE_VERSION=${BUNDLE_VERSION:-1.12.0}
+        - BUNDLE_VERSION=${BUNDLE_VERSION:-2.2.0}
 
 networks:
   default:


### PR DESCRIPTION
## Goal

Use Bundler 2 in tests where possible for Ruby 3 compatibility. Older Ruby versions will still use 1.12