### PR TITLE
Improve active job context when using Delayed Job or Resque

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Changelog
 * Add support for tracking exceptions and capturing metadata in Active Job, when not using an existing integration
   | [#670](https://github.com/bugsnag/bugsnag-ruby/pull/670)
 
+* Improve the report context when using Delayed Job or Resque as the Active Job queue adapter
+  | [#671](https://github.com/bugsnag/bugsnag-ruby/pull/671)
+
 ## v6.21.0 (23 June 2021)
 
 ### Enhancements

--- a/lib/bugsnag/integrations/resque.rb
+++ b/lib/bugsnag/integrations/resque.rb
@@ -44,8 +44,18 @@ module Bugsnag
           :attributes => FRAMEWORK_ATTRIBUTES
         }
 
-        context = "#{payload['class']}@#{queue}"
-        report.meta_data.merge!({:context => context, :payload => payload})
+        metadata = payload
+        class_name = payload['class']
+
+        # when using Active Job the payload "class" will always be the Resque
+        # "JobWrapper", not the actual job class so we need to fix this here
+        if metadata['args'] && metadata['args'][0] && metadata['args'][0]['job_class']
+          class_name = metadata['args'][0]['job_class']
+          metadata['wrapped'] ||= class_name
+        end
+
+        context = "#{class_name}@#{queue}"
+        report.meta_data.merge!({ context: context, payload: metadata })
         report.context = context
       end
     end


### PR DESCRIPTION
## Goal

### Delayed Job

The current context for Delayed Job uses the `display_name` method, if implemented. [Rails implements `display_name` internally](https://github.com/rails/rails/blob/ac45e1d39610436fad35d061ecb1852bdb9ae4e1/activejob/lib/active_job/queue_adapters/delayed_job_adapter.rb#L37-L39) to help debugging, but this uses the job ID and arguments which makes it unusable as an event's context because the same job will have different contexts between executions

This PR avoids using `display_name` if it matches the Rails format and will use the same context that we use in other queuing libraries instead (`JobName@queue_name`)

### Resque

The Resque integration reads the class name from the payload data and uses that as context. When run in Active Job the class name is always the Resque wrapper: `ActiveJob::QueueAdapters::ResqueAdapter::JobWrapper`. This leads to the same context being used across different jobs

We will now "unwrap" the actual job class and use that instead, e.g. `SomeJob@some_queue`

## Testing

Existing tests cover breaks from this change & a new unit test has been added for Resque. We currently don't have unit tests for Delayed Job, but this will be covered by a Maze Runner test in #672 