### PR TITLE
Allow overriding an event's unhandled flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## TBD
+
+### Enhancements
+
+* Allow overriding an event's unhandled flag
+  | [#698](https://github.com/bugsnag/bugsnag-ruby/pull/698)
+
 ## v6.23.0 (21 September 2021)
 
 ### Enhancements

--- a/lib/bugsnag.rb
+++ b/lib/bugsnag.rb
@@ -136,6 +136,11 @@ module Bugsnag
           report.severity_reason = initial_reason
         end
 
+        if report.unhandled_overridden?
+          # let the dashboard know that the unhandled flag was overridden
+          report.severity_reason[:unhandledOverridden] = true
+        end
+
         deliver_notification(report)
       end
     end

--- a/lib/bugsnag/middleware/session_data.rb
+++ b/lib/bugsnag/middleware/session_data.rb
@@ -8,12 +8,14 @@ module Bugsnag::Middleware
 
     def call(report)
       session = Bugsnag::SessionTracker.get_current_session
-      unless session.nil?
+
+      if session
         if report.unhandled
           session[:events][:unhandled] += 1
         else
           session[:events][:handled] += 1
         end
+
         report.session = session
       end
 

--- a/spec/session_tracker_spec.rb
+++ b/spec/session_tracker_spec.rb
@@ -151,26 +151,4 @@ describe Bugsnag::SessionTracker do
     expect(device["hostname"]).to eq(Bugsnag.configuration.hostname)
     expect(device["runtimeVersions"]["ruby"]).to eq(Bugsnag.configuration.runtime_versions["ruby"])
   end
-
-  it 'uses middleware to attach session to notification' do
-    Bugsnag.configure do |conf|
-      conf.auto_capture_sessions = true
-      conf.release_stage = "test_stage"
-    end
-    Bugsnag.start_session
-    Bugsnag.notify(BugsnagTestException.new("It crashed"))
-    expect(Bugsnag).to have_sent_notification{ |payload, headers|
-      event = payload["events"][0]
-      expect(event.include?("session")).to be true
-      session = event["session"]
-      expect(session.include?("id")).to be true
-      expect(session.include?("startedAt")).to be true
-      expect(session.include?("events")).to be true
-      sesevents = session['events']
-      expect(sesevents.include?("unhandled")).to be true
-      expect(sesevents["unhandled"]).to eq(0)
-      expect(sesevents.include?("handled")).to be true
-      expect(sesevents["handled"]).to eq(1)
-    }
-  end
 end


### PR DESCRIPTION
## Goal

This PR allows overriding an event's unhandled flag, for example to mark a handled error as unhandled within a `notify` block:

```ruby
Bugsnag.notify(some_error) do |event|
  event.unhandled = true
end
```

The inverse also works — unhandled events can be marked as handled:

```ruby
Bugsnag.add_on_error(proc do |event|
  event.unhandled = false

  # it may also make sense to modify the severity as well
  event.severity = "warning"
end)
```

This will also update the associated session (if there is one) to ensure the count of handled/unhandled events remains consistent. This happens when the unhandled flag is written to, e.g.

```ruby
Bugsnag.notify(BugsnagTestException.new("It crashed")) do |event|
  expect(event.session[:events]).to eq({ handled: 1, unhandled: 0 })

  report.unhandled = true

  expect(event.session[:events]).to eq({ handled: 0, unhandled: 1 })
end
```