### PR TITLE
Allow Methods to be used as callbacks/middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## Unreleased
+
+### Enhancements
+
+* Allow a `Method` or any object responding to `#call` to be used as a callback or middleware
+  | [#662](https://github.com/bugsnag/bugsnag-ruby/pull/662)
+
 ## v6.20.0 (29 March 2021)
 
 ### Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Changelog
 
 ### Enhancements
 
-* Allow a `Method` or any object responding to `#call` to be used as a callback or middleware
+* Allow a `Method` or any object responding to `#call` to be used as an `on_error` callback or middleware
   | [#662](https://github.com/bugsnag/bugsnag-ruby/pull/662)
   | [odlp](https://github.com/odlp)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,13 @@
 Changelog
 =========
 
-## Unreleased
+## TBC
 
 ### Enhancements
 
 * Allow a `Method` or any object responding to `#call` to be used as a callback or middleware
   | [#662](https://github.com/bugsnag/bugsnag-ruby/pull/662)
+  | [odlp](https://github.com/odlp)
 
 ## v6.20.0 (29 March 2021)
 

--- a/lib/bugsnag.rb
+++ b/lib/bugsnag.rb
@@ -265,7 +265,7 @@ module Bugsnag
     # Returning false from an on_error callback will cause the error to be ignored
     # and will prevent any remaining callbacks from being called
     #
-    # @param callback [Proc]
+    # @param callback [Proc, Method, #call]
     # @return [void]
     def add_on_error(callback)
       configuration.add_on_error(callback)

--- a/lib/bugsnag/configuration.rb
+++ b/lib/bugsnag/configuration.rb
@@ -485,7 +485,7 @@ module Bugsnag
     # Returning false from an on_error callback will cause the error to be ignored
     # and will prevent any remaining callbacks from being called
     #
-    # @param callback [Proc]
+    # @param callback [Proc, Method, #call]
     # @return [void]
     def add_on_error(callback)
       middleware.use(callback)
@@ -494,10 +494,10 @@ module Bugsnag
     ##
     # Remove the given callback from the list of on_error callbacks
     #
-    # Note that this must be the same Proc instance that was passed to
+    # Note that this must be the same instance that was passed to
     # {#add_on_error}, otherwise it will not be removed
     #
-    # @param callback [Proc]
+    # @param callback [Proc, Method, #call]
     # @return [void]
     def remove_on_error(callback)
       middleware.remove(callback)

--- a/lib/bugsnag/middleware_stack.rb
+++ b/lib/bugsnag/middleware_stack.rb
@@ -131,8 +131,8 @@ module Bugsnag
     #
     # @return [Array<Proc>]
     def middleware_procs
-      # Split the middleware into separate lists of Procs and Classes
-      procs, classes = @middlewares.partition {|middleware| middleware.is_a?(Proc) }
+      # Split the middleware into separate lists of callables (e.g. Proc, Lambda, Method) and Classes
+      callables, classes = @middlewares.partition {|middleware| middleware.respond_to?(:call) }
 
       # Wrap the classes in a proc that, when called, news up the middleware and
       # passes the next middleware in the queue
@@ -140,12 +140,12 @@ module Bugsnag
         proc {|next_middleware| middleware.new(next_middleware) }
       end
 
-      # Wrap the list of procs in a proc that, when called, wraps them in an
+      # Wrap the list of callables in a proc that, when called, wraps them in an
       # 'OnErrorCallbacks' instance that also has a reference to the next middleware
-      wrapped_procs = proc {|next_middleware| OnErrorCallbacks.new(next_middleware, procs) }
+      wrapped_callables = proc {|next_middleware| OnErrorCallbacks.new(next_middleware, callables) }
 
-      # Return the combined middleware and wrapped procs
-      middleware_instances.push(wrapped_procs)
+      # Return the combined middleware and wrapped callables
+      middleware_instances.push(wrapped_callables)
     end
   end
 end

--- a/spec/on_error_spec.rb
+++ b/spec/on_error_spec.rb
@@ -332,11 +332,13 @@ describe "on_error callbacks" do
 
   describe "using methods as callbacks" do
     it "runs callbacks on notify" do
-      def callback(report)
-        report.add_tab(:important, { hello: "world" })
+      class OnErrorCallbackHaver
+        def callback(report)
+          report.add_tab(:important, { hello: "world" })
+        end
       end
 
-      Bugsnag.add_on_error(method(:callback))
+      Bugsnag.add_on_error(OnErrorCallbackHaver.new.method(:callback))
 
       Bugsnag.notify(RuntimeError.new("Oh no!"))
 
@@ -345,17 +347,19 @@ describe "on_error callbacks" do
 
         expect(event["metaData"]["important"]).to eq({ "hello" => "world" })
       end)
-    ensure
-      undef :callback
     end
 
     it "can remove an already registered callback" do
-      def callback(report)
-        report.add_tab(:important, { hello: "world" })
+      class OnErrorCallbackHaver
+        def callback(report)
+          report.add_tab(:important, { hello: "world" })
+        end
       end
 
-      Bugsnag.add_on_error(method(:callback))
-      Bugsnag.remove_on_error(method(:callback))
+      instance = OnErrorCallbackHaver.new
+
+      Bugsnag.add_on_error(instance.method(:callback))
+      Bugsnag.remove_on_error(instance.method(:callback))
 
       Bugsnag.notify(RuntimeError.new("Oh no!"))
 
@@ -364,8 +368,6 @@ describe "on_error callbacks" do
 
         expect(event["metaData"]["important"]).to be_nil
       end)
-    ensure
-      undef :callback
     end
   end
 end


### PR DESCRIPTION
## Goal

This is #662 with next merged and tweaks to the tests so they run on Ruby 1.9. I've also added a tests with a class that responds to `#call`