### PR TITLE
Move the Rack & Rails middleware into the `internal_middleware` stack

### DIFF
--- a/lib/bugsnag/integrations/rack.rb
+++ b/lib/bugsnag/integrations/rack.rb
@@ -25,9 +25,9 @@ module Bugsnag
         end
 
         # Hook up rack-based notification middlewares
-        config.middleware.insert_before([Bugsnag::Middleware::Rails3Request,Bugsnag::Middleware::Callbacks], Bugsnag::Middleware::RackRequest) if defined?(::Rack)
-        config.middleware.insert_before(Bugsnag::Middleware::Callbacks, Bugsnag::Middleware::WardenUser) if defined?(Warden)
-        config.middleware.insert_before(Bugsnag::Middleware::Callbacks, Bugsnag::Middleware::ClearanceUser) if defined?(Clearance)
+        config.internal_middleware.insert_before(Bugsnag::Middleware::Rails3Request, Bugsnag::Middleware::RackRequest) if defined?(::Rack)
+        config.internal_middleware.use(Bugsnag::Middleware::WardenUser) if defined?(Warden)
+        config.internal_middleware.use(Bugsnag::Middleware::ClearanceUser) if defined?(Clearance)
 
         # Set environment data for payload
         # Note we only set the detected app_type if it's not already set. This

--- a/lib/bugsnag/integrations/railtie.rb
+++ b/lib/bugsnag/integrations/railtie.rb
@@ -60,7 +60,7 @@ module Bugsnag
         config.logger = ::Rails.logger
         config.release_stage ||= ::Rails.env.to_s
         config.project_root = ::Rails.root.to_s
-        config.middleware.insert_before Bugsnag::Middleware::Callbacks, Bugsnag::Middleware::Rails3Request
+        config.internal_middleware.use(Bugsnag::Middleware::Rails3Request)
         config.runtime_versions["rails"] = ::Rails::VERSION::STRING
       end
 


### PR DESCRIPTION
## Goal

This PR moves the Rack & Rails middleware into the `internal_middleware` stack, from the `middleware` stack which is intended for user middleware

I don't think it was intentional that these ran with the user middleware. Even if it was these middleware were always added to the start of the stack, which is essentially the same as being at the end of the internal middleware stack

This allows other internal middleware to modify things set by the Rack/Rails middleware without also having to be in the `middleware` stack. For example, modifying the context of an event with internal middleware is not possible as the `Rails3Request` middleware will always overwrite the context

The only potential BC concern I can think of here is if a user is using `middleware.insert_before` with these middleware, but I don't think this is likely and shouldn't be necessary anyway