### PR TITLE
Fix Que & Mailman test fixtures on Ruby 2.0

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -713,8 +713,6 @@ steps:
       RUBY_TEST_VERSION: '2.0'
     concurrency: 4
     concurrency_group: 'ruby/integrations-maze-runner-tests'
-    soft_fail:
-      - exit_status: "*"
 
   - label: ':postbox: Mailman Ruby 2.1 tests'
     timeout_in_minutes: 30

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -823,8 +823,6 @@ steps:
       RUBY_TEST_VERSION: '2.0'
     concurrency: 4
     concurrency_group: 'ruby/integrations-maze-runner-tests'
-    soft_fail:
-      - exit_status: "*"
 
   - label: ':key: Que Ruby 2.1 tests'
     timeout_in_minutes: 30

--- a/features/fixtures/mailman/app/Gemfile
+++ b/features/fixtures/mailman/app/Gemfile
@@ -8,3 +8,6 @@ gem 'rb-inotify', '0.9.8'
 gem 'maildir', '~> 2.1.0'
 gem 'activesupport', '~> 3.2'
 gem 'rack', '~> 1.6.11'
+
+# Install a compatible FFI version on Ruby <2.3
+gem 'ffi', '< 1.13.0' if RUBY_VERSION < '2.3.0'

--- a/features/fixtures/que/app/Gemfile
+++ b/features/fixtures/que/app/Gemfile
@@ -5,5 +5,7 @@ gem "bugsnag", path: "/bugsnag"
 gem "que", "~> 0.14.3"
 
 gem "pg", RUBY_VERSION < "2.2.0" ? "0.21.0" : "> 0.21.0"
-
 gem "activerecord", RUBY_VERSION < "2.2.0" ? "4.2.11" : "> 4.2.11"
+
+# Install a compatible Minitest version on Ruby <2.3
+gem 'minitest', '5.11.3' if RUBY_VERSION < '2.3.0'


### PR DESCRIPTION
Fixes some dependency errors in the Que & Mailman test fixtures on Ruby 2.0 & removes soft fail on Buildkite

I also made the Que fixture more reliable by waiting for the Postgres container to be ready before it does anything else — it seemed to be fine on CI before this but was failing on most runs locally