### PR TITLE
Allow manually testing integrations fixture

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -79,3 +79,24 @@ RUBY_TEST_VERSION=2.6 RAILS_VERSION=6 docker-compose run --use-aliases ruby-maze
 ```
 
 In order to avoid running flakey or unfinished tests, the tag `"not @wip"` can be added to the tags option. This is recommended for all CI runs. If a tag is already specified, this should be added using the `and` keyword, e.g. `--tags "@rails6 and not @wip"`
+
+## Manually testing queue libraries
+
+To help manually test queue libraries and Active Job with various queue adapters, you can use [the `run-ruby-integrations` script](./features/fixtures/run-ruby-integrations). This takes care of installing your local copy of Bugsnag, booting Rails, setting up the database and booting the queue library
+
+As with the end-to-end tests, only Bugsnag employees can run this script as it relies on the same private resources
+
+The script will default to booting Sidekiq:
+
+```
+# run the rails_integrations fixture with sidekiq
+$ ./features/fixtures/run-rails-integrations
+```
+
+The script can also run Resque, Que or Delayed Job:
+
+```
+$ ./features/fixtures/run-rails-integrations resque
+$ ./features/fixtures/run-rails-integrations que
+$ ./features/fixtures/run-rails-integrations delayed_job
+```

--- a/features/fixtures/docker-compose.yml
+++ b/features/fixtures/docker-compose.yml
@@ -261,6 +261,8 @@ services:
       - RUN_AT_EXIT_HOOKS
       - ACTIVE_JOB_QUEUE_ADAPTER
     restart: "no"
+    ports:
+      - "3000:3000"
 
   sidekiq:
     build:

--- a/features/fixtures/rails_integrations/app/app/controllers/job_controller.rb
+++ b/features/fixtures/rails_integrations/app/app/controllers/job_controller.rb
@@ -1,0 +1,13 @@
+class JobController < ApplicationController
+  def working
+    WorkingJob.perform_later
+
+    render json: { result: 'queued WorkingJob!' }
+  end
+
+  def unhandled
+    UnhandledJob.perform_later
+
+    render json: { result: 'queued UnhandledJob!' }
+  end
+end

--- a/features/fixtures/rails_integrations/app/config/application.rb
+++ b/features/fixtures/rails_integrations/app/config/application.rb
@@ -32,7 +32,7 @@ module App
     # Only loads a smaller set of middleware suitable for API only apps.
     # Middleware like session, flash, cookies can be added back manually.
     # Skip views, helpers and assets when generating a new resource.
-    config.api_only = true
+    # config.api_only = true
 
     config.autoload_paths << Rails.root.join('app/workers')
   end

--- a/features/fixtures/rails_integrations/app/config/environments/development.rb
+++ b/features/fixtures/rails_integrations/app/config/environments/development.rb
@@ -44,4 +44,6 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+
+  config.hosts = []
 end

--- a/features/fixtures/rails_integrations/app/config/routes.rb
+++ b/features/fixtures/rails_integrations/app/config/routes.rb
@@ -1,3 +1,4 @@
 Rails.application.routes.draw do
-  # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
+  get '/job/working', 'job#working'
+  get '/job/unhandled', 'job#unhandled'
 end

--- a/features/fixtures/run-ruby-integrations
+++ b/features/fixtures/run-ruby-integrations
@@ -1,0 +1,120 @@
+#!/usr/bin/env ruby
+
+require "socket"
+require "timeout"
+require "pathname"
+
+DOCKER_DIRECTORY = Pathname.new(__dir__)
+ROOT_DIRECTORY = DOCKER_DIRECTORY + "../.."
+FIXTURE_DIRECTORY = DOCKER_DIRECTORY + "rails_integrations"
+
+raise "Fixture directory does not exist at: '#{FIXTURE_DIRECTORY}'" unless FIXTURE_DIRECTORY.exist?
+
+QUEUE_LIBRARY_COMMANDS = {
+  sidekiq: 'sidekiq',
+  resque: 'rake resque:work',
+  que: 'que --log-level debug --queue-name "*" ./config/environment.rb',
+  delayed_job: 'rake jobs:work',
+}
+
+QUEUE_LIBRARY = ARGV.fetch(0, :sidekiq).to_sym
+
+raise "Invalid queue libarary '#{QUEUE_LIBRARY}'" unless QUEUE_LIBRARY_COMMANDS.key?(QUEUE_LIBRARY)
+
+def wait_for_port(port, max_attempts: 60, seconds_between_attempts: 1)
+  is_open = false
+  attempts = 0
+
+  until is_open || attempts > max_attempts
+    begin
+      attempts += 1
+
+      # add a timeout as sometimes TCPSocket will wait for ages before realising
+      # it can't connect - this is a local port so should be """instant"""
+      Timeout.timeout(2) do
+        TCPSocket.new("127.0.0.1", port).close
+
+        # success!
+        is_open = true
+      end
+    rescue Timeout::Error, Errno::ECONNREFUSED, Errno::EHOSTUNREACH
+      # ignore timeouts and errors from the port being closed
+
+      # wait between attempts to give the port some time to open
+      sleep(seconds_between_attempts)
+    end
+  end
+
+  raise "Port #{port} not open in time!" unless is_open
+end
+
+def run_in_shell(command, env: {}, background: false)
+  puts "running '#{command}' with env: #{env}, background: #{background}"
+
+  if background
+    spawn(env, command)
+  else
+    system(env, command, exception: true)
+  end
+end
+
+def run_docker_command(command, env: {}, **kwargs)
+  default_env = { "NETWORK_NAME" => "notwerk-norm", "ACTIVE_JOB_QUEUE_ADAPTER" => QUEUE_LIBRARY.to_s }
+
+  run_in_shell(command, env: default_env.merge(env), **kwargs)
+end
+
+# ensure we clean up after ourselves on exit
+at_exit do
+  temp_bugsnag_lib = FIXTURE_DIRECTORY + "temp-bugsnag-lib"
+  temp_bugsnag_lib.rmtree if temp_bugsnag_lib.exist?
+
+  # stop the docker compose stack
+  Dir.chdir(FIXTURE_DIRECTORY) do
+    run_docker_command("docker-compose down")
+  end
+end
+
+# build the bugsnag gem and move it to the fixture directory
+Dir.chdir(ROOT_DIRECTORY) do
+  run_in_shell("gem build bugsnag.gemspec -o bugsnag.gem")
+  run_in_shell("mv bugsnag.gem #{FIXTURE_DIRECTORY}")
+end
+
+Dir.chdir(FIXTURE_DIRECTORY) do
+  # unpack the gem into the directory the dockerfile expects
+  run_in_shell("gem unpack bugsnag.gem --target temp-bugsnag-lib")
+  run_in_shell("rm bugsnag.gem")
+
+  rails_pid = run_docker_command(
+    "docker-compose up --build rails_integrations",
+    env: { "RUBY_TEST_VERSION" => "2.7" },
+    background: true
+  )
+
+  # wait for the container to finish building & starting
+  wait_for_port(3000)
+
+  # setup and migrate the database
+  run_docker_command("docker-compose run rails_integrations bundle exec rake db:prepare")
+  run_docker_command("docker-compose run rails_integrations bundle exec rake db:migrate")
+
+  # run the queue library in the background (not using '--detach' so we can see the logs)
+  queue_library_pid = run_docker_command(
+    "docker-compose run rails_integrations bundle exec #{QUEUE_LIBRARY_COMMANDS[QUEUE_LIBRARY]}",
+    background: true
+  )
+
+  # give the queue library some time to start before we print stuff, otherwise
+  # we'll print before the library does
+  sleep(5)
+
+  puts "Everything is running!"
+
+  # this will wait forever as the queue libraries won't exit on their own - quit with Ctrl+C
+  Process.wait(queue_library_pid)
+
+  # the queue library has exited (because of Ctrl+C) so tell rails to stop too,
+  # otherwise you'll need to Ctrl+C twice and no one has time for that
+  Process.kill("TERM", rails_pid)
+end


### PR DESCRIPTION
## Goal

Some changes are required in the integrations fixture in order to make it easier to run manually. I've also added a script that runs the fixture and starts one of the queuing libraries:

```
# run the rails_integrations fixture with sidekiq
$ ./features/fixtures/run-rails-integrations

# run the rails_integrations fixture with delayed_job
$ ./features/fixtures/run-rails-integrations delayed_job
```