### PR TITLE
Fix Delayed Job tests

### DIFF
--- a/features/fixtures/delayed_job/app/Gemfile
+++ b/features/fixtures/delayed_job/app/Gemfile
@@ -8,7 +8,7 @@ end
 gem 'bugsnag', path: '/bugsnag'
 gem 'delayed_job'
 gem 'delayed_job_active_record'
-gem 'therubyracer'
+gem 'mini_racer'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.0.7'
@@ -22,8 +22,6 @@ gem 'sass-rails', '~> 5.0'
 gem 'uglifier', '>= 1.3.0'
 # Use CoffeeScript for .coffee assets and views
 gem 'coffee-rails', '~> 4.2'
-# See https://github.com/rails/execjs#readme for more supported runtimes
-# gem 'therubyracer', platforms: :ruby
 
 # Use jquery as the JavaScript library
 gem 'jquery-rails'


### PR DESCRIPTION
## Goal

ExecJS doesn't support therubyracer anymore so the delayed job app doesn't run. They pass fine with mini_racer instead