### PR TITLE
Include the connection ID in ActiveRecord breadcrumbs on new version of Rails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,17 @@
 Changelog
 =========
 
+## TBD
+
 ### Enhancements
 
 * Classify `ActionDispatch::Http::MimeNegotiation::InvalidType` as info severity level
   | [#654](https://github.com/bugsnag/bugsnag-ruby/pull/654)
+
+### Fixes
+
+* Include `connection_id` in ActiveRecord breadcrumb metadata on new versons of Rails
+  | [#655](https://github.com/bugsnag/bugsnag-ruby/pull/655)
 
 ## 6.19.0 (6 January 2021)
 

--- a/lib/bugsnag/integrations/rails/rails_breadcrumbs.rb
+++ b/lib/bugsnag/integrations/rails/rails_breadcrumbs.rb
@@ -38,6 +38,8 @@ module Bugsnag::Rails
       :type => Bugsnag::Breadcrumbs::PROCESS_BREADCRUMB_TYPE,
       :allowed_data => [
         :name,
+        # :connection_id is no longer provided in Rails 6.1+ but we can get it
+        # from the :connection key of the event instead
         :connection_id,
         :cached
       ]


### PR DESCRIPTION
## Goal

Rails replaced the connection ID with a connection object in ActiveRecord instrumentation. We will now get the ID from the connection object, as before

This is partly tested by existing tests and is tested against Rails 6.1 in https://github.com/bugsnag/bugsnag-ruby/pull/656