### PR TITLE
Test on Sidekiq 6

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -95,7 +95,7 @@ steps:
         command: ["features/sidekiq.feature", "--tags", "not @wip"]
     env:
       RUBY_TEST_VERSION: "2.5"
-      SIDEKIQ_VERSION: "~> 5"
+      SIDEKIQ_VERSION: "5"
 
   - wait
 
@@ -326,7 +326,7 @@ steps:
         command: ["features/sidekiq.feature", "--tags", "not @wip"]
     env:
       RUBY_TEST_VERSION: "2.5"
-      SIDEKIQ_VERSION: "~> 2"
+      SIDEKIQ_VERSION: "2"
     concurrency: 4
     concurrency_group: 'ruby/integrations-maze-runner-tests'
 
@@ -339,7 +339,7 @@ steps:
         command: ["features/sidekiq.feature", "--tags", "not @wip"]
     env:
       RUBY_TEST_VERSION: "2.5"
-      SIDEKIQ_VERSION: "~> 3"
+      SIDEKIQ_VERSION: "3"
     concurrency: 4
     concurrency_group: 'ruby/integrations-maze-runner-tests'
 
@@ -352,7 +352,7 @@ steps:
         command: ["features/sidekiq.feature", "--tags", "not @wip"]
     env:
       RUBY_TEST_VERSION: "2.5"
-      SIDEKIQ_VERSION: "~> 4"
+      SIDEKIQ_VERSION: "4"
     concurrency: 4
     concurrency_group: 'ruby/integrations-maze-runner-tests'
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -86,7 +86,7 @@ steps:
     env:
       RUBY_TEST_VERSION: "2.5"
 
-  - label: ':sidekiq: Sidekiq 5 tests'
+  - label: ':sidekiq: Sidekiq 6 tests'
     timeout_in_minutes: 30
     plugins:
       docker-compose#v3.1.0:
@@ -95,7 +95,7 @@ steps:
         command: ["features/sidekiq.feature", "--tags", "not @wip"]
     env:
       RUBY_TEST_VERSION: "2.5"
-      SIDEKIQ_VERSION: "5"
+      SIDEKIQ_VERSION: "6"
 
   - wait
 
@@ -355,6 +355,17 @@ steps:
       SIDEKIQ_VERSION: "4"
     concurrency: 4
     concurrency_group: 'ruby/integrations-maze-runner-tests'
+
+  - label: ':sidekiq: Sidekiq 5 tests'
+    timeout_in_minutes: 30
+    plugins:
+      docker-compose#v3.1.0:
+        run: ruby-maze-runner
+        use-aliases: true
+        command: ["features/sidekiq.feature", "--tags", "not @wip"]
+    env:
+      RUBY_TEST_VERSION: "2.5"
+      SIDEKIQ_VERSION: "5"
 
   - label: ':rails: Rails 3 Ruby 2.0 tests'
     timeout_in_minutes: 30

--- a/TESTING.md
+++ b/TESTING.md
@@ -59,7 +59,7 @@ Configure the tests to be run in the following way:
 
 - Determine the Ruby version to be tested using the environment variable `RUBY_TEST_VERSION` e.g. `RUBY_TEST_VERSION=2.6`
 - If testing rails, set the rails version to be tested using the environment variable `RAILS_VERSION` e.g. `RAILS_VERSION=3`
-- If testing sidekiq, set the version to be tested using the environment variable `SIDEKIQ_VERSION` as the bundler version,  e.g. `SIDEKIQ_VERSION="~> 2"`
+- If testing sidekiq, set the version to be tested using the environment variable `SIDEKIQ_VERSION`,  e.g. `SIDEKIQ_VERSION=2`
 
 When running the end-to-end tests, you'll want to restrict the feature files run to the specific test features for the platform.  This is done using the Cucumber CLI syntax at the end of the `docker-compose run ruby-maze-runner` command, i.e:
 

--- a/features/fixtures/sidekiq/app/Gemfile
+++ b/features/fixtures/sidekiq/app/Gemfile
@@ -1,8 +1,13 @@
 source 'https://rubygems.org'
 
+sidekiq_version = ENV.fetch('SIDEKIQ_VERSION')
+
 gem 'bugsnag', path: '/bugsnag'
-gem 'hitimes', '~> 1.2.6'
 gem 'rake', '~> 12.3.0'
-gem 'redis', '~> 3.3.5'
-gem 'sidekiq', ENV['SIDEKIQ_VERSION']
-gem 'timers', '~> 4.1.2'
+gem 'sidekiq', "~> #{sidekiq_version}"
+
+if sidekiq_version == '2'
+  gem 'hitimes', '~> 1.2.6'
+  gem 'redis', '~> 3.3.5'
+  gem 'timers', '~> 4.1.2'
+end

--- a/features/steps/ruby_notifier_steps.rb
+++ b/features/steps/ruby_notifier_steps.rb
@@ -92,22 +92,18 @@ When("I navigate to the route {string} on the rack app") do |route|
 end
 
 Then("the payload field {string} matches the appropriate Sidekiq handled payload") do |field|
-  if ENV["SIDEKIQ_VERSION"] == "~> 2"
-    created_at_present = "false"
-  else
-    created_at_present = "true"
-  end
+  # Sidekiq 2 doesn't include the "created_at" field
+  created_at_present = ENV["SIDEKIQ_VERSION"] > "2"
+
   steps %Q{
     And the payload field "#{field}" matches the JSON fixture in "features/fixtures/sidekiq/payloads/handled_metadata_ca_#{created_at_present}.json"
   }
 end
 
 Then("the payload field {string} matches the appropriate Sidekiq unhandled payload") do |field|
-  if ENV["SIDEKIQ_VERSION"] == "~> 2"
-    created_at_present = "false"
-  else
-    created_at_present = "true"
-  end
+  # Sidekiq 2 doesn't include the "created_at" field
+  created_at_present = ENV["SIDEKIQ_VERSION"] > "2"
+
   steps %Q{
     And the payload field "#{field}" matches the JSON fixture in "features/fixtures/sidekiq/payloads/unhandled_metadata_ca_#{created_at_present}.json"
   }


### PR DESCRIPTION
## Goal

Adds Sidekiq 6 to CI. This required adjusting the dependencies in our Sidekiq fixture — we pinned to lower versions of Sidekiq's dependencies, but this is actually only necessary on Sidekiq 2