### PR TITLE
Give the configuration context precedence over context in integrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,9 @@ Changelog
   | [#681](https://github.com/bugsnag/bugsnag-ruby/pull/681)
 * Add `on_breadcrumb` callbacks to replace `before_breadcrumb_callbacks`
   | [#686](https://github.com/bugsnag/bugsnag-ruby/pull/686)
-* Add `context` attribute to configuration, which will be used as the default context for events
+* Add `context` attribute to configuration, which will be used as the default context for events. Using this option will disable automatic context setting
   | [#687](https://github.com/bugsnag/bugsnag-ruby/pull/687)
+  | [#688](https://github.com/bugsnag/bugsnag-ruby/pull/688)
 
 ### Fixes
 

--- a/lib/bugsnag/configuration.rb
+++ b/lib/bugsnag/configuration.rb
@@ -553,6 +553,18 @@ module Bugsnag
       @on_breadcrumb_callbacks.remove(callback)
     end
 
+    ##
+    # Has the context been explicitly set?
+    #
+    # This is necessary to differentiate between the context not being set and
+    # the context being set to 'nil' explicitly
+    #
+    # @api private
+    # @return [Boolean]
+    def context_set?
+      defined?(@context) != nil
+    end
+
     # TODO: These methods can be a simple attr_accessor when they replace the
     #       methods they are aliasing
     # NOTE: they are not aliases as YARD doesn't allow documenting the non-alias

--- a/lib/bugsnag/configuration.rb
+++ b/lib/bugsnag/configuration.rb
@@ -146,6 +146,7 @@ module Bugsnag
     attr_accessor :vendor_path
 
     # The default context for all future events
+    # Setting this will disable automatic context setting
     # @return [String, nil]
     attr_accessor :context
 

--- a/lib/bugsnag/integrations/resque.rb
+++ b/lib/bugsnag/integrations/resque.rb
@@ -56,7 +56,7 @@ module Bugsnag
 
         context = "#{class_name}@#{queue}"
         report.meta_data.merge!({ context: context, payload: metadata })
-        report.context = context
+        report.automatic_context = context
       end
     end
   end

--- a/lib/bugsnag/middleware/active_job.rb
+++ b/lib/bugsnag/middleware/active_job.rb
@@ -9,7 +9,7 @@ module Bugsnag::Middleware
 
       if data
         report.add_tab(:active_job, data)
-        report.context = "#{data[:job_name]}@#{data[:queue]}"
+        report.automatic_context = "#{data[:job_name]}@#{data[:queue]}"
       end
 
       @bugsnag.call(report)

--- a/lib/bugsnag/middleware/delayed_job.rb
+++ b/lib/bugsnag/middleware/delayed_job.rb
@@ -30,7 +30,7 @@ module Bugsnag::Middleware
           payload_data = construct_job_payload(job.payload_object)
 
           context = get_context(payload_data, job_data[:active_job])
-          report.context = context unless context.nil?
+          report.automatic_context = context unless context.nil?
 
           job_data[:payload] = payload_data
         end

--- a/lib/bugsnag/middleware/exception_meta_data.rb
+++ b/lib/bugsnag/middleware/exception_meta_data.rb
@@ -16,6 +16,8 @@ module Bugsnag::Middleware
 
         if exception.respond_to?(:bugsnag_context)
           context = exception.bugsnag_context
+          # note: this should set 'context' not 'automatic_context' as it's a
+          #       user-supplied value
           report.context = context if context.is_a?(String)
         end
 

--- a/lib/bugsnag/middleware/rack_request.rb
+++ b/lib/bugsnag/middleware/rack_request.rb
@@ -18,8 +18,8 @@ module Bugsnag::Middleware
         client_ip = request.ip.to_s rescue SPOOF
         session = env["rack.session"]
 
-        # Set the context
-        report.context = "#{request.request_method} #{request.path}"
+        # Set the automatic context
+        report.automatic_context = "#{request.request_method} #{request.path}"
 
         # Set a sensible default for user_id
         report.user["id"] = request.ip

--- a/lib/bugsnag/middleware/rails3_request.rb
+++ b/lib/bugsnag/middleware/rails3_request.rb
@@ -15,8 +15,8 @@ module Bugsnag::Middleware
         client_ip = env["action_dispatch.remote_ip"].to_s rescue SPOOF
 
         if params
-          # Set the context
-          report.context = "#{params[:controller]}##{params[:action]}"
+          # Set the automatic context
+          report.automatic_context = "#{params[:controller]}##{params[:action]}"
 
           # Augment the request tab
           report.add_tab(:request, {

--- a/lib/bugsnag/middleware/rake.rb
+++ b/lib/bugsnag/middleware/rake.rb
@@ -16,7 +16,7 @@ module Bugsnag::Middleware
           :arguments => task.arg_description
         })
 
-        report.context ||= task.name
+        report.automatic_context ||= task.name
       end
 
       @bugsnag.call(report)

--- a/lib/bugsnag/middleware/sidekiq.rb
+++ b/lib/bugsnag/middleware/sidekiq.rb
@@ -10,7 +10,7 @@ module Bugsnag::Middleware
       sidekiq = report.request_data[:sidekiq]
       if sidekiq
         report.add_tab(:sidekiq, sidekiq)
-        report.context ||= "#{sidekiq[:msg]['wrapped'] || sidekiq[:msg]['class']}@#{sidekiq[:msg]['queue']}"
+        report.automatic_context ||= "#{sidekiq[:msg]['wrapped'] || sidekiq[:msg]['class']}@#{sidekiq[:msg]['queue']}"
       end
       @bugsnag.call(report)
     end

--- a/lib/bugsnag/report.rb
+++ b/lib/bugsnag/report.rb
@@ -114,7 +114,7 @@ module Bugsnag
       self.app_type = configuration.app_type
       self.app_version = configuration.app_version
       self.breadcrumbs = []
-      self.context = configuration.context
+      self.context = configuration.context if configuration.context_set?
       self.delivery_method = configuration.delivery_method
       self.hostname = configuration.hostname
       self.runtime_versions = configuration.runtime_versions.dup
@@ -130,7 +130,9 @@ module Bugsnag
     # @!attribute context
     # @return [String, nil]
     def context
-      @context || @automatic_context
+      return @context if defined?(@context)
+
+      @automatic_context
     end
 
     attr_writer :context

--- a/lib/bugsnag/report.rb
+++ b/lib/bugsnag/report.rb
@@ -45,10 +45,6 @@ module Bugsnag
     # @return [Configuration]
     attr_accessor :configuration
 
-    # Additional context for this report
-    # @return [String, nil]
-    attr_accessor :context
-
     # The delivery method that will be used for this report
     # @see Configuration#delivery_method
     # @return [Symbol]
@@ -128,6 +124,23 @@ module Bugsnag
       self.severity_reason = auto_notify ? {:type => UNHANDLED_EXCEPTION} : {:type => HANDLED_EXCEPTION}
       self.user = {}
     end
+
+    ##
+    # Additional context for this report
+    # @!attribute context
+    # @return [String, nil]
+    def context
+      @context || @automatic_context
+    end
+
+    attr_writer :context
+
+    ##
+    # Context set automatically by Bugsnag uses this attribute, which prevents
+    # it from overwriting the user-supplied context
+    # @api private
+    # @return [String, nil]
+    attr_accessor :automatic_context
 
     ##
     # Add a new metadata tab to this notification.

--- a/lib/bugsnag/tasks/bugsnag.rake
+++ b/lib/bugsnag/tasks/bugsnag.rake
@@ -7,7 +7,7 @@ namespace :bugsnag do
       raise RuntimeError.new("Bugsnag test exception")
     rescue => e
       Bugsnag.notify(e) do |report|
-        report.context = "rake#test_exception"
+        report.automatic_context = "rake#test_exception"
       end
     end
   end

--- a/spec/integrations/rack_spec.rb
+++ b/spec/integrations/rack_spec.rb
@@ -124,7 +124,7 @@ describe Bugsnag::Rack do
       allow(report).to receive(:request_data).and_return({
         :rack_env => rack_env
       })
-      expect(report).to receive(:context=).with("TEST /TEST_PATH")
+      expect(report).to receive(:automatic_context=).with("TEST /TEST_PATH")
       expect(report).to receive(:user).and_return({})
 
       config = Bugsnag.configuration
@@ -185,7 +185,7 @@ describe Bugsnag::Rack do
       allow(report).to receive(:request_data).and_return({
         :rack_env => rack_env
       })
-      expect(report).to receive(:context=).with("TEST /TEST_PATH")
+      expect(report).to receive(:automatic_context=).with("TEST /TEST_PATH")
       expect(report).to receive(:user).and_return({})
 
       config = Bugsnag.configuration

--- a/spec/integrations/rake_spec.rb
+++ b/spec/integrations/rake_spec.rb
@@ -23,8 +23,8 @@ describe "Bugsnag Rake integration" do
         :description => "TEST_COMMENT",
         :arguments => "TEST_ARGS"
       })
-      expect(report).to receive(:context).with(no_args)
-      expect(report).to receive(:context=).with("TEST_NAME")
+      expect(report).to receive(:automatic_context).with(no_args)
+      expect(report).to receive(:automatic_context=).with("TEST_NAME")
 
       expect(callback).to receive(:call).with(report)
 

--- a/spec/integrations/resque_spec.rb
+++ b/spec/integrations/resque_spec.rb
@@ -85,7 +85,7 @@ describe 'Bugsnag::Resque', :order => :defined do
         "class" => "class"
       }
     })
