### PR TITLE
Add the stacktrace to `Error`s

### DIFF
--- a/lib/bugsnag/error.rb
+++ b/lib/bugsnag/error.rb
@@ -1,11 +1,25 @@
 module Bugsnag
-  # @!attribute error_class
-  #   @return [String] the error's class name
-  # @!attribute error_message
-  #   @return [String] the error's message
-  # @!attribute stacktrace
-  #   @return [Hash] the error's processed stacktrace
-  # @!attribute type
-  #   @return [String] the type of error (always "ruby")
-  Error = Struct.new(:error_class, :error_message, :stacktrace, :type)
+  class Error
+    # @return [String] the error's class name
+    attr_accessor :error_class
+
+    # @return [String] the error's message
+    attr_accessor :error_message
+
+    # @return [Hash] the error's processed stacktrace
+    attr_reader :stacktrace
+
+    # @return [String] the type of error (always "ruby")
+    attr_accessor :type
+
+    # @api private
+    TYPE = "ruby".freeze
+
+    def initialize(error_class, error_message, stacktrace)
+      @error_class = error_class
+      @error_message = error_message
+      @stacktrace = stacktrace
+      @type = TYPE
+    end
+  end
 end

--- a/lib/bugsnag/error.rb
+++ b/lib/bugsnag/error.rb
@@ -3,7 +3,9 @@ module Bugsnag
   #   @return [String] the error's class name
   # @!attribute error_message
   #   @return [String] the error's message
+  # @!attribute stacktrace
+  #   @return [Hash] the error's processed stacktrace
   # @!attribute type
   #   @return [String] the type of error (always "ruby")
-  Error = Struct.new(:error_class, :error_message, :type)
+  Error = Struct.new(:error_class, :error_message, :stacktrace, :type)
 end

--- a/lib/bugsnag/report.rb
+++ b/lib/bugsnag/report.rb
@@ -373,7 +373,12 @@ module Bugsnag
 
     def generate_error_list
       exceptions.map do |exception|
-        Error.new(exception[:errorClass], exception[:message], ERROR_TYPE)
+        Error.new(
+          exception[:errorClass],
+          exception[:message],
+          exception[:stacktrace],
+          ERROR_TYPE
+        )
       end
     end
 

--- a/lib/bugsnag/report.rb
+++ b/lib/bugsnag/report.rb
@@ -21,9 +21,6 @@ module Bugsnag
 
     CURRENT_PAYLOAD_VERSION = "4.0"
 
-    # @api private
-    ERROR_TYPE = "ruby".freeze
-
     # Whether this report is for a handled or unhandled error
     # @return [Boolean]
     attr_reader :unhandled
@@ -373,12 +370,7 @@ module Bugsnag
 
     def generate_error_list
       exceptions.map do |exception|
-        Error.new(
-          exception[:errorClass],
-          exception[:message],
-          exception[:stacktrace],
-          ERROR_TYPE
-        )
+        Error.new(exception[:errorClass], exception[:message], exception[:stacktrace])
       end
     end
 

--- a/spec/report_spec.rb
+++ b/spec/report_spec.rb
@@ -158,6 +158,11 @@ shared_examples "Report or Event tests" do |class_to_test|
       expect(error).to respond_to(:error_message)
       expect(error).to respond_to(:type)
       expect(error).to respond_to(:stacktrace)
+
+      expect(error).to respond_to(:error_class=)
+      expect(error).to respond_to(:error_message=)
+      expect(error).to respond_to(:type=)
+      expect(error).not_to respond_to(:stacktrace=)
     end
 
     it "includes errors that caused the top-most exception" do
@@ -266,10 +271,6 @@ shared_examples "Report or Event tests" do |class_to_test|
           method: "do_nothing",
           code: "yes, lots"
         }
