### PR TITLE
Add `Bugsnag#breadcrumbs` getter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Changelog
 * Add `context` attribute to configuration, which will be used as the default context for events. Using this option will disable automatic context setting
   | [#687](https://github.com/bugsnag/bugsnag-ruby/pull/687)
   | [#688](https://github.com/bugsnag/bugsnag-ruby/pull/688)
+* Add `Bugsnag#breadcrumbs` getter to fetch the current list of breadcrumbs
+  | [#689](https://github.com/bugsnag/bugsnag-ruby/pull/689)
 
 ### Fixes
 

--- a/lib/bugsnag.rb
+++ b/lib/bugsnag.rb
@@ -327,6 +327,17 @@ module Bugsnag
     end
 
     ##
+    # Returns the current list of breadcrumbs
+    #
+    # This is a per-thread circular buffer, containing at most 'max_breadcrumbs'
+    # breadcrumbs
+    #
+    # @return [Bugsnag::Utility::CircularBuffer]
+    def breadcrumbs
+      configuration.breadcrumbs
+    end
+
+    ##
     # Returns the client's Cleaner object, or creates one if not yet created.
     #
     # @api private

--- a/lib/bugsnag/configuration.rb
+++ b/lib/bugsnag/configuration.rb
@@ -449,9 +449,12 @@ module Bugsnag
     end
 
     ##
-    # Returns the breadcrumb circular buffer
+    # Returns the current list of breadcrumbs
     #
-    # @return [Bugsnag::Utility::CircularBuffer] a thread based circular buffer containing breadcrumbs
+    # This is a per-thread circular buffer, containing at most 'max_breadcrumbs'
+    # breadcrumbs
+    #
+    # @return [Bugsnag::Utility::CircularBuffer]
     def breadcrumbs
       request_data[:breadcrumbs] ||= Bugsnag::Utility::CircularBuffer.new(@max_breadcrumbs)
     end

--- a/spec/bugsnag_spec.rb
+++ b/spec/bugsnag_spec.rb
@@ -521,4 +521,10 @@ describe Bugsnag do
       }
     end
   end
+
+  describe "#breadcrumbs" do
+    it "returns the configuration's breadcrumb buffer" do
+      expect(Bugsnag.breadcrumbs).to be(Bugsnag.configuration.breadcrumbs)
+    end
+  end
 end


### PR DESCRIPTION
## Goal

This PR adds `Bugsnag#breadcrumbs`; a simple getter for the current list of breadcrumbs

This already existed on the Configuration class, so this API is just for convenience (`Bugsnag.breadcrumbs` vs `Bugsnag.configuration.breadcrumbs`)