### PR TITLE
Deliver even when an error raised in the block argument

### DIFF
--- a/lib/bugsnag.rb
+++ b/lib/bugsnag.rb
@@ -106,7 +106,11 @@ module Bugsnag
 
         # If this is not an auto_notify then the block was provided by the user. This should be the last
         # block that is run as it is the users "most specific" block.
-        yield(report) if block_given? && !auto_notify
+        begin
+          yield(report) if block_given? && !auto_notify
+        rescue => e
+          report.add_tab(:report_error, "Failed to report block (#{e.class}): #{e.message} \n#{e.backtrace[0..9].join("\n")}")
+        end
 
         if report.ignore?
           configuration.debug("Not notifying #{report.exceptions.last[:errorClass]} due to ignore being signified in user provided block")

--- a/spec/bugsnag_spec.rb
+++ b/spec/bugsnag_spec.rb
@@ -56,6 +56,16 @@ describe Bugsnag do
       })
       expect(breadcrumb.timestamp).to be_within(1).of(sent_time)
     end
+
+    it 'is also be delivered when an error raised in the block argument' do
+      Bugsnag.notify('It crashed') do |report|
+        repor.context = 'test'
+      end
+      expect(Bugsnag).to have_sent_notification{ |payload, headers|
+        event = get_event_from_payload(payload)
+        expect(event['metaData']['custom']['report_error']).to match(/Failed to report block \(NameError\): undefined local variable or method/)
+      }
+    end
   end
 
   describe '#configure' do


### PR DESCRIPTION
## Goal

I would also like to be notified if there is an error in the block argument of the notify method.
This is because the more important the error handling, the more complex the contents of the block argument, and the more likely it is that an error will occur.
