### PR TITLE
Bugsnag gem crashes when used with an older mongo gem (1.12)

### DIFF
--- a/lib/bugsnag/integrations/mongo.rb
+++ b/lib/bugsnag/integrations/mongo.rb
@@ -127,6 +127,8 @@ module Bugsnag
   end
 end
 
-##
-# Add the subscriber to the global Mongo monitoring object
-Mongo::Monitoring::Global.subscribe(Mongo::Monitoring::COMMAND, Bugsnag::MongoBreadcrumbSubscriber.new)
+if defined?(Mongo::Monitoring)
+  ##
+  # Add the subscriber to the global Mongo monitoring object
+  Mongo::Monitoring::Global.subscribe(Mongo::Monitoring::COMMAND, Bugsnag::MongoBreadcrumbSubscriber.new)
+end


### PR DESCRIPTION
Trying to use bugsnag gem together with mongo 1.12 raises the following error during application boot time: uninitialized constant Mongo::Monitoring (NameError).

## Goal

To make sure Bugsnag can be used with applications that are stuck with an older mongo version, even if Mongo integration cannot be used in that case.

## Changeset

I added a check to make sure Mongo::Monitoring class is defined before Bugsnag tries to use it. Pretty simple.

## Testing

Tested manually.