### PR TITLE
Add `errors` to Report/Event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ Changelog
   | [#689](https://github.com/bugsnag/bugsnag-ruby/pull/689)
 * Add `time` (an ISO8601 string in UTC) to `device` metadata
   | [#690](https://github.com/bugsnag/bugsnag-ruby/pull/690)
+* Add `errors` to `Report`/`Event` containing an array of `Error` objects. The `Error` object contains `error_class`, `error_message` and `type` (always "ruby")
+  | [#691](https://github.com/bugsnag/bugsnag-ruby/pull/691)
 
 ### Fixes
 
@@ -37,6 +39,7 @@ Changelog
     * The `Breadcrumb#name` attribute has been deprecated in favour of `Breadcrumb#message`
     * The breadcrumb type constants in the `Bugsnag::Breadcrumbs` module has been deprecated in favour of the constants available in the `Bugsnag::BreadcrumbType` module
     For example, `Bugsnag::Breadcrumbs::ERROR_BREADCRUMB_TYPE` is now available as `Bugsnag::BreadcrumbType::ERROR`
+* `Report#exceptions` has been deprecated in favour of the new `errors` property
 
 ## v6.22.1 (11 August 2021)
 

--- a/lib/bugsnag/error.rb
+++ b/lib/bugsnag/error.rb
@@ -1,0 +1,9 @@
+module Bugsnag
+  # @!attribute error_class
+  #   @return [String] the error's class name
+  # @!attribute error_message
+  #   @return [String] the error's message
+  # @!attribute type
+  #   @return [String] the type of error (always "ruby")
+  Error = Struct.new(:error_class, :error_message, :type)
+end


### PR DESCRIPTION
## Goal

This PR adds an `errors` attribute to the `Report`/`Event` class, containing an array of `Bugsnag::Error` objects. The Error object is a Struct with `error_class`, `error_message` and `type` attributes

This will replace the current `Report#exceptions` in the next major version, after the addition of a `Error#stacktrace` method (currently `exceptions` contains the stacktrace)