### PR TITLE
Add the ability to store metadata globally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Changelog
 
 * Allow overriding an event's unhandled flag
   | [#698](https://github.com/bugsnag/bugsnag-ruby/pull/698)
+* Add the ability to store metadata globally
+  | [#699](https://github.com/bugsnag/bugsnag-ruby/pull/699)
 
 ## v6.23.0 (21 September 2021)
 

--- a/lib/bugsnag.rb
+++ b/lib/bugsnag.rb
@@ -34,6 +34,7 @@ require "bugsnag/breadcrumbs/validator"
 require "bugsnag/breadcrumbs/breadcrumb"
 require "bugsnag/breadcrumbs/breadcrumbs"
 
+require "bugsnag/utility/duplicator"
 require "bugsnag/utility/metadata_delegate"
 
 # rubocop:todo Metrics/ModuleLength
@@ -355,6 +356,51 @@ module Bugsnag
       @cleaner || LOCK.synchronize do
         @cleaner ||= Bugsnag::Cleaner.new(configuration)
       end
+    end
+
+    ##
+    # Global metadata added to every event
+    #
+    # @return [Hash]
+    def metadata
+      configuration.metadata
+    end
+
+    ##
+    # Add values to metadata
+    #
+    # @overload add_metadata(section, data)
+    #   Merges data into the given section of metadata
+    #   @param section [String, Symbol]
+    #   @param data [Hash]
+    #
+    # @overload add_metadata(section, key, value)
+    #   Sets key to value in the given section of metadata. If the value is nil
+    #   the key will be deleted
+    #   @param section [String, Symbol]
+    #   @param key [String, Symbol]
+    #   @param value
+    #
+    # @return [void]
+    def add_metadata(section, key_or_data, *args)
+      configuration.add_metadata(section, key_or_data, *args)
+    end
+
+    ##
+    # Clear values from metadata
+    #
+    # @overload clear_metadata(section)
+    #   Clears the given section of metadata
+    #   @param section [String, Symbol]
+    #
+    # @overload clear_metadata(section, key)
+    #   Clears the key in the given section of metadata
+    #   @param section [String, Symbol]
+    #   @param key [String, Symbol]
+    #
+    # @return [void]
+    def clear_metadata(section, *args)
+      configuration.clear_metadata(section, *args)
     end
 
     private

--- a/lib/bugsnag/report.rb
+++ b/lib/bugsnag/report.rb
@@ -136,7 +136,7 @@ module Bugsnag
       self.delivery_method = configuration.delivery_method
       self.hostname = configuration.hostname
       self.runtime_versions = configuration.runtime_versions.dup
-      self.meta_data = {}
+      self.meta_data = Utility::Duplicator.duplicate(configuration.metadata)
       self.release_stage = configuration.release_stage
       self.severity = auto_notify ? "error" : "warning"
       self.severity_reason = auto_notify ? {:type => UNHANDLED_EXCEPTION} : {:type => HANDLED_EXCEPTION}

--- a/lib/bugsnag/utility/duplicator.rb
+++ b/lib/bugsnag/utility/duplicator.rb
@@ -1,0 +1,124 @@
+module Bugsnag::Utility
+  # @api private
+  class Duplicator
+    class << self
+      ##
+      # Duplicate (deep clone) the given object
+      #
+      # @param object [Object]
+      # @param seen_objects [Hash<String, Object>]
+      # @return [Object]
+      def duplicate(object, seen_objects = {})
+        case object
+        # return immutable & non-duplicatable objects as-is
+        when Symbol, Numeric, Method, TrueClass, FalseClass, NilClass
+          object
+        when Array
+          duplicate_array(object, seen_objects)
+        when Hash
+          duplicate_hash(object, seen_objects)
+        when Range
+          duplicate_range(object, seen_objects)
+        when Struct
+          duplicate_struct(object, seen_objects)
+        else
+          duplicate_generic_object(object, seen_objects)
+        end
+      rescue StandardError
+        object
+      end
+
+      private
+
+      def duplicate_array(array, seen_objects)
+        id = array.object_id
+
+        return seen_objects[id] if seen_objects.key?(id)
+
+        copy = array.dup
+        seen_objects[id] = copy
+
+        copy.map! do |value|
+          duplicate(value, seen_objects)
+        end
+
+        copy
+      end
+
+      def duplicate_hash(hash, seen_objects)
+        id = hash.object_id
+
+        return seen_objects[id] if seen_objects.key?(id)
+
+        copy = {}
+        seen_objects[id] = copy
+
+        hash.each do |key, value|
+          copy[duplicate(key, seen_objects)] = duplicate(value, seen_objects)
+        end
+
+        copy
+      end
+
+      ##
+      # Ranges are immutable but the values they contain may not be
+      #
+      # For example, a range of "a".."z" can be mutated: range.first.upcase!
+      def duplicate_range(range, seen_objects)
+        id = range.object_id
+
+        return seen_objects[id] if seen_objects.key?(id)
+
+        begin
+          copy = range.class.new(
+            duplicate(range.first, seen_objects),
+            duplicate(range.last, seen_objects),
+            range.exclude_end?
+          )
+        rescue StandardError
+          copy = range.dup
+        end
+
+        seen_objects[id] = copy
+      end
+
+      def duplicate_struct(struct, seen_objects)
+        id = struct.object_id
+
+        return seen_objects[id] if seen_objects.key?(id)
+
+        copy = struct.dup
+        seen_objects[id] = copy
+
+        struct.each_pair do |attribute, value|
+          begin
+            copy.send("#{attribute}=", duplicate(value, seen_objects))
+          rescue StandardError # rubocop:todo Lint/SuppressedException
+          end
+        end
+
+        copy
+      end
+
+      def duplicate_generic_object(object, seen_objects)
+        id = object.object_id
+
+        return seen_objects[id] if seen_objects.key?(id)
+
+        copy = object.dup
+        seen_objects[id] = copy
+
+        begin
+          copy.instance_variables.each do |variable|
+            value = copy.instance_variable_get(variable)
+
+            copy.instance_variable_set(variable, duplicate(value, seen_objects))
+          end
+        rescue StandardError # rubocop:todo Lint/SuppressedException
+        end
+
+        copy
+      end
+    end
+  end
+end

--- a/spec/report_spec.rb
+++ b/spec/report_spec.rb
@@ -1817,14 +1817,7 @@ describe Bugsnag::Report do
       # - Report.generate_exceptions_list
       # - Report.generate_exceptions_list | raw_exceptions.map
       # - Report.generate_exceptions_list | raw_exceptions.map | block
-      # However, JRUBY does not include the `Report.new` frame, resulting in 5 bugsnag frames
-      if defined?(JRUBY_VERSION)
-        frame_count = 5
-      else
-        frame_count = 6
-      end
-
-      expect(bugsnag_count).to equal frame_count
+      expect(bugsnag_count).to eq(6)
     }
   end
 

--- a/spec/utility/duplicator_spec.rb
+++ b/spec/utility/duplicator_spec.rb
@@ -1,0 +1,299 @@
+require 'spec_helper'
+require 'bugsnag/utility/duplicator'
+
+# NOTE: RSpec will freeze when trying to print the diff of recursive objects
+#       to avoid this, we use a custom "have_the_same_id_as" matcher and must
+#       not use the built-in "to eq", "to be" etc...
+RSpec.describe Bugsnag::Utility::Duplicator do
+  subject(:duplicator) { Bugsnag::Utility::Duplicator }
+
+  describe "simple values" do
+    it "does not copy symbols" do
+      symbol = :abc
+      expect(duplicator.duplicate(symbol)).to have_the_same_id_as(symbol)
+    end
+
+    it "does not copy integers" do
+      integer = 123
+      expect(duplicator.duplicate(integer)).to have_the_same_id_as(integer)
+    end
+
+    it "does not copy floats" do
+      float = 2.3
+      expect(duplicator.duplicate(float)).to have_the_same_id_as(float)
+    end
+
+    it "does not copy rationals" do
+      rational = 45.67.to_r
+      expect(duplicator.duplicate(rational)).to have_the_same_id_as(rational)
+    end
+
+    it "does not copy methods" do
+      subject_method = method(:subject)
+      expect(duplicator.duplicate(subject_method)).to have_the_same_id_as(subject_method)
+    end
+
+    it "does not copy true" do
+      true_value = true
+      expect(duplicator.duplicate(true_value)).to have_the_same_id_as(true_value)
+    end
+
+    it "does not copy false" do
+      false_value = false
+      expect(duplicator.duplicate(false_value)).to have_the_same_id_as(false_value)
+    end
+
+    it "does not copy nil" do
+      nil_value = nil
+      expect(duplicator.duplicate(nil_value)).to have_the_same_id_as(nil_value)
+    end
+
+    it "does not copy BasicObjects" do
+      object = BasicObject.new
+      expect(duplicator.duplicate(object)).to have_the_same_id_as(object)
+    end
+
+    it "copys strings" do
+      string = "hello"
+      copy = duplicator.duplicate(string)
+
+      expect(copy).not_to have_the_same_id_as(string)
+
+      copy.upcase!
+
+      expect(string).to eq("hello")
+      expect(copy).to eq("HELLO")
+    end
+
+    it "copys Objects" do
+      object = Object.new
+      object.instance_variable_set(:@abc, "hello")
+
+      copy = duplicator.duplicate(object)
+
+      expect(copy).to_not have_the_same_id_as(object)
+      expect(copy.instance_variable_get(:@abc)).not_to have_the_same_id_as(object.instance_variable_get(:@abc))
+
+      copy.instance_variable_set(:@xyz, 123)
+
+      expect(copy.instance_variable_get(:@xyz)).to be(123)
+      expect(object.instance_variable_defined?(:@xyz)).to be(false)
+      expect(object.instance_variable_get(:@xyz)).to be(nil)
+    end
+
+    it "copys Structs" do
+      struct_for_testing = Struct.new(:name, :sound)
+
+      object = struct_for_testing.new("Rover", "bark")
+      copy = duplicator.duplicate(object)
+
+      expect(copy).not_to have_the_same_id_as(object)
+
+      copy.name.downcase!
+      copy.sound.upcase!
+
+      expect(copy.name).to eq("rover")
+      expect(copy.sound).to eq("BARK")
+
+      expect(object.name).to eq("Rover")
+      expect(object.sound).to eq("bark")
+    end
+
+    it "copys frozen Structs" do
+      struct_for_testing = Struct.new(:name, :sound)
+
+      object = struct_for_testing.new("Rover", "bark").freeze
+      copy = duplicator.duplicate(object)
+
+      expect(copy).not_to have_the_same_id_as(object)
+
+      copy.name.downcase!
+      copy.sound.upcase!
+
+      expect(copy.name).to eq("rover")
+      expect(copy.sound).to eq("BARK")
+
+      expect(object.name).to eq("Rover")
+      expect(object.sound).to eq("bark")
+    end
+
+    it "copys Ranges" do
+      range = "a".."z"
+      copy = duplicator.duplicate(range)
+
+      expect(copy).not_to have_the_same_id_as(range)
+
+      copy.first.upcase!
+
+      expect(copy.first).to eq("A")
+      expect(range.first).to eq("a")
+
+      # the size is 58 because it includes punctuation between "Z" and "a" (ASCII 91-96)
+      expect(copy.to_a.size).to eq(58)
+      expect(range.to_a.size).to eq(26)
+    end
+
+    it "copys a custom class" do
+      class ExampleClassForTesting
+        attr_accessor :one, :two, :three
+
+        def initialize(one, two, three)
+          @one = one
+          @two = two
+          @three = three
+        end
+      end
+
+      original = ExampleClassForTesting.new(["a", "b", ["c", "d"]], { abc: "xyz" }, 3)
+
+      copy = duplicator.duplicate(original)
+
+      expect(copy).not_to have_the_same_id_as(original)
+
+      copy.one[1].upcase!
+      copy.one[2].push("e", "f")
+      copy.two[:abc].upcase!
+
+      expect(copy.one[1]).to eq("B")
+      expect(original.one[1]).to eq("b")
+
+      expect(copy.one[2].length).to eq(4)
+      expect(original.one[2].length).to eq(2)
+
+      expect(copy.two[:abc]).to eq("XYZ")
+      expect(original.two[:abc]).to eq("xyz")
+
+      copy.three = 6
+
+      expect(copy.three).to eq(6)
+      expect(original.three).to eq(3)
+    end
+  end
+
+  describe "arrays" do
+    it "copys arrays and any duplicatable values within them" do
+      array = [1, "a", nil, Object.new]
+
+      copy = duplicator.duplicate(array)
+
+      expect(copy).not_to have_the_same_id_as(array)
+
+      expect(copy[0]).to have_the_same_id_as(array[0])
+      expect(copy[1]).not_to have_the_same_id_as(array[1])
+      expect(copy[2]).to have_the_same_id_as(array[2])
+      expect(copy[3]).not_to have_the_same_id_as(array[3])
+    end
+
+    it "copys nested arrays" do
+      sub_array = [2, "b"]
+      array = [1, "a", sub_array]
+
+      copy = duplicator.duplicate(array)
+      sub_array_copy = copy.last
+
+      expect(copy).not_to have_the_same_id_as(array)
+      expect(sub_array_copy).not_to have_the_same_id_as(sub_array)
+
+      copy[1].upcase!
+      sub_array_copy[1].upcase!
+
+      expect(copy[0]).to eq(1)
+      expect(array[0]).to eq(1)
+      expect(copy[1]).to eq("A")
+      expect(array[1]).to eq("a")
+
+      expect(sub_array_copy[0]).to eq(2)
+      expect(sub_array[0]).to eq(2)
+      expect(sub_array_copy[1]).to eq("B")
+      expect(sub_array[1]).to eq("b")
+    end
+
+    it "handles recursive arrays" do
+      array = [1, "a", nil, Object.new]
+      array.push(array)
+
+      copy = duplicator.duplicate(array)
+
+      expect(copy).not_to have_the_same_id_as(array)
+
+      # the recursive array should resolve to itself, not a separate copy
+      expect(copy.last).to have_the_same_id_as(copy)
+      expect(copy.last.last).to have_the_same_id_as(copy)
+    end
+  end
+
+  describe "hashes" do
+    it "copys hashes and any duplicatable values within them" do
+      hash = { a: 123, b: "yes", c: Object.new }
+
+      copy = duplicator.duplicate(hash)
+
+      expect(copy).not_to have_the_same_id_as(hash)
+
+      expect(copy[:a]).to have_the_same_id_as(hash[:a])
+      expect(copy[:b]).not_to have_the_same_id_as(hash[:b])
+      expect(copy[:c]).not_to have_the_same_id_as(hash[:c])
+
+      copy[:b].upcase!
+      copy[:c].instance_variable_set(:@hello, "world")
+
+      expect(copy[:b]).to eq("YES")
+      expect(hash[:b]).to eq("yes")
+
+      expect(copy[:c].instance_variable_get(:@hello)).to eq("world")
+      expect(hash[:c].instance_variable_get(:@hello)).to eq(nil)
+    end
+
+    it "copys nested hashes" do
+      hash = { a: { b: { c: "hello" } } }
+
+      copy = duplicator.duplicate(hash)
+
+      expect(copy).not_to have_the_same_id_as(hash)
+
+      expect(copy[:a]).not_to have_the_same_id_as(hash[:a])
+      expect(copy[:a][:b]).not_to have_the_same_id_as(hash[:a][:b])
+      expect(copy[:a][:b][:c]).not_to have_the_same_id_as(hash[:a][:b][:c])
+
+      copy[:a][:b][:c].upcase!
+
+      expect(copy[:a][:b][:c]).to eq("HELLO")
+      expect(hash[:a][:b][:c]).to eq("hello")
+    end
+
+    it "copys frozen hashes" do
+      hash = { a: 123, b: "yes", c: Object.new }.freeze
+
+      copy = duplicator.duplicate(hash)
+
+      expect(copy).not_to have_the_same_id_as(hash)
+
+      expect(copy[:a]).to have_the_same_id_as(hash[:a])
+      expect(copy[:b]).not_to have_the_same_id_as(hash[:b])
+      expect(copy[:c]).not_to have_the_same_id_as(hash[:c])
+
+      copy[:b].upcase!
+      copy[:c].instance_variable_set(:@hello, "world")
+
+      expect(copy[:b]).to eq("YES")
+      expect(hash[:b]).to eq("yes")
+
+      expect(copy[:c].instance_variable_get(:@hello)).to eq("world")
+      expect(hash[:c].instance_variable_get(:@hello)).to eq(nil)
+    end
+
+    it "handles recursive hashes" do
+      hash = { abc: 123 }
+      hash[:me] = hash
+
+      copy = duplicator.duplicate(hash)
+
+      expect(copy).not_to have_the_same_id_as(hash)
+      expect(copy[:me]).not_to have_the_same_id_as(hash[:me])
+      expect(copy[:me][:me]).not_to have_the_same_id_as(hash[:me][:me])
+
+      expect(copy[:abc]).to eq(123)
+      expect(copy[:me][:me][:abc]).to eq(123)
+    end
+  end
+end


### PR DESCRIPTION
## Goal

This PR adds the ability to store metadata globally, which will then be attached to any future events. The API matches the new event metadata API added in https://github.com/bugsnag/bugsnag-ruby/pull/694, for example:

```ruby
Bugsnag.configure do |config|
  config.add_metadata(:abc, { x: 1, y: 2, z: 3 })
  config.add_metadata(:abc, :a, 9)

  config.clear_metadata(:abc, :x)

  # metadata is: { abc: { y: 2, z: 3, a: 9 } }
end
```

Metadata can also be added/cleared outside of a `configure` block with `Bugsnag.add_metadata` and `Bugsnag.clear_metadata`

Global metadata is deeply cloned when attached to an event, which means mutating the event's metadata won't affect the global metadata:

```ruby
Bugsnag.add_metadata(:abc, { x: 1, y: 2, z: 3 })

Bugsnag.notify(RuntimeError.new("example")) do |event|
  event.add_metadata(:abc, :x, "changed")
  event.clear_metadata(:abc, :z)

  # event metadata is: { x: "changed", y: 2 }
  # global metadata is: { x: 1, y: 2, z: 3 }
end
```

## Design

The deep cloning is handled by a new `Bugsnag::Utility::Duplicator` class. The existing Gems I found were either unmaintained, monkey patched core objects or didn't support all of our supported Ruby versions

While this should be pretty thorough, it's possible for some values not to be duplicated. I think this is unlikely to be a problem given that types of values that will realistically be used in metadata, since it has to serialise to JSON in the end

The alternative to adding this class is using the `Marshal.load(Marshal.dump(object))` trick, but this has a few drawbacks:
- it doesn't work for every object and will fail entirely if given an unsupported value
- there's a potential security risk to loading untrusted data, e.g. if user input is provided as metadata