### PR TITLE
Add `configuration.context` which sets the context of new events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,10 @@ Changelog
   | [#680](https://github.com/bugsnag/bugsnag-ruby/pull/680)
 * Log errors that prevent delivery at `ERROR` level
   | [#681](https://github.com/bugsnag/bugsnag-ruby/pull/681)
-
 * Add `on_breadcrumb` callbacks to replace `before_breadcrumb_callbacks`
   | [#686](https://github.com/bugsnag/bugsnag-ruby/pull/686)
+* Add `context` attribute to configuration, which will be used as the default context for events
+  | [#687](https://github.com/bugsnag/bugsnag-ruby/pull/687)
 
 ### Fixes
 

--- a/lib/bugsnag/configuration.rb
+++ b/lib/bugsnag/configuration.rb
@@ -145,6 +145,10 @@ module Bugsnag
     # @return [Regexp]
     attr_accessor :vendor_path
 
+    # The default context for all future events
+    # @return [String, nil]
+    attr_accessor :context
+
     # @api private
     # @return [Array<String>]
     attr_reader :scopes_to_filter

--- a/lib/bugsnag/report.rb
+++ b/lib/bugsnag/report.rb
@@ -118,6 +118,7 @@ module Bugsnag
       self.app_type = configuration.app_type
       self.app_version = configuration.app_version
       self.breadcrumbs = []
+      self.context = configuration.context
       self.delivery_method = configuration.delivery_method
       self.hostname = configuration.hostname
       self.runtime_versions = configuration.runtime_versions.dup

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -61,6 +61,17 @@ describe Bugsnag::Configuration do
     end
   end
 
+  describe "context" do
+    it "should default to nil" do
+      expect(subject.context).to be_nil
+    end
+
+    it "should be settable" do
+      subject.context = "test"
+      expect(subject.context).to eq("test")
+    end
+  end
+
   describe "#notify_endpoint" do
     it "defaults to DEFAULT_NOTIFY_ENDPOINT" do
       expect(subject.notify_endpoint).to eq(Bugsnag::Configuration::DEFAULT_NOTIFY_ENDPOINT)

--- a/spec/report_spec.rb
+++ b/spec/report_spec.rb
@@ -568,6 +568,34 @@ describe Bugsnag::Report do
     }
   end
 
+  it "uses the context from Configuration, if set" do
+    Bugsnag.configure do |config|
+      config.context = "example context"
+    end
+
+    Bugsnag.notify(BugsnagTestException.new("It crashed"))
+
+    expect(Bugsnag).to(have_sent_notification { |payload, _headers|
+      event = get_event_from_payload(payload)
+      expect(event["context"]).to eq("example context")
+    })
+  end
+
+  it "allows overriding the context from Configuration" do
+    Bugsnag.configure do |config|
+      config.context = "example context"
+    end
+
+    Bugsnag.notify(BugsnagTestException.new("It crashed")) do |report|
+      report.context = "different context"
+    end
+
+    expect(Bugsnag).to(have_sent_notification { |payload, _headers|
+      event = get_event_from_payload(payload)
+      expect(event["context"]).to eq("different context")
+    })
+  end
+
   it "accepts a user_id in overrides" do
     Bugsnag.notify(BugsnagTestException.new("It crashed")) do |report|
       report.user = {id: 'test_user'}


### PR DESCRIPTION
## Goal

This PR adds a `context` attribute to configuration, which will be used as the default context for new events

In a future PR setting the context this way will prevent Bugsnag from setting an automatic context, such as the Sidekiq job & queue name