### PR TITLE
Add Ruby 3.0 to CI

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -194,6 +194,17 @@ steps:
     concurrency: 4
     concurrency_group: 'ruby/unit-tests'
 
+  - label: ':ruby: Ruby 3.0 unit tests'
+    timeout_in_minutes: 30
+    plugins:
+      docker-compose#v3.1.0:
+        run: ruby-unit-tests
+        use-aliases: true
+    env:
+      RUBY_TEST_VERSION: "3.0"
+    concurrency: 4
+    concurrency_group: 'ruby/unit-tests'
+
   - label: ':ruby: Ruby 1.9 plain tests'
     timeout_in_minutes: 30
     plugins:
@@ -291,6 +302,18 @@ steps:
         command: ["features/plain_features/", "--tags", "not @wip"]
     env:
       RUBY_TEST_VERSION: "2.6"
+    concurrency: 8
+    concurrency_group: 'ruby/slow-maze-runner-tests'
+
+  - label: ':ruby: Ruby 3.0 plain tests'
+    timeout_in_minutes: 30
+    plugins:
+      docker-compose#v3.1.0:
+        run: ruby-maze-runner
+        use-aliases: true
+        command: ["features/plain_features/", "--tags", "not @wip"]
+    env:
+      RUBY_TEST_VERSION: "3.0"
     concurrency: 8
     concurrency_group: 'ruby/slow-maze-runner-tests'
 
@@ -533,6 +556,32 @@ steps:
     concurrency: 8
     concurrency_group: 'ruby/slow-maze-runner-tests'
 
+  - label: ':rails: Rails 6 Ruby 3.0 tests'
+    timeout_in_minutes: 30
+    plugins:
+      docker-compose#v3.1.0:
+        run: ruby-maze-runner
+        use-aliases: true
+        command: ["features/rails_features/",  "--tags", "@rails6 and not @wip"]
+    env:
+      RUBY_TEST_VERSION: "3.0"
+      RAILS_VERSION: "6"
+    concurrency: 8
+    concurrency_group: 'ruby/slow-maze-runner-tests'
+
+  - label: ':rails: Rails integrations Ruby 3.0 tests'
+    timeout_in_minutes: 30
+    plugins:
+      docker-compose#v3.1.0:
+        run: ruby-maze-runner
+        use-aliases: true
+        command: ["features/rails_features/", "--tags", "@rails_integrations"]
+    env:
+      RUBY_TEST_VERSION: "3.0"
+      RAILS_VERSION: "_integrations"
+    concurrency: 8
+    concurrency_group: 'ruby/slow-maze-runner-tests'
+
   - label: ':clipboard: Rake Ruby 1.9 tests'
     timeout_in_minutes: 30
     plugins:
@@ -641,6 +690,18 @@ steps:
     concurrency: 4
     concurrency_group: 'ruby/integrations-maze-runner-tests'
 
+  - label: ':clipboard: Rake Ruby 3.0 tests'
+    timeout_in_minutes: 30
+    plugins:
+      docker-compose#v3.1.0:
+        run: ruby-maze-runner
+        use-aliases: true
+        command: ['features/rake.feature', '--tags', 'not @wip']
+    env:
+      RUBY_TEST_VERSION: "3.0"
+    concurrency: 4
+    concurrency_group: 'ruby/integrations-maze-runner-tests'
+
   - label: ':postbox: Mailman Ruby 2.0 tests'
     timeout_in_minutes: 30
     plugins:
@@ -739,6 +800,18 @@ steps:
     concurrency: 4
     concurrency_group: 'ruby/integrations-maze-runner-tests'
 
+  - label: ':postbox: Mailman Ruby 3.0 tests'
+    timeout_in_minutes: 30
+    plugins:
+      docker-compose#v3.1.0:
+        run: ruby-maze-runner
+        use-aliases: true
+        command: ['features/mailman.feature', '--tags', 'not @wip']
+    env:
+      RUBY_TEST_VERSION: "3.0"
+    concurrency: 4
+    concurrency_group: 'ruby/integrations-maze-runner-tests'
+
   - label: ':key: Que Ruby 2.0 tests'
     timeout_in_minutes: 30
     plugins:
@@ -834,6 +907,18 @@ steps:
         command: ['features/que.feature', '--tags', 'not @wip']
     env:
       RUBY_TEST_VERSION: '2.7'
+    concurrency: 4
+    concurrency_group: 'ruby/integrations-maze-runner-tests'
+
+  - label: ':key: Que Ruby 3.0 tests'
+    timeout_in_minutes: 30
+    plugins:
+      docker-compose#v3.1.0:
+        run: ruby-maze-runner
+        use-aliases: true
+        command: ['features/que.feature', '--tags', 'not @wip']
+    env:
+      RUBY_TEST_VERSION: "3.0"
     concurrency: 4
     concurrency_group: 'ruby/integrations-maze-runner-tests'
 
@@ -954,6 +1039,19 @@ steps:
     concurrency: 4
     concurrency_group: 'ruby/integrations-maze-runner-tests'
 