-    expect(report).to receive(:context=).with(expected_context)
+    expect(report).to receive(:automatic_context=).with(expected_context)
     expect(Bugsnag).to receive(:notify).with(exception, true).and_yield(report)
     resque.save
   end

--- a/spec/report_spec.rb
+++ b/spec/report_spec.rb
@@ -610,6 +610,21 @@ describe Bugsnag::Report do
     })
   end
 
+  it "uses overridden context even it is set to 'nil'" do
+    Bugsnag.configure do |config|
+      config.context = nil
+    end
+
+    Bugsnag.notify(BugsnagTestException.new("It crashed")) do |report|
+      report.automatic_context = "automatic context"
+    end
+
+    expect(Bugsnag).to(have_sent_notification { |payload, _headers|
+      event = get_event_from_payload(payload)
+      expect(event["context"]).to be_nil
+    })
+  end
+
   it "uses the context from Configuration, if set" do
     Bugsnag.configure do |config|
       config.context = "example context"

--- a/spec/report_spec.rb
+++ b/spec/report_spec.rb
@@ -568,6 +568,48 @@ describe Bugsnag::Report do
     }
   end
 
+  it "uses automatic context if no other context has been set" do
+    Bugsnag.notify(BugsnagTestException.new("It crashed")) do |report|
+      report.automatic_context = "automatic context"
+    end
+
+    expect(Bugsnag).to(have_sent_notification { |payload, _headers|
+      event = get_event_from_payload(payload)
+      expect(event["context"]).to eq("automatic context")
+    })
+  end
+
+  it "uses Configuration context even if the automatic context has been set" do
+    Bugsnag.configure do |config|
+      config.context = "configuration context"
+    end
+
+    Bugsnag.notify(BugsnagTestException.new("It crashed")) do |report|
+      report.automatic_context = "automatic context"
+    end
+
+    expect(Bugsnag).to(have_sent_notification { |payload, _headers|
+      event = get_event_from_payload(payload)
+      expect(event["context"]).to eq("configuration context")
+    })
+  end
+
+  it "uses overridden context even if the automatic context has been set" do
+    Bugsnag.configure do |config|
+      config.context = "configuration context"
+    end
+
+    Bugsnag.notify(BugsnagTestException.new("It crashed")) do |report|
+      report.context = "overridden context"
+      report.automatic_context = "automatic context"
+    end
+
+    expect(Bugsnag).to(have_sent_notification { |payload, _headers|
+      event = get_event_from_payload(payload)
+      expect(event["context"]).to eq("overridden context")
+    })
+  end
+
   it "uses the context from Configuration, if set" do
     Bugsnag.configure do |config|
       config.context = "example context"


### PR DESCRIPTION
## Goal

If `Configuration#context` is set then it will now take precedence over the context set by integrations. This is true even if it is set to `nil`, in which case no context will be sent by the notifier — the context will be set by the Bugsnag app instead

For example:

![image](https://user-images.githubusercontent.com/282732/130803923-a7f4fc28-db79-44f7-930d-926cc0c14d54.png)

The top error has `config.context = nil`, so the context is set by the Bugsnag app
The middle error has `config.context = 'some context'` and so always uses that value as the context
The bottom error has no context set in `config`, which allows the Rack integration's context to be used