### PR TITLE
Add support for Active Job 

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,6 +11,14 @@ Lint/RescueException:
   Exclude:
     - 'lib/bugsnag/integrations/**/*'
 
+Metrics/AbcSize:
+  Exclude:
+    - 'lib/bugsnag/configuration.rb'
+
+Metrics/ClassLength:
+  Exclude:
+    - 'lib/bugsnag/configuration.rb'
+
 # We can't use ".freeze" on our constants in case users are monkey patching
 # them — this would be a BC break
 Style/MutableConstant:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,6 +7,10 @@ AllCops:
     - 'spec/fixtures/**/*'
     - 'features/fixtures/**/*'
 
+Lint/RescueException:
+  Exclude:
+    - 'lib/bugsnag/integrations/**/*'
+
 # We can't use ".freeze" on our constants in case users are monkey patching
 # them — this would be a BC break
 Style/MutableConstant:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -229,16 +229,6 @@ Lint/RedundantRequireStatement:
     - 'lib/bugsnag/delivery/thread_queue.rb'
     - 'lib/bugsnag/session_tracker.rb'
 
-# Offense count: 7
-Lint/RescueException:
-  Exclude:
-    - 'lib/bugsnag/integrations/delayed_job.rb'
-    - 'lib/bugsnag/integrations/mailman.rb'
-    - 'lib/bugsnag/integrations/rack.rb'
-    - 'lib/bugsnag/integrations/rake.rb'
-    - 'lib/bugsnag/integrations/shoryuken.rb'
-    - 'lib/bugsnag/integrations/sidekiq.rb'
-
 # Offense count: 1
 # Cop supports --auto-correct.
 Lint/SendWithMixinArgument:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## TBD
