### PR TITLE
Add missing deprecation to changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Changelog
 * For consistency with Bugsnag notifiers for other languages, a number of methods have been deprecated in this release. The old options will be removed in the next major version | [#676](https://github.com/bugsnag/bugsnag-ruby/pull/676)
     * The `notify_release_stages` configuration option has been deprecated in favour of `enabled_release_stages`
     * The `auto_capture_sessions` and `track_sessions` configuration options have been deprecated in favour of `auto_track_sessions`
+    * The `enabled_automatic_breadcrumb_types` configuration option has been deprecated in favour of `enabled_breadcrumb_types`
     * The `Report` class has been deprecated in favour of the `Event` class
     * The `Report#meta_data` attribute has been deprecated in favour of `Event#metadata`
     * The `Breadcrumb#meta_data` attribute has been deprecated in favour of `Breadcrumb#metadata`


### PR DESCRIPTION
## Goal

I missed adding `enabled_automatic_breadcrumb_types` &rarr; `enabled_breadcrumb_types` to the changelog after https://github.com/bugsnag/bugsnag-ruby/pull/676 when updating the docs