### PR TITLE
Fix breadcrumb message matcher

### DIFF
--- a/features/fixtures/expected_breadcrumbs/mongo_failed.json
+++ b/features/fixtures/expected_breadcrumbs/mongo_failed.json
@@ -10,6 +10,6 @@
         "request_id": "NUMBER",
         "duration": "NUMBER",
         "collection": 1,
-        "message": "no such command: 'bogus' (59)"
+        "message": ".*no such command: 'bogus'.*"
     }
 }


### PR DESCRIPTION
## Goal

This changed in a dependency update to prefix the error code instead of postfixing it. The exact message doesn't really matter as long as the breadcrumb is recorded, so I've loosened the regex to allow either message