### PR TITLE
Loosen rails version constraint in v5 & v6 fixtures

### DIFF
--- a/features/fixtures/rails5/app/Gemfile
+++ b/features/fixtures/rails5/app/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
-gem 'rails', '~> 5.0.0'
+gem 'rails', '~> 5'
 # Use sqlite3 as the database for Active Record
 gem 'sqlite3', '< 1.4'
 # Use Puma as the app server

--- a/features/fixtures/rails5/app/config/initializers/new_framework_defaults.rb
+++ b/features/fixtures/rails5/app/config/initializers/new_framework_defaults.rb
@@ -17,8 +17,5 @@ ActiveSupport.to_time_preserves_timezone = true
 # Require `belongs_to` associations by default. Previous versions had false.
 Rails.application.config.active_record.belongs_to_required_by_default = true
 
-# Do not halt callback chains when a callback returns false. Previous versions had true.
-ActiveSupport.halt_callback_chains_on_return_false = false
-
 # Configure SSL options to enable HSTS with subdomains. Previous versions had false.
 Rails.application.config.ssl_options = { hsts: { subdomains: true } }

--- a/features/fixtures/rails6/app/Gemfile
+++ b/features/fixtures/rails6/app/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
-gem 'rails', '~> 6.0.0.beta3'
+gem 'rails', '~> 6'
 # Use sqlite3 as the database for Active Record
 gem 'sqlite3', '~> 1.3', '>= 1.3.6'
 # Use Puma as the app server


### PR DESCRIPTION
## Goal

Loosens the version constraint for rails 5 & 6 fixtures from `~> x.0.0` to `~> x`. This was inadvertently stopping us from testing on the latest v5/v6 versions as we were locked to 5.0.x/6.0.x — for example, we weren't test against Rails 6.1

## Testing

Covered by CI, requires https://github.com/bugsnag/bugsnag-ruby/pull/655 to pass