### PR TITLE
Add Maze Runner tests for queue libraries using Active Job

### DIFF
--- a/features/fixtures/docker-compose.yml
+++ b/features/fixtures/docker-compose.yml
@@ -259,6 +259,7 @@ services:
       - DB_HOST=postgres
       - REDIS_URL=redis://redis:6379
       - RUN_AT_EXIT_HOOKS
+      - ACTIVE_JOB_QUEUE_ADAPTER
     restart: "no"
 
   sidekiq:

--- a/features/fixtures/rails_integrations/app/app/jobs/unhandled_job.rb
+++ b/features/fixtures/rails_integrations/app/app/jobs/unhandled_job.rb
@@ -1,0 +1,7 @@
+class UnhandledJob < ApplicationJob
+  self.queue_adapter = ENV['ACTIVE_JOB_QUEUE_ADAPTER'].to_sym
+
+  def perform(*args, **kwargs)
+    raise 'Oh no!'
+  end
+end

--- a/features/rails_features/integrations.feature
+++ b/features/rails_features/integrations.feature
@@ -126,3 +126,88 @@ Scenario: Sidekiq
   And the event "metaData.sidekiq.msg.queue" equals "default"
   And the event "metaData.sidekiq.msg.class" equals "SidekiqWorker"
   And the event "metaData.sidekiq.queue" equals "default"
+
+@rails_integrations
+Scenario: Using Sidekiq as the Active Job queue adapter
+  When I set environment variable "ACTIVE_JOB_QUEUE_ADAPTER" to "sidekiq"
+  And I run "bundle exec sidekiq" in the rails app
+  And I run "UnhandledJob.perform_later(1, yes: true)" with the rails runner
+  And I wait to receive a request
+  Then the request is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier"
+  And the event "unhandled" is true
+  And the event "context" equals "UnhandledJob@default"
+  And the event "severity" equals "error"
+  And the event "severityReason.type" equals "unhandledExceptionMiddleware"
+  And the event "severityReason.attributes.framework" equals "Sidekiq"
+  And the event "app.type" equals "sidekiq"
+  And the exception "errorClass" equals "RuntimeError"
+  And the event "metaData.active_job" is null
+  And the event "metaData.sidekiq.msg.queue" equals "default"
+  And the event "metaData.sidekiq.msg.class" equals "ActiveJob::QueueAdapters::SidekiqAdapter::JobWrapper"
+  And the event "metaData.sidekiq.msg.wrapped" equals "UnhandledJob"
+  And the event "metaData.sidekiq.msg.args.0.arguments.0" equals 1
+  And the event "metaData.sidekiq.msg.args.0.arguments.1.yes" is true
+  And the event "metaData.sidekiq.queue" equals "default"
+
+@rails_integrations
+Scenario: Using Rescue as the Active Job queue adapter
+  When I set environment variable "ACTIVE_JOB_QUEUE_ADAPTER" to "resque"
+  And I run "bundle exec rake resque:work" in the rails app
+  And I run "UnhandledJob.perform_later(1, yes: true)" with the rails runner
+  And I wait to receive a request
+  Then the request is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier"
+  And the event "unhandled" is true
+  And the event "context" equals "UnhandledJob@default"
+  And the event "severity" equals "error"
+  And the event "severityReason.type" equals "unhandledExceptionMiddleware"
+  And the event "severityReason.attributes.framework" equals "Resque"
+  And the event "app.type" equals "resque"
+  And the exception "errorClass" equals "RuntimeError"
+  And the event "metaData.active_job" is null
+  And the event "metaData.payload.class" equals "ActiveJob::QueueAdapters::ResqueAdapter::JobWrapper"
+  And the event "metaData.payload.wrapped" equals "UnhandledJob"
+  And the event "metaData.payload.args.0.arguments.0" equals 1
+  And the event "metaData.payload.args.0.arguments.1.yes" is true
+  And the event "metaData.payload.args.0.queue_name" equals "default"
+
+@rails_integrations
+Scenario: Using Que as the Active Job queue adapter
+  When I set environment variable "ACTIVE_JOB_QUEUE_ADAPTER" to "que"
+  And I run "bundle exec que -q default ./config/environment.rb" in the rails app
+  And I run "UnhandledJob.perform_later(1, yes: true)" with the rails runner
+  And I wait to receive a request
+  Then the request is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier"
+  And the event "unhandled" is true
+  And the event "context" is null
+  And the event "severity" equals "error"
+  And the event "severityReason.type" equals "unhandledExceptionMiddleware"
+  And the event "severityReason.attributes.framework" equals "Que"
+  And the event "app.type" equals "que"
+  And the exception "errorClass" equals "RuntimeError"
+  And the event "metaData.active_job" is null
+  And the event "metaData.job.wrapper_job_class" equals "ActiveJob::QueueAdapters::QueAdapter::JobWrapper"
+  And the event "metaData.job.job_class" equals "UnhandledJob"
+  And the event "metaData.job.args.0" equals 1
+  And the event "metaData.job.args.1.yes" is true
+  And the event "metaData.job.queue" equals "default"
+
+@rails_integrations
+Scenario: Using Delayed Job as the Active Job queue adapter
+  When I set environment variable "ACTIVE_JOB_QUEUE_ADAPTER" to "delayed_job"
+  And I run the "jobs:work" rake task in the rails app
+  And I run "UnhandledJob.perform_later(1, yes: true)" with the rails runner
+  And I wait to receive a request
+  Then the request is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier"
+  And the event "unhandled" is true
+  And the event "context" equals "UnhandledJob@default"
+  And the event "severity" equals "error"
+  And the event "severityReason.type" equals "unhandledExceptionMiddleware"
+  And the event "severityReason.attributes.framework" equals "DelayedJob"
+  And the event "app.type" equals "delayed_job"
+  And the exception "errorClass" equals "RuntimeError"
+  And the event "metaData.active_job" is null
+  And the event "metaData.job.payload.class" equals "ActiveJob::QueueAdapters::DelayedJobAdapter::JobWrapper"
+  And the event "metaData.job.payload.job_class" equals "UnhandledJob"
+  And the event "metaData.job.payload.arguments.0" equals 1
+  And the event "metaData.job.payload.arguments.1.yes" is true
+  And the event "metaData.job.queue" equals "default"


### PR DESCRIPTION
## Goal

This PR adds a Maze Runner test using each queue library we support as the Active Job adapter. This proves that we don't run the Active Job integration for these jobs and tests that the same information is available in metadata