### PR TITLE
Deliver even when an error raised in the block argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+## TBD
+
+### Fixes
+
+* Deliver when an error is raised in the block argument to `notify`
+  | [#660](https://github.com/bugsnag/bugsnag-ruby/pull/660)
+  | [aki77](https://github.com/aki77)
+
 ## v6.20.0 (29 March 2021)
 
 ### Enhancements

--- a/lib/bugsnag.rb
+++ b/lib/bugsnag.rb
@@ -106,7 +106,11 @@ module Bugsnag
 
         # If this is not an auto_notify then the block was provided by the user. This should be the last
         # block that is run as it is the users "most specific" block.
-        yield(report) if block_given? && !auto_notify
+        begin
+          yield(report) if block_given? && !auto_notify
+        rescue => e
+          report.add_tab(:report_error, "Failed to report block (#{e.class}): #{e.message} \n#{e.backtrace[0..9].join("\n")}")
+        end
 
         if report.ignore?
           configuration.debug("Not notifying #{report.exceptions.last[:errorClass]} due to ignore being signified in user provided block")

--- a/lib/bugsnag.rb
+++ b/lib/bugsnag.rb
@@ -109,7 +109,8 @@ module Bugsnag
         begin
           yield(report) if block_given? && !auto_notify
         rescue => e
-          report.add_tab(:report_error, "Failed to report block (#{e.class}): #{e.message} \n#{e.backtrace[0..9].join("\n")}")
+          configuration.warn("Error in notify block: #{e}")
+          configuration.warn("Error in notify block stacktrace: #{e.backtrace.inspect}")
         end
 
         if report.ignore?

--- a/lib/bugsnag.rb
+++ b/lib/bugsnag.rb
@@ -79,7 +79,12 @@ module Bugsnag
       report = Report.new(exception, configuration, auto_notify)
 
       # If this is an auto_notify we yield the block before the any middleware is run
-      yield(report) if block_given? && auto_notify
+      begin
+        yield(report) if block_given? && auto_notify
+      rescue => e
+        configuration.warn("Error in internal notify block: #{e}")
+        configuration.warn("Error in internal notify block stacktrace: #{e.backtrace.inspect}")
+      end
 
       if report.ignore?
         configuration.debug("Not notifying #{report.exceptions.last[:errorClass]} due to ignore being signified in auto_notify block")

--- a/lib/bugsnag.rb
+++ b/lib/bugsnag.rb
@@ -81,7 +81,7 @@ module Bugsnag
       # If this is an auto_notify we yield the block before the any middleware is run
       begin
         yield(report) if block_given? && auto_notify
-      rescue => e
+      rescue StandardError => e
         configuration.warn("Error in internal notify block: #{e}")
         configuration.warn("Error in internal notify block stacktrace: #{e.backtrace.inspect}")
       end
@@ -113,7 +113,7 @@ module Bugsnag
         # block that is run as it is the users "most specific" block.
         begin
           yield(report) if block_given? && !auto_notify
-        rescue => e
+        rescue StandardError => e
           configuration.warn("Error in notify block: #{e}")
           configuration.warn("Error in notify block stacktrace: #{e.backtrace.inspect}")
         end

--- a/spec/bugsnag_spec.rb
+++ b/spec/bugsnag_spec.rb
@@ -56,6 +56,16 @@ describe Bugsnag do
       })
       expect(breadcrumb.timestamp).to be_within(1).of(sent_time)
     end
+
+    it 'is also be delivered when an error raised in the block argument' do
+      Bugsnag.notify('It crashed') do |report|
+        repor.context = 'test'
+      end
+      expect(Bugsnag).to have_sent_notification{ |payload, headers|
+        event = get_event_from_payload(payload)
+        expect(event['metaData']['custom']['report_error']).to match(/Failed to report block \(NameError\): undefined local variable or method/)
+      }
+    end
   end
 
   describe '#configure' do


### PR DESCRIPTION
## Goal

This is #660 with `next` merged and the implementation tweaked to log a message instead of adding metadata, so it's consistent with how we handle errors in other places — e.g. in `on_error` callbacks:

https://github.com/bugsnag/bugsnag-ruby/blob/98b73dc7632ac99055abd3d3a2af1f7b901b4ee5/lib/bugsnag/on_error_callbacks.rb#L13-L18