+  - label: ':bed: Rack 1 Ruby 3.0 tests'
+    timeout_in_minutes: 30
+    plugins:
+      docker-compose#v3.1.0:
+        run: ruby-maze-runner
+        use-aliases: true
+        command: ['features/rack.feature', '--tags', 'not @wip']
+    env:
+      RUBY_TEST_VERSION: "3.0"
+      RACK_VERSION: '1'
+    concurrency: 4
+    concurrency_group: 'ruby/integrations-maze-runner-tests'
+
   - label: ':bed: Rack 2 Ruby 2.2 tests'
     timeout_in_minutes: 30
     plugins:
@@ -1028,6 +1126,19 @@ steps:
         command: ['features/rack.feature', '--tags', 'not @wip']
     env:
       RUBY_TEST_VERSION: '2.7'
+      RACK_VERSION: '2'
+    concurrency: 4
+    concurrency_group: 'ruby/integrations-maze-runner-tests'
+
+  - label: ':bed: Rack 2 Ruby 3.0 tests'
+    timeout_in_minutes: 30
+    plugins:
+      docker-compose#v3.1.0:
+        run: ruby-maze-runner
+        use-aliases: true
+        command: ['features/rack.feature', '--tags', 'not @wip']
+    env:
+      RUBY_TEST_VERSION: "3.0"
       RACK_VERSION: '2'
     concurrency: 4
     concurrency_group: 'ruby/integrations-maze-runner-tests'

--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,9 @@ group :test, optional: true do
   elsif ruby_version >= Gem::Version.new('2.3.0')
     gem 'did_you_mean', '~> 1.0.4'
   end
+
+  # WEBrick is no longer in the stdlib in Ruby 3.0
+  gem 'webrick' if ruby_version >= Gem::Version.new('3.0.0')
 end
 
 group :coverage, optional: true do

--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,9 @@ group :test, optional: true do
 
   gem 'hashdiff', ruby_version <= Gem::Version.new('1.9.3') ? '0.3.8': '>0.3.8'
 
-  if ruby_version >= Gem::Version.new('2.7.0')
+  if ruby_version >= Gem::Version.new('3.0.0')
+    gem 'did_you_mean', '~> 1.5.0'
+  elsif ruby_version >= Gem::Version.new('2.7.0')
     gem 'did_you_mean', '~> 1.4.0'
   elsif ruby_version >= Gem::Version.new('2.5.0')
     gem 'did_you_mean', '~> 1.3.1'

--- a/Gemfile
+++ b/Gemfile
@@ -9,12 +9,17 @@ group :test, optional: true do
   gem 'yard', '~> 0.9.25'
   gem 'pry'
   gem 'addressable', '~> 2.3.8'
+
   if ruby_version >= Gem::Version.new('2.2.2')
     gem 'delayed_job', ruby_version < Gem::Version.new('2.5.0') ? '4.1.7': '>4.1.7'
     gem 'i18n', ruby_version <= Gem::Version.new('2.3.0') ? '1.4.0' : '>1.4.0'
   end
+
   gem 'webmock', ruby_version <= Gem::Version.new('1.9.3') ? '2.3.2': '>2.3.2'
+  gem 'crack', '< 0.4.5' if ruby_version <= Gem::Version.new('1.9.3')
+
   gem 'hashdiff', ruby_version <= Gem::Version.new('1.9.3') ? '0.3.8': '>0.3.8'
+
   if ruby_version >= Gem::Version.new('2.7.0')
     gem 'did_you_mean', '~> 1.4.0'
   elsif ruby_version >= Gem::Version.new('2.5.0')

--- a/features/fixtures/rack1/app/Gemfile
+++ b/features/fixtures/rack1/app/Gemfile
@@ -2,3 +2,4 @@ source 'https://rubygems.org'
 
 gem 'bugsnag', path: '/bugsnag'
 gem 'rack', '~> 1'
+gem 'webrick' if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('3.0.0')

--- a/features/fixtures/rack2/app/Gemfile
+++ b/features/fixtures/rack2/app/Gemfile
@@ -2,3 +2,4 @@ source 'https://rubygems.org'
 
 gem 'bugsnag', path: '/bugsnag'
 gem 'rack', '~> 2'
+gem 'webrick' if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('3.0.0')

--- a/features/fixtures/rails_integrations/app/Gemfile
+++ b/features/fixtures/rails_integrations/app/Gemfile
@@ -6,6 +6,14 @@ gem 'bugsnag', path: ENV.fetch('BUGSNAG_GEM_PATH', '../../../../')
 gem 'delayed_job_active_record'
 gem 'mailman', '~> 0.7.3'
 gem 'que', '~> 0.14.3'
+
+# Ensure we get a version of 'redis-namespace' that's compatible with Ruby 3
+# There isn't a tag for this yet, so we fetch a commit that's known to work
+# TODO remove this when a new version is released
+if RUBY_VERSION >= '3.0.0'
+  gem 'redis-namespace', github: 'resque/redis-namespace', ref: 'c31e63dc3cd5e59ef5ea394d4d46ac60d1e6f82e'
+end
+
 gem 'resque', '~> 2.0.0'
 gem 'sidekiq', '~> 6.1.0'
 

