### PR TITLE
Truncate Exception Messages if needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+## TBD
+
+### Enhancements
+
+* Exception messages will be truncated if they have a length greater than 3,072
+  | [#636](https://github.com/bugsnag/bugsnag-ruby/pull/636)
+  | [joshuapinter](https://github.com/joshuapinter)
+
 ## 6.18.0 (27 October 2020)
 
 ### Enhancements


### PR DESCRIPTION
This is PR #636 rebased onto `next` + a changelog entry

---

## Goal

If an exception occurs, such as a `Mysql2::Error::ConnectionError`, where the query is extremely long, this can cause the payload to exceed what Bugsnag will accept and throw a `Errno::EPIPE: Broken pipe` error when trying to send the request to Bugsnag.

A number of elements are already trimmed when the payload is too large, including meta data, stacktrace code, etc. However, the exception messages were not being trimmed.

This commit adds exception message trimming to `Bugsnag::Helpers.trim_if_needed`, which should help reduce errors when the queries causing the errors are exceptionally long.

## Design

A number of elements are already trimmed when the payload is too large, including meta data, stacktrace code, etc. However, the exception messages were not being trimmed.

This commit adds exception message trimming to `Bugsnag::Helpers.trim_if_needed`, which should help reduce errors when the queries causing the errors are exceptionally long.

## Changeset

Added `truncate_exception_messages` to `Bugsnag::Helpers.trim_if_needed` method, which truncates the exception messages if necessary.

## Testing

Manually on our Rails 4.2 / Bugsnag 6.17.0 enterprise application. 

Added a spec to `helper_spec.rb` that tests this functionality specifically.

✅  All tests passing when running `bundle exec rake`. 