-
-        # reassiging the stacktrace will not affect the payload, until
-        # 'report#errors' replaces 'report#exceptions' entirely
-        error.stacktrace = []
       end
 
       expect(Bugsnag).to(have_sent_notification { |payload, _headers|

--- a/spec/report_spec.rb
+++ b/spec/report_spec.rb
@@ -146,13 +146,18 @@ shared_examples "Report or Event tests" do |class_to_test|
   end
 
   describe "#errors" do
-    it "has required hash keys" do
+    it "has required attributes" do
       exception = RuntimeError.new("example error")
       report = class_to_test.new(exception, Bugsnag.configuration)
 
-      expect(report.errors).to eq(
-        [Bugsnag::Error.new("RuntimeError", "example error", "ruby")]
-      )
+      expect(report.errors.length).to eq(1)
+
+      error = report.errors.first
+
+      expect(error).to respond_to(:error_class)
+      expect(error).to respond_to(:error_message)
+      expect(error).to respond_to(:type)
+      expect(error).to respond_to(:stacktrace)
     end
 
     it "includes errors that caused the top-most exception" do
@@ -167,12 +172,21 @@ shared_examples "Report or Event tests" do |class_to_test|
 
       report = class_to_test.new(exception, Bugsnag.configuration)
 
-      expect(report.errors).to eq(
-        [
-          Bugsnag::Error.new("Ruby21Exception", "two", "ruby"),
-          Bugsnag::Error.new("RuntimeError", "one", "ruby")
-        ]
-      )
+      expect(report.errors.length).to eq(2)
+
+      expect(report.errors[0].stacktrace).not_to be_empty
+      expect(report.errors[0]).to have_attributes({
+        error_class: "Ruby21Exception",
+        error_message: "two",
+        type: "ruby"
+      })
+
+      expect(report.errors[1].stacktrace).not_to be_empty
+      expect(report.errors[1]).to have_attributes({
+        error_class: "RuntimeError",
+        error_message: "one",
+        type: "ruby"
+      })
     end
 
     it "cannot be assigned to" do
@@ -190,25 +204,88 @@ shared_examples "Report or Event tests" do |class_to_test|
       report.errors.push("haha 2")
       report.errors.pop
 
-      expect(report.errors).to eq(
-        [
-          Bugsnag::Error.new("RuntimeError", "example error", "ruby"),
-          "haha"
-        ]
-      )
+      expect(report.errors.length).to eq(2)
+
+      expect(report.errors.first.stacktrace).not_to be_empty
+      expect(report.errors.first).to have_attributes({
+        error_class: "RuntimeError",
+        error_message: "example error",
+        type: "ruby"
+      })
+
+      expect(report.errors[1]).to eq("haha")
     end
 
     it "contains mutable data" do
       exception = RuntimeError.new("example error")
       report = class_to_test.new(exception, Bugsnag.configuration)
 
+      expect(report.errors.length).to eq(1)
+
       report.errors.first.error_class = "haha"
       report.errors.first.error_message = "ahah"
       report.errors.first.type = "aahh"
 
-      expect(report.errors).to eq(
-        [Bugsnag::Error.new("haha", "ahah", "aahh")]
-      )
+      expect(report.errors.first.stacktrace).not_to be_empty
+      expect(report.errors.first).to have_attributes({
+        error_class: "haha",
+        error_message: "ahah",
+        type: "aahh"
+      })
+    end
+
+    it "shares the stacktrace with #exceptions" do
+      exception = RuntimeError.new("example error")
+      report = class_to_test.new(exception, Bugsnag.configuration)
+
+      expect(report.errors.length).to eq(1)
+      expect(report.exceptions.length).to eq(1)
+
+      error = report.errors.first
+      exception = report.exceptions.first
+
+      expect(error.stacktrace).not_to be_empty
+      expect(error.stacktrace).to all(have_key(:lineNumber))
+      expect(error.stacktrace).to all(have_key(:file))
+      expect(error.stacktrace).to all(have_key(:method))
+      expect(error.stacktrace).to all(have_key(:code))
+
+      expect(error.stacktrace).to be(exception[:stacktrace])
+    end
+
+    it "mutating the stacktrace affects the payload" do
+      Bugsnag.notify(BugsnagTestException.new("It crashed")) do |report|
+        expect(report.errors.length).to eq(1)
+
+        error = report.errors.first
+
+        error.stacktrace.clear
+        error.stacktrace[0] = {
+          lineNumber: 123,
+          file: "/dev/null",
+          method: "do_nothing",
+          code: "yes, lots"
+        }
+
+        # reassiging the stacktrace will not affect the payload, until
+        # 'report#errors' replaces 'report#exceptions' entirely
+        error.stacktrace = []
+      end
+
+      expect(Bugsnag).to(have_sent_notification { |payload, _headers|
+        exception = get_exception_from_payload(payload)
+
+        expect(exception["stacktrace"]).to eq(
+          [
+            {
+              "lineNumber" => 123,
+              "file" => "/dev/null",
+              "method" => "do_nothing",
+              "code" => "yes, lots"
+            }
+          ]
+        )
+      })
     end
   end
 


### PR DESCRIPTION
## Goal

Adds the stacktrace to `Error` instances; this is the same stacktrace hash that the `exceptions` array uses (i.e. we're not duplicating it). This means the stacktrace can be modified on an `Error` instance and the changes will be reflected in the payload that's send to Bugsnag

## Design

To make the stacktrace readonly, I've made `Error` a plain class instead of a `Struct`; I think this is better than messing around with the struct to get a readonly field (especially given the number of Rubies we support) and we don't really need most of the struct API anyway

## Testing

Had to tweak the existing tests as we can't directly compare Error instances without having identical stacktraces, which isn't really feasible