--- a/features/steps/ruby_notifier_steps.rb
+++ b/features/steps/ruby_notifier_steps.rb
@@ -45,11 +45,17 @@ Given("I start the rails service") do
   }
 end
 
+# When running tests against Rails on Ruby 3, the base Maze Runner step
+# "I open the url {string}" commonly flakes due to a "Errno::ECONNREFUSED"
+# error, which MR doesn't rescue. The notifier request is still fired so the
+# test passes when these errors are rescued and there's no risk of swallowing an
+# actual failure because any assertion steps will fail if the notifier request
+# isn't fired. This may become unnecessary in future, when running Rails on
+# Ruby 3 is more stable
 When("I navigate to the route {string} on the rails app") do |route|
-  rails_version = ENV["RAILS_VERSION"]
-  steps %Q{
-    When I open the URL "http://rails#{rails_version}:3000#{route}"
-  }
+  URI.open("http://rails#{ENV["RAILS_VERSION"]}:3000#{route}", &:read)
+rescue => e
+  $logger.debug(e.inspect)
 end
 
 When("I run {string} in the rails app") do |command|

--- a/spec/fixtures/apps/rails-initializer-config/Gemfile
+++ b/spec/fixtures/apps/rails-initializer-config/Gemfile
@@ -4,6 +4,6 @@ ruby_version = Gem::Version.new(RUBY_VERSION.dup)
 
 gem 'railties', ruby_version <= Gem::Version.new('2.6') ? '4.2.10' : '~> 6.0.2', require: %w(action_controller rails)
 gem 'rake', ruby_version <= Gem::Version.new('1.9.3') ? '~> 11.3.0' : '~> 12.3.0'
-gem 'minitest', ruby_version <= Gem::Version.new('2.2') ? '5.11.3' : '~> 5.13.0'
+gem 'minitest', ruby_version <= Gem::Version.new('2.2') ? '5.11.3' : '~> 5.14.0'
 gem 'nokogiri', '1.6.8'
 gem 'bugsnag', path: '../../../..'

--- a/spec/fixtures/apps/rails-invalid-initializer-config/Gemfile
+++ b/spec/fixtures/apps/rails-invalid-initializer-config/Gemfile
@@ -4,6 +4,6 @@ ruby_version = Gem::Version.new(RUBY_VERSION.dup)
 
 gem 'railties', ruby_version <= Gem::Version.new('2.6') ? '4.2.10' : '~> 6.0.2', require: %w(action_controller rails)
 gem 'rake', ruby_version <= Gem::Version.new('1.9.3') ? '~> 11.3.0' : '~> 12.3.0'
-gem 'minitest', ruby_version <= Gem::Version.new('2.2') ? '5.11.3' : '~> 5.13.0'
+gem 'minitest', ruby_version <= Gem::Version.new('2.2') ? '5.11.3' : '~> 5.14.0'
 gem 'nokogiri', '1.6.8'
 gem 'bugsnag', path: '../../../..'

--- a/spec/fixtures/apps/rails-no-config/Gemfile
+++ b/spec/fixtures/apps/rails-no-config/Gemfile
@@ -4,6 +4,6 @@ ruby_version = Gem::Version.new(RUBY_VERSION.dup)
 
 gem 'railties', ruby_version <= Gem::Version.new('2.6') ? '4.2.10' : '~> 6.0.2', require: %w(action_controller rails)
 gem 'rake', ruby_version <= Gem::Version.new('1.9.3') ? '~> 11.3.0' : '~> 12.3.0'
-gem 'minitest', ruby_version <= Gem::Version.new('2.2') ? '5.11.3' : '~> 5.13.0'
+gem 'minitest', ruby_version <= Gem::Version.new('2.2') ? '5.11.3' : '~> 5.14.0'
 gem 'nokogiri', '1.6.8'
 gem 'bugsnag', path: '../../../..'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -42,12 +42,8 @@ def notify_test_exception(*args)
   Bugsnag.notify(RuntimeError.new("test message"), *args)
 end
 
-def ruby_version_greater_equal?(version)
-  current_version = RUBY_VERSION.split "."
-  target_version = version.split "."
-  (Integer(current_version[0]) >= Integer(target_version[0])) &&
-    (Integer(current_version[1]) >= Integer(target_version[1])) &&
-    (Integer(current_version[2]) >= Integer(target_version[2]))
+def ruby_version_greater_equal?(target_version)
+  Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new(target_version)
 end
 
 RSpec.configure do |config|


### PR DESCRIPTION
**Waiting for full release & a 3.0.0 Docker tag before merging**

## Goal

Adds Ruby 3.0 to CI, with related changes to fixtures to make this work

## Changeset

- Added Gems that are no longer in the stdlib to the `test` group in `Gemfile`
- Ensure we get a version of 'redis-namespace' that's compatible with Ruby 3 for the Rails integrations tests (this is temporary until a new version is released)
- Fix an issue with the "I navigate to the route {string} on the rails app" step in Ruby 3
- Use minitest 5.14 in fixture apps
- Fix ruby version comparison helper