### PR TITLE
Add `on_breadcrumb` callbacks to replace `before_breadcrumb_callbacks`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Changelog
 * Sessions will now be delivered every 10 seconds, instead of every 30 seconds
   | [#680](https://github.com/bugsnag/bugsnag-ruby/pull/680)
 
+* Add `on_breadcrumb` callbacks to replace `before_breadcrumb_callbacks`
+  | [#686](https://github.com/bugsnag/bugsnag-ruby/pull/686)
+
 ### Fixes
 
 * Avoid starting session delivery thread when the current release stage is not enabled
@@ -15,6 +18,7 @@ Changelog
 
 ### Deprecated
 
+* `before_breadcrumb_callbacks` have been deprecated in favour of `on_breadcrumb` callbacks and will be removed in the next major release
 * For consistency with Bugsnag notifiers for other languages, a number of methods have been deprecated in this release. The old options will be removed in the next major version | [#676](https://github.com/bugsnag/bugsnag-ruby/pull/676)
     * The `notify_release_stages` configuration option has been deprecated in favour of `enabled_release_stages`
     * The `auto_capture_sessions` and `track_sessions` configuration options have been deprecated in favour of `auto_track_sessions`

--- a/lib/bugsnag.rb
+++ b/lib/bugsnag.rb
@@ -252,13 +252,17 @@ module Bugsnag
       # Skip if it's already invalid
       return if breadcrumb.ignore?
 
-      # Run callbacks
+      # Run before_breadcrumb_callbacks
       configuration.before_breadcrumb_callbacks.each do |c|
         c.arity > 0 ? c.call(breadcrumb) : c.call
         break if breadcrumb.ignore?
       end
 
       # Return early if ignored
+      return if breadcrumb.ignore?
+
+      # Run on_breadcrumb callbacks
+      configuration.on_breadcrumb_callbacks.call(breadcrumb)
       return if breadcrumb.ignore?
 
       # Validate again in case of callback alteration

--- a/lib/bugsnag.rb
+++ b/lib/bugsnag.rb
@@ -296,6 +296,33 @@ module Bugsnag
     end
 
     ##
+    # Add the given callback to the list of on_breadcrumb callbacks
+    #
+    # The on_breadcrumb callbacks will be called when a breadcrumb is left and
+    # are passed the {Breadcrumbs::Breadcrumb Breadcrumb} object
+    #
+    # Returning false from an on_breadcrumb callback will cause the breadcrumb
+    # to be ignored and will prevent any remaining callbacks from being called
+    #
+    # @param callback [Proc, Method, #call]
+    # @return [void]
+    def add_on_breadcrumb(callback)
+      configuration.add_on_breadcrumb(callback)
+    end
+
+    ##
+    # Remove the given callback from the list of on_breadcrumb callbacks
+    #
+    # Note that this must be the same instance that was passed to
+    # {add_on_breadcrumb}, otherwise it will not be removed
+    #
+    # @param callback [Proc, Method, #call]
+    # @return [void]
+    def remove_on_breadcrumb(callback)
+      configuration.remove_on_breadcrumb(callback)
+    end
+
+    ##
     # Returns the client's Cleaner object, or creates one if not yet created.
     #
     # @api private

--- a/lib/bugsnag/breadcrumbs/on_breadcrumb_callback_list.rb
+++ b/lib/bugsnag/breadcrumbs/on_breadcrumb_callback_list.rb
@@ -1,0 +1,44 @@
+require "set"
+
+module Bugsnag::Breadcrumbs
+  class OnBreadcrumbCallbackList
+    def initialize
+      @callbacks = Set.new
+      @mutex = Mutex.new
+    end
+
+    ##
+    # @param callback [Proc, Method, #call]
+    # @return [void]
+    def add(callback)
+      @mutex.synchronize do
+        @callbacks.add(callback)
+      end
+    end
+
+    ##
+    # @param callback [Proc, Method, #call]
+    # @return [void]
+    def remove(callback)
+      @mutex.synchronize do
+        @callbacks.delete(callback)
+      end
+    end
+
+    ##
+    # @param breadcrumb [Breadcrumb]
+    # @return [void]
+    def call(breadcrumb)
+      @callbacks.each do |callback|
+        should_continue = callback.call(breadcrumb)
+
+        # only stop if should_continue is explicity 'false' to allow callbacks
+        # to return 'nil'
+        if should_continue == false
+          breadcrumb.ignore!
+          break
+        end
+      end
+    end
+  end
+end

--- a/spec/breadcrumbs/on_breadcrumb_callback_list_spec.rb
+++ b/spec/breadcrumbs/on_breadcrumb_callback_list_spec.rb
@@ -1,0 +1,231 @@
+require "spec_helper"
+
+require "bugsnag/breadcrumbs/on_breadcrumb_callback_list"
+
+RSpec.describe Bugsnag::Breadcrumbs::OnBreadcrumbCallbackList do
+  it "can add callbacks to its list" do
+    callback = spy('callback')
+
+    list = Bugsnag::Breadcrumbs::OnBreadcrumbCallbackList.new
+    list.add(callback)
+
+    breadcrumb = Bugsnag::Breadcrumbs::Breadcrumb.new('name', 'type', {}, nil)
+
+    list.call(breadcrumb)
+
+    expect(callback).to have_received(:call).with(breadcrumb)
+    expect(breadcrumb.ignore?).to be(false)
+  end
+
+  it "can remove callbacks to its list" do
+    callback = spy('callback')
+
+    list = Bugsnag::Breadcrumbs::OnBreadcrumbCallbackList.new
+    list.add(callback)
+    list.remove(callback)
+
+    breadcrumb = Bugsnag::Breadcrumbs::Breadcrumb.new('name', 'type', {}, nil)
+
+    list.call(breadcrumb)
+
+    expect(callback).not_to have_received(:call)
+    expect(breadcrumb.ignore?).to be(false)
+  end
+
+  it "won't remove a callback that isn't the same instance" do
+    callback1 = spy('callback1')
+    callback2 = spy('callback2')
+
+    list = Bugsnag::Breadcrumbs::OnBreadcrumbCallbackList.new
+
+    # note: adding callback1 but removing callback2
+    list.add(callback1)
+    list.remove(callback2)
+
+    breadcrumb = Bugsnag::Breadcrumbs::Breadcrumb.new('name', 'type', {}, nil)
+
+    list.call(breadcrumb)
+
+    expect(callback1).to have_received(:call).with(breadcrumb)
+    expect(callback2).not_to have_received(:call)
+    expect(breadcrumb.ignore?).to be(false)
+  end
+
+  it "calls callbacks in the order they were added" do
+    calls = []
+
+    list = Bugsnag::Breadcrumbs::OnBreadcrumbCallbackList.new
+
+    list.add(proc { calls << 1 })
+    list.add(proc { calls << 2 })
+    list.add(proc { calls << 3 })
+
+    breadcrumb = Bugsnag::Breadcrumbs::Breadcrumb.new('name', 'type', {}, nil)
+
+    list.call(breadcrumb)
+
+    expect(calls).to eq([1, 2, 3])
+    expect(breadcrumb.ignore?).to be(false)
+  end
+
+  it "ignores the breadcrumb if a callback returns false" do
+    list = Bugsnag::Breadcrumbs::OnBreadcrumbCallbackList.new
+
+    list.add(proc { false })
+
+    breadcrumb = Bugsnag::Breadcrumbs::Breadcrumb.new('name', 'type', {}, nil)
+
+    list.call(breadcrumb)
+
+    expect(breadcrumb.ignore?).to be(true)
+  end
+
+  it "does not ignore the breadcrumb if a callback returns nil" do
+    list = Bugsnag::Breadcrumbs::OnBreadcrumbCallbackList.new
+
+    list.add(proc { nil })
+
+    breadcrumb = Bugsnag::Breadcrumbs::Breadcrumb.new('name', 'type', {}, nil)
+
+    list.call(breadcrumb)
+
+    expect(breadcrumb.ignore?).to be(false)
+  end
+
+  it "supports Method objects as callbacks" do
+    class ArbitraryClassMethod
+      def self.arbitrary_name(breadcrumb)
+        breadcrumb.metadata[:abc] = 123
+      end
+    end
+
+    class ArbitraryInstanceMethod
+      def arbitrary_name(breadcrumb)
+        breadcrumb.metadata[:xyz] = 789
+      end
+    end
+
+    list = Bugsnag::Breadcrumbs::OnBreadcrumbCallbackList.new
+
+    list.add(ArbitraryClassMethod.method(:arbitrary_name))
+
+    xyz = ArbitraryInstanceMethod.new
+    list.add(xyz.method(:arbitrary_name))
+
+    breadcrumb = Bugsnag::Breadcrumbs::Breadcrumb.new('name', 'type', {}, nil)
+
+    list.call(breadcrumb)
+
+    expect(breadcrumb.metadata).to eq({ abc: 123, xyz: 789 })
+  end
+
+  it "allows removing Method objects as callbacks" do
+    class ArbitraryClassMethod
+      def self.arbitrary_name(breadcrumb)
+        breadcrumb.metadata[:abc] = 123
+      end
+    end
+
+    class ArbitraryInstanceMethod
+      def arbitrary_name(breadcrumb)
+        breadcrumb.metadata[:xyz] = 789
+      end
+    end
+
+    list = Bugsnag::Breadcrumbs::OnBreadcrumbCallbackList.new
+
+    list.add(ArbitraryClassMethod.method(:arbitrary_name))
+    list.remove(ArbitraryClassMethod.method(:arbitrary_name))
+
+    xyz = ArbitraryInstanceMethod.new
+    list.add(xyz.method(:arbitrary_name))
+    list.remove(xyz.method(:arbitrary_name))
+
+    breadcrumb = Bugsnag::Breadcrumbs::Breadcrumb.new('name', 'type', {}, nil)
+
+    list.call(breadcrumb)
+
+    expect(breadcrumb.metadata).to eq({})
+  end
+
+  it "supports arbitrary objects that respond to #call as callbacks" do
+    class RespondsToCallAsClassMethod
+      def self.call(breadcrumb)
+        breadcrumb.metadata[:abc] = 123
+      end
+    end
+
+    class RespondsToCallAsInstanceMethod
+      def call(breadcrumb)
+        breadcrumb.metadata[:xyz] = 789
+      end
+    end
+
+    list = Bugsnag::Breadcrumbs::OnBreadcrumbCallbackList.new
+
+    list.add(RespondsToCallAsClassMethod)
+    list.add(RespondsToCallAsInstanceMethod.new)
+
+    breadcrumb = Bugsnag::Breadcrumbs::Breadcrumb.new('name', 'type', {}, nil)
+
+    list.call(breadcrumb)
+
+    expect(breadcrumb.metadata).to eq({ abc: 123, xyz: 789 })
+  end
+
+  it "supports removing arbitrary objects that respond to #call as callbacks" do
+    class RespondsToCallAsClassMethod
+      def self.call(breadcrumb)
+        breadcrumb.metadata[:abc] = 123
+      end
+    end
+
+    class RespondsToCallAsInstanceMethod
+      def call(breadcrumb)
+        breadcrumb.metadata[:xyz] = 789
+      end
+    end
+
+    list = Bugsnag::Breadcrumbs::OnBreadcrumbCallbackList.new
+
+    list.add(RespondsToCallAsClassMethod)
+    list.remove(RespondsToCallAsClassMethod)
+
+    instance = RespondsToCallAsInstanceMethod.new
+    list.add(instance)
+    list.remove(instance)
+
+    breadcrumb = Bugsnag::Breadcrumbs::Breadcrumb.new('name', 'type', {}, nil)
+
+    list.call(breadcrumb)
+
+    expect(breadcrumb.metadata).to eq({})
+  end
+
+  it "works when accessed concurrently" do
+    list = Bugsnag::Breadcrumbs::OnBreadcrumbCallbackList.new
+
+    list.add(proc do |breadcrumb|
+      breadcrumb.metadata[:numbers] = []
+    end)
+
+    NUMBER_OF_THREADS = 20
+
+    threads = NUMBER_OF_THREADS.times.map do |i|
+      Thread.new do
+        list.add(proc do |breadcrumb|
+          breadcrumb.metadata[:numbers].push(i)
+        end)
+      end
+    end
+
+    threads.shuffle.each(&:join)
+
+    breadcrumb = Bugsnag::Breadcrumbs::Breadcrumb.new('name', 'type', {}, nil)
+    list.call(breadcrumb)
+
+    # sort the numbers as they will be out of order but that doesn't matter as
+    # long as every number is present
+    expect(breadcrumb.metadata[:numbers].sort).to eq((0...NUMBER_OF_THREADS).to_a)
+  end
+end


### PR DESCRIPTION
## Goal

Adds `on_breadcrumb` callbacks, which will replace `before_breadcrumb_callbacks` in the next major release

The API is similar to `on_error` callbacks:

```ruby
callback = proc do |breadcrumb|
  breadcrumb.metadata = { hello: 'world' }
end

Bugsnag.configure do |config|
  config.add_on_breadcrumb(callback)
  config.remove_on_breadcrumb(callback)
end

Bugsnag.add_on_breadcrumb(callback)
Bugsnag.remove_on_breadcrumb(callback)
```

The semantics also follow `on_error` callbacks:

- returning `false` from a callback will discard the breadcrumb and stop any subsequent callbacks from running
- any errors raised by a callback will be rescued and logged. Any subsequent callbacks will still be run and the breadcrumb will not be discarded
- any object responding to `#call` is a valid callback

## Changeset

- add `Bugsnag::Breadcrumbs::OnBreadcrumbCallbackList` which manages the callbacks and can call them with the correct semantics
- add `Bugnsag#add_on_breadcrumb`, `Bugnsag#remove_on_breadcrumb`, `Bugnsag#add_on_breadcrumb` and `Bugnsag::Configuration#remove_on_breadcrumb`
- modified `Bugsnag#leave_breadcrumb` to call the new callbacks via the `OnBreadcrumbCallbackList`

## Testing

This is tested both in tests specifically for `OnBreadcrumbCallbackList` to ensure the semantics are correct and as part of the main set of `Bugsnag` tests to ensure they are called when leaving a breadcrumb

There are big whitespace changes in `bugsnag_spec.rb` to split `before_breadcrumb_callbacks` into their own `describe`, so it's easier to review that file by ignoring whitespace