### PR TITLE
Add `set_user` to Report/Event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ Changelog
   | [#693](https://github.com/bugsnag/bugsnag-ruby/pull/693)
 * Add `add_metadata` and `clear_metadata` to `Report`/`Event`
   | [#694](https://github.com/bugsnag/bugsnag-ruby/pull/694)
+* Add `set_user` to `Report`/`Event`
+  | [#695](https://github.com/bugsnag/bugsnag-ruby/pull/695)
 
 ### Fixes
 

--- a/lib/bugsnag/report.rb
+++ b/lib/bugsnag/report.rb
@@ -359,6 +359,24 @@ module Bugsnag
       @metadata_delegate.clear_metadata(@meta_data, section, *args)
     end
 
+    ##
+    # Set information about the current user
+    #
+    # Additional user fields can be added as metadata in a "user" section
+    #
+    # Setting a field to 'nil' will remove it from the user data
+    #
+    # @param id [String, nil]
+    # @param email [String, nil]
+    # @param name [String, nil]
+    # @return [void]
+    def set_user(id = nil, email = nil, name = nil)
+      new_user = { id: id, email: email, name: name }
+      new_user.reject! { |key, value| value.nil? }
+
+      @user = new_user
+    end
+
     private
 
     def generate_exception_list

--- a/spec/report_spec.rb
+++ b/spec/report_spec.rb
@@ -792,17 +792,6 @@ describe Bugsnag::Report do
     })
   end
 
-  it "accepts a user_id in overrides" do
-    Bugsnag.notify(BugsnagTestException.new("It crashed")) do |report|
-      report.user = {id: 'test_user'}
-    end
-
-    expect(Bugsnag).to have_sent_notification{ |payload, headers|
-      event = get_event_from_payload(payload)
-      expect(event["user"]["id"]).to eq("test_user")
-    }
-  end
-
   it "does not send an automatic notification if auto_notify is false" do
     Bugsnag.configure do |config|
       config.auto_notify = false
@@ -1868,6 +1857,85 @@ describe Bugsnag::Report do
       # This matches the time we stubbed earlier (fake_sent_at)
       expect(headers["Bugsnag-Sent-At"]).to eq("2021-01-02T03:04:05.123Z")
     })
+  end
+
+  context "#user" do
+    it "accepts an arbitrary user hash" do
+      Bugsnag.notify(BugsnagTestException.new("It crashed")) do |report|
+        report.user = { id: "test_user", abc: "xyz" }
+      end
+
+      expect(Bugsnag).to(have_sent_notification { |payload, _headers|
+        event = get_event_from_payload(payload)
+        expect(event["user"]["id"]).to eq("test_user")
+        expect(event["user"]["abc"]).to eq("xyz")
+      })
+    end
+
+    it "set_user will set the three supported fields" do
+      Bugsnag.notify(BugsnagTestException.new("It crashed")) do |report|
+        report.set_user("123", "abc.xyz@example.com", "abc xyz")
+      end
+
+      expect(Bugsnag).to(have_sent_notification { |payload, _headers|
+        event = get_event_from_payload(payload)
+        expect(event["user"]["id"]).to eq("123")
+        expect(event["user"]["email"]).to eq("abc.xyz@example.com")
+        expect(event["user"]["name"]).to eq("abc xyz")
+      })
+    end
+
+    it "set_user will not set fields that are 'nil'" do
+      Bugsnag.notify(BugsnagTestException.new("It crashed")) do |report|
+        report.set_user("123", nil, "abc xyz")
+      end
+
+      expect(Bugsnag).to(have_sent_notification { |payload, _headers|
+        event = get_event_from_payload(payload)
+        expect(event["user"]["id"]).to eq("123")
+        expect(event["user"]).not_to have_key("email")
+        expect(event["user"]["name"]).to eq("abc xyz")
+      })
+    end
+
+    it "set_user will unset all fields if passed no parameters" do
+      Bugsnag.notify(BugsnagTestException.new("It crashed")) do |report|
+        report.user = { id: "nope", email: "nah@example.com", name: "yes", other: "stuff" }
+
+        report.set_user
+      end
+
+      expect(Bugsnag).to(have_sent_notification { |payload, _headers|
+        event = get_event_from_payload(payload)
+        expect(event["user"]).to be_empty
+      })
+    end
+
+    it "set_user can be passed only an ID" do
+      Bugsnag.notify(BugsnagTestException.new("It crashed")) do |report|
+        report.set_user("123")
+      end
+
+      expect(Bugsnag).to(have_sent_notification { |payload, _headers|
+        event = get_event_from_payload(payload)
+        expect(event["user"]["id"]).to eq("123")
+        expect(event["user"]).not_to have_key("email")
+        expect(event["user"]).not_to have_key("name")
+      })
+    end
+
+    it "set_user can be passed only an ID and email" do
+      Bugsnag.notify(BugsnagTestException.new("It crashed")) do |report|
+        report.set_user("123", "123@example.com")
+      end
+
+      expect(Bugsnag).to(have_sent_notification { |payload, _headers|
+        event = get_event_from_payload(payload)
+        expect(event["user"]["id"]).to eq("123")
+        expect(event["user"]["email"]).to eq("123@example.com")
+        expect(event["user"]).not_to have_key("name")
+      })
+    end
   end
 end
 # rubocop:enable Metrics/BlockLength


### PR DESCRIPTION
## Goal

Adds a `set_user` method, with the same API as other notifiers e.g. [`@bugsnag/js`](https://docs.bugsnag.com/platforms/javascript/customizing-error-reports/#setuser):

```ruby
report.set_user("123", "abc.xyz@example.com", "abc xyz")
# { id: "123", email: "abc.xyz@example.com", name: "abc xyz" }

# passing 'nil' removes that field
report.set_user("123", nil, "abc xyz")
# { id: "123", name: "abc xyz" }

# passing nothing removes all user data
report.set_user
# {}
```