### PR TITLE
Add `original_error` to Report/Event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ Changelog
   | [#690](https://github.com/bugsnag/bugsnag-ruby/pull/690)
 * Add `errors` to `Report`/`Event` containing an array of `Error` objects. The `Error` object contains `error_class`, `error_message` and `type` (always "ruby")
   | [#691](https://github.com/bugsnag/bugsnag-ruby/pull/691)
+* Add `original_error` to `Report`/`Event` containing the original Exception instance
+  | [#692](https://github.com/bugsnag/bugsnag-ruby/pull/692)
 
 ### Fixes
 
@@ -40,6 +42,7 @@ Changelog
     * The breadcrumb type constants in the `Bugsnag::Breadcrumbs` module has been deprecated in favour of the constants available in the `Bugsnag::BreadcrumbType` module
     For example, `Bugsnag::Breadcrumbs::ERROR_BREADCRUMB_TYPE` is now available as `Bugsnag::BreadcrumbType::ERROR`
 * `Report#exceptions` has been deprecated in favour of the new `errors` property
+* `Report#raw_exceptions` has been deprecated in favour of the new `original_error` property
 
 ## v6.22.1 (11 August 2021)
 

--- a/lib/bugsnag/report.rb
+++ b/lib/bugsnag/report.rb
@@ -79,6 +79,7 @@ module Bugsnag
     attr_accessor :meta_data
 
     # The raw Exception instances for this report
+    # @deprecated Use {#original_error} instead
     # @see #exceptions
     # @return [Array<Exception>]
     attr_accessor :raw_exceptions
@@ -109,6 +110,10 @@ module Bugsnag
     # @return [Array<Error>]
     attr_reader :errors
 
+    # The Exception instance this report was created for
+    # @return [Exception]
+    attr_reader :original_error
+
     ##
     # Initializes a new report from an exception.
     def initialize(exception, passed_configuration, auto_notify=false)
@@ -120,6 +125,7 @@ module Bugsnag
 
       self.configuration = passed_configuration
 
+      @original_error = exception
       self.raw_exceptions = generate_raw_exceptions(exception)
       self.exceptions = generate_exception_list
       @errors = generate_error_list

--- a/spec/report_spec.rb
+++ b/spec/report_spec.rb
@@ -192,6 +192,13 @@ shared_examples "Report or Event tests" do |class_to_test|
       )
     end
   end
+
+  it "has a reference to the original error" do
+    exception = RuntimeError.new("example error")
+    report = class_to_test.new(exception, Bugsnag.configuration)
+
+    expect(report.original_error).to be(exception)
+  end
 end
 
 # rubocop:disable Metrics/BlockLength


### PR DESCRIPTION
## Goal

This PR adds an `original_error` attribute to the `Report`/`Event` class, containing the `Exception` instance used to construct the Report

This will replace the current `Report#raw_exceptions` in the next major version