+
+### Enhancements
+
+* Add support for tracking exceptions and capturing metadata in Active Job, when not using an existing integration
+  | [#670](https://github.com/bugsnag/bugsnag-ruby/pull/670)
+
 ## v6.21.0 (23 June 2021)
 
 ### Enhancements

--- a/features/fixtures/rails4/app/app/controllers/active_job_controller.rb
+++ b/features/fixtures/rails4/app/app/controllers/active_job_controller.rb
@@ -1,0 +1,15 @@
+class ActiveJobController < ActionController::Base
+  protect_from_forgery
+
+  def handled
+    NotifyJob.perform_later(1, "hello", { a: "a", b: "b" }, keyword: true)
+
+    render json: {}
+  end
+
+  def unhandled
+    UnhandledJob.perform_later(123, { abc: "xyz" }, "abcxyz")
+
+    render json: {}
+  end
+end

--- a/features/fixtures/rails4/app/app/jobs/notify_job.rb
+++ b/features/fixtures/rails4/app/app/jobs/notify_job.rb
@@ -1,5 +1,5 @@
 class NotifyJob < ApplicationJob
-  def perform
+  def perform(*args, **kwargs)
     Bugsnag.notify("Failed")
   end
 end

--- a/features/fixtures/rails4/app/app/jobs/unhandled_job.rb
+++ b/features/fixtures/rails4/app/app/jobs/unhandled_job.rb
@@ -1,0 +1,17 @@
+# Rails 4 doesn't automatically retry jobs, so this is a quick hack to allow us
+# to run the same Rails 5/6 tests against Rails 4 by allowing one retry
+$attempts = 0
+
+class UnhandledJob < ApplicationJob
+  rescue_from(RuntimeError) do |exception|
+    raise exception if $attempts >= 2
+
+    retry_job
+  end
+
+  def perform(*args, **kwargs)
+    $attempts += 1
+
+    raise 'Oh no!'
+  end
+end

--- a/features/fixtures/rails4/app/config/routes.rb
+++ b/features/fixtures/rails4/app/config/routes.rb
@@ -18,4 +18,5 @@ App::Application.routes.draw do
   get "/devise/(:action)", controller: 'devise'
   get "/breadcrumbs/(:action)", controller: 'breadcrumbs'
   get "/mongo/(:action)", controller: 'mongo'
+  get "/active_job/(:action)", controller: 'active_job'
 end

--- a/features/fixtures/rails5/app/app/controllers/active_job_controller.rb
+++ b/features/fixtures/rails5/app/app/controllers/active_job_controller.rb
@@ -1,0 +1,15 @@
+class ActiveJobController < ActionController::Base
+  protect_from_forgery
+
+  def handled
+    NotifyJob.perform_later(1, "hello", { a: "a", b: "b" }, keyword: true)
+
+    render json: {}
+  end
+
+  def unhandled
+    UnhandledJob.perform_later(123, { abc: "xyz" }, "abcxyz")
+
+    render json: {}
+  end
+end

--- a/features/fixtures/rails5/app/app/jobs/notify_job.rb
+++ b/features/fixtures/rails5/app/app/jobs/notify_job.rb
@@ -1,5 +1,5 @@
 class NotifyJob < ApplicationJob
-  def perform
+  def perform(*args, **kwargs)
     Bugsnag.notify("Failed")
   end
 end

--- a/features/fixtures/rails5/app/app/jobs/unhandled_job.rb
+++ b/features/fixtures/rails5/app/app/jobs/unhandled_job.rb
@@ -1,0 +1,7 @@
+class UnhandledJob < ApplicationJob
+  retry_on RuntimeError, wait: 1.second, attempts: 2
+
+  def perform(*args, **kwargs)
+    raise 'Oh no!'
+  end
+end

--- a/features/fixtures/rails5/app/config/routes.rb
+++ b/features/fixtures/rails5/app/config/routes.rb
@@ -61,4 +61,7 @@ Rails.application.routes.draw do
   get 'mongo/success_crash', to: 'mongo#success_crash'
   get 'mongo/get_crash', to: 'mongo#get_crash'
   get 'mongo/failure_crash', to: 'mongo#failure_crash'
+
+  get 'active_job/handled', to: 'active_job#handled'
+  get 'active_job/unhandled', to: 'active_job#unhandled'
 end

--- a/features/fixtures/rails6/app/app/controllers/active_job_controller.rb
+++ b/features/fixtures/rails6/app/app/controllers/active_job_controller.rb
@@ -1,0 +1,15 @@
+class ActiveJobController < ActionController::Base
+  protect_from_forgery
+
+  def handled
+    NotifyJob.perform_later(1, "hello", { a: "a", b: "b" }, keyword: true)
+
+    render json: {}
+  end
+
+  def unhandled
+    UnhandledJob.perform_later(123, { abc: "xyz" }, "abcxyz")
+
+    render json: {}
+  end
+end

--- a/features/fixtures/rails6/app/app/jobs/notify_job.rb
+++ b/features/fixtures/rails6/app/app/jobs/notify_job.rb
@@ -1,5 +1,5 @@
 class NotifyJob < ApplicationJob
-  def perform
+  def perform(*args, **kwargs)
     Bugsnag.notify("Failed")
   end
 end

--- a/features/fixtures/rails6/app/app/jobs/unhandled_job.rb
+++ b/features/fixtures/rails6/app/app/jobs/unhandled_job.rb
@@ -1,0 +1,7 @@
+class UnhandledJob < ApplicationJob
+  retry_on RuntimeError, wait: 1.second, attempts: 2
+
+  def perform(*args, **kwargs)
+    raise 'Oh no!'
+  end
+end

--- a/features/fixtures/rails6/app/config/routes.rb
+++ b/features/fixtures/rails6/app/config/routes.rb
@@ -61,4 +61,7 @@ Rails.application.routes.draw do
   get 'mongo/success_crash', to: 'mongo#success_crash'
   get 'mongo/get_crash', to: 'mongo#get_crash'
   get 'mongo/failure_crash', to: 'mongo#failure_crash'
+
+  get 'active_job/handled', to: 'active_job#handled'
+  get 'active_job/unhandled', to: 'active_job#unhandled'
 end

--- a/features/rails_features/active_job.feature
+++ b/features/rails_features/active_job.feature
@@ -1,0 +1,62 @@
+Feature: Active Job
+
+@rails4
+Scenario: A handled error will be delivered
+  Given I start the rails service
+  When I navigate to the route "/active_job/handled" on the rails app
+  And I wait to receive a request
+  Then the request is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier"
+  And the event "unhandled" is false
+  And the event "severity" equals "warning"
+  And the event "context" equals "NotifyJob@default"
+  And the event "app.type" equals "active job"
+  And the exception "errorClass" equals "RuntimeError"
+  And the exception "message" equals "Failed"
+  And the event "metaData.active_job.job_id" matches "^[0-9a-f-]{36}$"
+  And the event "metaData.active_job.job_name" equals "NotifyJob"
+  And the event "metaData.active_job.queue" equals "default"
+  And the event "metaData.active_job.locale" equals "en"
+  And the event "metaData.active_job.arguments.0" equals 1
+  And the event "metaData.active_job.arguments.1" equals "hello"
+  And the event "metaData.active_job.arguments.2.a" equals "a"
+  And the event "metaData.active_job.arguments.2.b" equals "b"
+  And the event "metaData.active_job.arguments.3.keyword" is true
+
+@rails4
+Scenario: An unhandled error will be delivered
+  Given I start the rails service
+  When I navigate to the route "/active_job/unhandled" on the rails app
+  And I wait to receive 2 requests
+  Then the request is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier"
+  And the event "unhandled" is true
+  And the event "severity" equals "error"
+  And the event "context" equals "UnhandledJob@default"
+  And the event "app.type" equals "active job"
+  And the event "severityReason.type" equals "unhandledExceptionMiddleware"
+  And the event "severityReason.attributes.framework" equals "Active Job"
+  And the exception "errorClass" equals "RuntimeError"
+  And the exception "message" equals "Oh no!"
+  And the event "metaData.active_job.job_id" matches "^[0-9a-f-]{36}$"
+  And the event "metaData.active_job.job_name" equals "UnhandledJob"
+  And the event "metaData.active_job.queue" equals "default"
+  And the event "metaData.active_job.locale" equals "en"
+  And the event "metaData.active_job.arguments.0" equals 123
+  And the event "metaData.active_job.arguments.1.abc" equals "xyz"
+  And the event "metaData.active_job.arguments.2" equals "abcxyz"
+  When I discard the oldest request
+  Then the request is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier"
+  And the event "unhandled" is true
+  And the event "severity" equals "error"
+  And the event "context" equals "UnhandledJob@default"
+  And the event "app.type" equals "active job"
+  And the event "severityReason.type" equals "unhandledExceptionMiddleware"
+  And the event "severityReason.attributes.framework" equals "Active Job"
+  And the exception "errorClass" equals "RuntimeError"
+  And the exception "message" equals "Oh no!"
+  And the event "metaData.active_job.job_id" matches "^[0-9a-f-]{36}$"
+  And the event "metaData.active_job.job_name" equals "UnhandledJob"
+  And the event "metaData.active_job.queue" equals "default"
+  And the event "metaData.active_job.locale" equals "en"
+  And the event "metaData.active_job.arguments.0" equals 123
+  And the event "metaData.active_job.arguments.1.abc" equals "xyz"
+  And the event "metaData.active_job.arguments.2" equals "abcxyz"

--- a/features/rails_features/active_job.feature
+++ b/features/rails_features/active_job.feature
@@ -1,6 +1,6 @@
 Feature: Active Job
 
-@rails4 @rails5
+@rails4 @rails5 @rails6
 Scenario: A handled error will be delivered
   Given I start the rails service
   When I navigate to the route "/active_job/handled" on the rails app
@@ -23,8 +23,10 @@ Scenario: A handled error will be delivered
   And the event "metaData.active_job.arguments.3.keyword" is true
   And in Rails versions ">=" 5 the event "metaData.active_job.provider_job_id" matches "^[0-9a-f-]{36}$"
   And in Rails versions ">=" 5 the event "metaData.active_job.executions" equals 1
+  And in Rails versions ">=" 6 the event "metaData.active_job.timezone" equals "UTC"
+  And in Rails versions ">=" 6 the event "metaData.active_job.enqueued_at" is a timestamp
 
-@rails4 @rails5
+@rails4 @rails5 @rails6
 Scenario: An unhandled error will be delivered
   Given I start the rails service
   When I navigate to the route "/active_job/unhandled" on the rails app
@@ -47,6 +49,8 @@ Scenario: An unhandled error will be delivered
   And the event "metaData.active_job.arguments.2" equals "abcxyz"
   And in Rails versions ">=" 5 the event "metaData.active_job.provider_job_id" matches "^[0-9a-f-]{36}$"
   And in Rails versions ">=" 5 the event "metaData.active_job.executions" equals 1
+  And in Rails versions ">=" 6 the event "metaData.active_job.timezone" equals "UTC"
+  And in Rails versions ">=" 6 the event "metaData.active_job.enqueued_at" is a timestamp
   When I discard the oldest request
   Then the request is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier"
   And the event "unhandled" is true
@@ -66,3 +70,5 @@ Scenario: An unhandled error will be delivered
   And the event "metaData.active_job.arguments.2" equals "abcxyz"
   And in Rails versions ">=" 5 the event "metaData.active_job.provider_job_id" matches "^[0-9a-f-]{36}$"
   And in Rails versions ">=" 5 the event "metaData.active_job.executions" equals 2
+  And in Rails versions ">=" 6 the event "metaData.active_job.timezone" equals "UTC"
+  And in Rails versions ">=" 6 the event "metaData.active_job.enqueued_at" is a timestamp

--- a/features/rails_features/active_job.feature
+++ b/features/rails_features/active_job.feature
@@ -1,6 +1,6 @@
 Feature: Active Job
 
-@rails4
+@rails4 @rails5
 Scenario: A handled error will be delivered
   Given I start the rails service
   When I navigate to the route "/active_job/handled" on the rails app
@@ -21,8 +21,10 @@ Scenario: A handled error will be delivered
   And the event "metaData.active_job.arguments.2.a" equals "a"
   And the event "metaData.active_job.arguments.2.b" equals "b"
   And the event "metaData.active_job.arguments.3.keyword" is true
+  And in Rails versions ">=" 5 the event "metaData.active_job.provider_job_id" matches "^[0-9a-f-]{36}$"
+  And in Rails versions ">=" 5 the event "metaData.active_job.executions" equals 1
 
-@rails4
+@rails4 @rails5
 Scenario: An unhandled error will be delivered
   Given I start the rails service
   When I navigate to the route "/active_job/unhandled" on the rails app
@@ -43,6 +45,8 @@ Scenario: An unhandled error will be delivered
   And the event "metaData.active_job.arguments.0" equals 123
   And the event "metaData.active_job.arguments.1.abc" equals "xyz"
   And the event "metaData.active_job.arguments.2" equals "abcxyz"
+  And in Rails versions ">=" 5 the event "metaData.active_job.provider_job_id" matches "^[0-9a-f-]{36}$"
+  And in Rails versions ">=" 5 the event "metaData.active_job.executions" equals 1
   When I discard the oldest request
   Then the request is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier"
   And the event "unhandled" is true
@@ -60,3 +64,5 @@ Scenario: An unhandled error will be delivered
   And the event "metaData.active_job.arguments.0" equals 123
   And the event "metaData.active_job.arguments.1.abc" equals "xyz"
   And the event "metaData.active_job.arguments.2" equals "abcxyz"
+  And in Rails versions ">=" 5 the event "metaData.active_job.provider_job_id" matches "^[0-9a-f-]{36}$"
+  And in Rails versions ">=" 5 the event "metaData.active_job.executions" equals 2

--- a/features/steps/ruby_notifier_steps.rb
+++ b/features/steps/ruby_notifier_steps.rb
@@ -108,3 +108,57 @@ Then("the payload field {string} matches the appropriate Sidekiq unhandled paylo
     And the payload field "#{field}" matches the JSON fixture in "features/fixtures/sidekiq/payloads/unhandled_metadata_ca_#{created_at_present}.json"
   }
 end
+
+def rails_version_matches?(operator, version_to_compare)
+  # send the given operator as a method to the current rails version
+  # this will evaluate to e.g. '6.send(">=", 5)', which is the same as '6 >= 5'
+  ENV["RAILS_VERSION"].to_i.send(operator, version_to_compare)
+end
+
+Then("in Rails versions {string} {int} the event {string} equals {string}") do |operator, version, path, expected|
+  if rails_version_matches?(operator, version)
+    steps %Q{
+      And the event "#{path}" equals "#{expected}"
+    }
+  else
+    steps %Q{
+      And the event "#{path}" is null
+    }
+  end
+end
+
+Then("in Rails versions {string} {int} the event {string} equals {int}") do |operator, version, path, expected|
+  if rails_version_matches?(operator, version)
+    steps %Q{
+      And the event "#{path}" equals #{expected}
+    }
+  else
+    steps %Q{
+      And the event "#{path}" is null
+    }
+  end
+end
+
+Then("in Rails versions {string} {int} the event {string} matches {string}") do |operator, version, path, expected|
+  if rails_version_matches?(operator, version)
+    steps %Q{
+      And the event "#{path}" matches "#{expected}"
+    }
+  else
+    steps %Q{
+      And the event "#{path}" is null
+    }
+  end
+end
+
+Then("in Rails versions {string} {int} the event {string} is a timestamp") do |operator, version, path|
+  if rails_version_matches?(operator, version)
+    steps %Q{
+      And the event "#{path}" is a timestamp
+    }
+  else
+    steps %Q{
+      And the event "#{path}" is null
+    }
+  end
+end

--- a/lib/bugsnag/integrations/rails/active_job.rb
+++ b/lib/bugsnag/integrations/rails/active_job.rb
@@ -1,0 +1,102 @@
+require 'set'
+
+module Bugsnag::Rails
+  module ActiveJob
+    SEVERITY = 'error'
+    SEVERITY_REASON = {
+      type: Bugsnag::Report::UNHANDLED_EXCEPTION_MIDDLEWARE,
+      attributes: { framework: 'Active Job' }
+    }
+
+    EXISTING_INTEGRATIONS = Set[
+      'ActiveJob::QueueAdapters::DelayedJobAdapter',
+      'ActiveJob::QueueAdapters::QueAdapter',
+      'ActiveJob::QueueAdapters::ResqueAdapter',
+      'ActiveJob::QueueAdapters::ShoryukenAdapter',
+      'ActiveJob::QueueAdapters::SidekiqAdapter'
+    ]
+
+    INLINE_ADAPTER = 'ActiveJob::QueueAdapters::InlineAdapter'
+
+    # these methods were added after the first Active Job release so
+    # may not be present, depending on the Rails version
+    MAYBE_MISSING_METHODS = [
+      :provider_job_id,
+      :priority,
+      :executions,
+      :enqueued_at,
+      :timezone
+    ]
+
+    def self.included(base)
+      base.class_eval do
+        around_perform do |job, block|
+          adapter = _bugsnag_get_adapter_name(job)
+
+          # if we have an integration for this queue adapter already then we should
+          # leave this job alone or we'll end up with duplicate metadata
+          return block.call if EXISTING_INTEGRATIONS.include?(adapter)
+
+          Bugsnag.configuration.detected_app_type = 'active job'
+
+          begin
+            Bugsnag.configuration.set_request_data(:active_job, _bugsnag_extract_metadata(job))
+
+            block.call
+          rescue Exception => e
+            Bugsnag.notify(e, true) do |report|
+              report.severity = SEVERITY
+              report.severity_reason = SEVERITY_REASON
+            end
+
+            # when using the "inline" adapter the job is run immediately, which
+            # will result in our Rack integration catching the re-raised error
+            # and reporting it a second time if it's run in a web request
+            if adapter == INLINE_ADAPTER
+              e.instance_eval do
+                def skip_bugsnag
+                  true
+                end
+              end
+            end
+
+            raise
+          ensure
+            Bugsnag.configuration.clear_request_data
+          end
+        end
+      end
+    end
+
+    private
+
+    def _bugsnag_get_adapter_name(job)
+      adapter = job.class.queue_adapter
+
+      # in Rails 4 queue adapters were references to a class. In Rails 5+
+      # they are an instance of that class instead
+      return adapter.name if adapter.is_a?(Class)
+
+      adapter.class.name
+    end
+
+    def _bugsnag_extract_metadata(job)
+      metadata = {
+        job_id: job.job_id,
+        job_name: job.class.name,
+        queue: job.queue_name,
+        arguments: job.arguments,
+        locale: job.locale
+      }
+
+      MAYBE_MISSING_METHODS.each do |method_name|
+        next unless job.respond_to?(method_name)
+
+        metadata[method_name] = job.send(method_name)
+      end
+
+      metadata.compact!
+      metadata
+    end
+  end
+end

--- a/lib/bugsnag/integrations/railtie.rb
+++ b/lib/bugsnag/integrations/railtie.rb
@@ -74,6 +74,14 @@ module Bugsnag
         include Bugsnag::Rails::ActiveRecordRescue
       end
 
+      ActiveSupport.on_load(:active_job) do
+        require "bugsnag/middleware/active_job"
+        Bugsnag.configuration.internal_middleware.use(Bugsnag::Middleware::ActiveJob)
+
+        require "bugsnag/integrations/rails/active_job"
+        include Bugsnag::Rails::ActiveJob
+      end
+
       Bugsnag::Rails::DEFAULT_RAILS_BREADCRUMBS.each { |event| event_subscription(event) }
 
       # Make sure we don't overwrite the value set by another integration because

--- a/lib/bugsnag/middleware/active_job.rb
+++ b/lib/bugsnag/middleware/active_job.rb
@@ -1,0 +1,18 @@
+module Bugsnag::Middleware
+  class ActiveJob
+    def initialize(bugsnag)
+      @bugsnag = bugsnag
+    end
+
+    def call(report)
+      data = report.request_data[:active_job]
+
+      if data
+        report.add_tab(:active_job, data)
+        report.context = "#{data[:job_name]}@#{data[:queue]}"
+      end
+
+      @bugsnag.call(report)
+    end
+  end
+end

--- a/spec/middleware/active_job_spec.rb
+++ b/spec/middleware/active_job_spec.rb
@@ -1,0 +1,38 @@
+require 'spec_helper'
+require 'bugsnag/middleware/active_job'
+
+describe Bugsnag::Middleware::ActiveJob do
+  it 'does nothing if there is no active_job request data' do
+    report = Bugsnag::Report.new(RuntimeError.new, Bugsnag.configuration)
+    middleware = Bugsnag::Middleware::ActiveJob.new(->(_) {})
+
+    middleware.call(report)
+
+    expect(report.context).to be_nil
+    expect(report.meta_data).to eq({})
+  end
+
+  it 'attaches active_job request data as metadata and sets the context' do
+    report = Bugsnag::Report.new(RuntimeError.new, Bugsnag.configuration)
+    report.request_data[:active_job] = {
+      abc: 123,
+      xyz: 456,
+      job_name: 'ExampleJob',
+      queue: 'default_queue'
+    }
+
+    middleware = Bugsnag::Middleware::ActiveJob.new(->(_) {})
+
+    middleware.call(report)
+
+    expect(report.context).to eq('ExampleJob@default_queue')
+    expect(report.meta_data).to eq({
+      active_job: {
+        abc: 123,
+        xyz: 456,
+        job_name: 'ExampleJob',
+        queue: 'default_queue'
+      }
+    })
+  end
+end


### PR DESCRIPTION
## Goal

This PR adds support for Active Job when not using an existing integration. For example, nothing will change when using Sidekiq as the backend but we can now track exceptions in Active Job's `async` backend

We capture the following metadata automatically for both handled and unhandled exceptions (note some data is not available on certain Rails versions):

- `job_id`
- `job_name`
- `queue`
- `locale`
- `arguments`
- `provider_job_id` (added in Rails 5)
- `executions` (added in Rails 5)
- `timezone` (added in Rails 6)
- `enqueued_at` (added in Rails 6)

The context is set to the job name and queue to match other queue integrations, e.g. `ExampleJob@some_queue`, and the default app type is set to "active job"

## Testing

Maze Runner tests run against Rails 4, 5 & 6 with a variety of Ruby versions