### PR TITLE
Add license checker to CI

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -11,12 +11,6 @@ steps:
             - ruby-maze-runner:855461928731.dkr.ecr.us-west-1.amazonaws.com/ruby:base-ruby${BRANCH_NAME}
             - ruby-maze-runner:855461928731.dkr.ecr.us-west-1.amazonaws.com/ruby:base-ruby-latest
 
-  - name: ':copyright: License Audit'
-    plugins:
-      docker-compose#v3.7.0:
-        run: license_finder
-    command: /bin/bash -lc '/scan/scripts/license_finder.sh'
-
   - wait
 
   - label: ':ruby: Ruby 1.9 unit tests'
@@ -1155,3 +1149,9 @@ steps:
       RACK_VERSION: '2'
     concurrency: 4
     concurrency_group: 'ruby/integrations-maze-runner-tests'
+
+  - name: ':copyright: License Audit'
+    plugins:
+      docker-compose#v3.7.0:
+        run: license_finder
+    command: /bin/bash -lc '/scan/scripts/license_finder.sh'

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -11,6 +11,12 @@ steps:
             - ruby-maze-runner:855461928731.dkr.ecr.us-west-1.amazonaws.com/ruby:base-ruby${BRANCH_NAME}
             - ruby-maze-runner:855461928731.dkr.ecr.us-west-1.amazonaws.com/ruby:base-ruby-latest
 
+  - name: ':copyright: License Audit'
+    plugins:
+      docker-compose#v3.7.0:
+        run: license_finder
+    command: /bin/bash -lc '/scan/scripts/license_finder.sh'
+
   - wait
 
   - label: ':ruby: Ruby 1.9 unit tests'

--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,8 @@ group :test, optional: true do
 
   # WEBrick is no longer in the stdlib in Ruby 3.0
   gem 'webrick' if ruby_version >= Gem::Version.new('3.0.0')
+
+  gem 'rexml', '< 3.2.5' if ruby_version == Gem::Version.new('2.0.0')
 end
 
 group :coverage, optional: true do

--- a/config/.gitignore
+++ b/config/.gitignore
@@ -1,0 +1,1 @@
+decisions.yml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,13 @@
 version: '3.6'
 services:
+
+  license_finder:
+    build:
+      dockerfile: dockerfiles/Dockerfile.audit
+      context: .
+    volumes:
+      - ./:/scan
+
   ruby-maze-runner:
     build:
       context: .

--- a/dockerfiles/Dockerfile.audit
+++ b/dockerfiles/Dockerfile.audit
@@ -1,0 +1,5 @@
+FROM licensefinder/license_finder
+
+WORKDIR /scan
+
+CMD /scan/scripts/license_finder.sh

--- a/scripts/license_finder.sh
+++ b/scripts/license_finder.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+curl https://raw.githubusercontent.com/bugsnag/license-audit/master/config/decision_files/global.yml -o config/decisions.yml
+curl https://raw.githubusercontent.com/bugsnag/license-audit/master/config/decision_files/bugsnag-ruby.yml >> config/decisions.yml
+
+bundle install
+license_finder --decisions-file=config/decisions.yml


### PR DESCRIPTION
## Goal

Adds license checking to CI, following the same approach of our other Ruby based repos.

## Testing

Covered by CI.  Requires https://github.com/bugsnag/license-audit/pull/8 to be merged for the new step to pass.