### PR TITLE
Don't start sessions when the current release stage is not enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ Changelog
 
 ## TBD
 
+### Fixes
+
+* Avoid starting session delivery thread when the current release stage is not enabled
+  | [#677](https://github.com/bugsnag/bugsnag-ruby/pull/677)
+
 ### Deprecated
 
 * For consistency with Bugsnag notifiers for other languages, a number of methods have been deprecated in this release. The old options will be removed in the next major version | [#676](https://github.com/bugsnag/bugsnag-ruby/pull/676)

--- a/lib/bugsnag/session_tracker.rb
+++ b/lib/bugsnag/session_tracker.rb
@@ -35,7 +35,8 @@ module Bugsnag
     #
     # This allows Bugsnag to track error rates for a release.
     def start_session
-      return unless Bugsnag.configuration.enable_sessions
+      return unless Bugsnag.configuration.enable_sessions && Bugsnag.configuration.should_notify_release_stage?
+
       start_delivery_thread
       start_time = Time.now().utc().strftime('%Y-%m-%dT%H:%M:00')
       new_session = {
@@ -103,11 +104,6 @@ module Bugsnag
 
       if !Bugsnag.configuration.valid_api_key?
         Bugsnag.configuration.debug("Not delivering sessions due to an invalid api_key")
-        return
-      end
-
-      if !Bugsnag.configuration.should_notify_release_stage?
-        Bugsnag.configuration.debug("Not delivering sessions due to notify_release_stages :#{Bugsnag.configuration.notify_release_stages.inspect}")
         return
       end
 

--- a/spec/session_tracker_spec.rb
+++ b/spec/session_tracker_spec.rb
@@ -16,7 +16,7 @@ describe Bugsnag::SessionTracker do
       res.status = 202
       res.body = "OK\n"
     end
-    Thread.new{ server.start }
+    Thread.new { server.start }
   end
 
   before(:each) do
@@ -76,6 +76,26 @@ describe Bugsnag::SessionTracker do
     expect(Bugsnag.session_tracker.session_counts.size).to eq(0)
     Bugsnag.start_session
     expect(Bugsnag.session_tracker.session_counts.size).to eq(0)
+  end
+
+  it 'will not create sessions if the release stage is not enabled' do
+    Bugsnag.configure do |config|
+      config.enabled_release_stages = ['abc']
+      config.release_stage = 'xyz'
+    end
+
+    expect(Bugsnag.configuration.enable_sessions).to eq(true)
+    expect(Bugsnag.session_tracker.session_counts.size).to eq(0)
+
+    Bugsnag.start_session
+
+    expect(Bugsnag.session_tracker.session_counts.size).to eq(0)
+
+    Bugsnag.configuration.release_stage = 'abc'
+
+    Bugsnag.start_session
+
+    expect(Bugsnag.session_tracker.session_counts.size).to eq(1)
   end
 
   it 'sends sessions when send_sessions is called' do


### PR DESCRIPTION
## Goal

Currently we start sessions but will not deliver them when the current release stage is not enabled

This PR changes the session tracker to avoid starting a session instead; this has a small performance benefit as the background delivery thread won't be started for sessions that will never be delivered