### PR TITLE
Add `cookies`, `body` and `httpVersion` to the automatically captured request data for Rack apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Changelog
   | [#698](https://github.com/bugsnag/bugsnag-ruby/pull/698)
 * Add the ability to store metadata globally
   | [#699](https://github.com/bugsnag/bugsnag-ruby/pull/699)
+* Add `cookies`, `body` and `httpVersion` to the automatically captured request data for Rack apps
+  | [#700](https://github.com/bugsnag/bugsnag-ruby/pull/700)
 
 ## v6.23.0 (21 September 2021)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Changelog
 * Add `cookies`, `body` and `httpVersion` to the automatically captured request data for Rack apps
   | [#700](https://github.com/bugsnag/bugsnag-ruby/pull/700)
 
+### Deprecated
+
+* In the next major release, `params` will only contain query string parameters. Currently it also contains the request body for form data requests, but this is deprecated in favour of the new `body` property
+
 ## v6.23.0 (21 September 2021)
 
 ### Enhancements

--- a/features/fixtures/docker-compose.yml
+++ b/features/fixtures/docker-compose.yml
@@ -85,6 +85,7 @@ services:
     environment:
       - BUGSNAG_API_KEY
       - BUGSNAG_ENDPOINT
+      - BUGSNAG_METADATA_FILTERS
     restart: "no"
 
   rack2:
@@ -95,6 +96,7 @@ services:
     environment:
       - BUGSNAG_API_KEY
       - BUGSNAG_ENDPOINT
+      - BUGSNAG_METADATA_FILTERS
     restart: "no"
 
   rails3:

--- a/features/fixtures/rack1/app/app.rb
+++ b/features/fixtures/rack1/app/app.rb
@@ -1,11 +1,14 @@
 require 'bugsnag'
 require 'rack'
+require 'json'
 
 Bugsnag.configure do |config|
-  puts "Configuring `api_key` to #{ENV['BUGSNAG_API_KEY']}"
   config.api_key = ENV['BUGSNAG_API_KEY']
-  puts "Configuring `endpoint` to #{ENV['BUGSNAG_ENDPOINT']}"
   config.endpoint = ENV['BUGSNAG_ENDPOINT']
+
+  if ENV.key?('BUGSNAG_METADATA_FILTERS')
+    config.meta_data_filters = JSON.parse(ENV['BUGSNAG_METADATA_FILTERS'])
+  end
 end
 
 class BugsnagTests

--- a/features/fixtures/rack2/app/app.rb
+++ b/features/fixtures/rack2/app/app.rb
@@ -1,11 +1,14 @@
 require 'bugsnag'
 require 'rack'
+require 'json'
 
 Bugsnag.configure do |config|
-  puts "Configuring `api_key` to #{ENV['BUGSNAG_API_KEY']}"
   config.api_key = ENV['BUGSNAG_API_KEY']
-  puts "Configuring `endpoint` to #{ENV['BUGSNAG_ENDPOINT']}"
   config.endpoint = ENV['BUGSNAG_ENDPOINT']
+
+  if ENV.key?('BUGSNAG_METADATA_FILTERS')
+    config.meta_data_filters = JSON.parse(ENV['BUGSNAG_METADATA_FILTERS'])
+  end
 end
 
 class BugsnagTests

--- a/features/rack.feature
+++ b/features/rack.feature
@@ -2,7 +2,7 @@ Feature: Bugsnag raises errors in Rack
 
 Scenario: An unhandled RuntimeError sends a report
   Given I start the rack service
-  When I navigate to the route "/unhandled" on the rack app
+  When I navigate to the route "/unhandled?a=123&b=456" on the rack app
   And I wait to receive a request
   Then the request is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier"
   And the event "unhandled" is true
@@ -11,10 +11,22 @@ Scenario: An unhandled RuntimeError sends a report
   And the event "severityReason.attributes.framework" equals "Rack"
   And the event "app.type" equals "rack"
   And the exception "errorClass" equals "RuntimeError"
+  And the event "metaData.request.body" is null
+  And the event "metaData.request.clientIp" is not null
+  And the event "metaData.request.cookies" is null
+  And the event "metaData.request.headers.Host" is not null
+  And the event "metaData.request.headers.User-Agent" is not null
+  And the event "metaData.request.headers.Version" is not null
+  And the event "metaData.request.httpMethod" equals "GET"
+  And the event "metaData.request.httpVersion" matches "^HTTP/\d\.\d$"
+  And the event "metaData.request.params.a" equals "123"
+  And the event "metaData.request.params.b" equals "456"
+  And the event "metaData.request.referer" is null
+  And the event "metaData.request.url" ends with "/unhandled?a=123&b=456"
 
 Scenario: A handled RuntimeError sends a report
   Given I start the rack service
-  When I navigate to the route "/handled" on the rack app
+  When I navigate to the route "/handled?a=123&b=456" on the rack app
   And I wait to receive a request
   Then the request is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier"
   And the event "unhandled" is false
@@ -22,3 +34,61 @@ Scenario: A handled RuntimeError sends a report
   And the event "severityReason.type" equals "handledException"
   And the event "app.type" equals "rack"
   And the exception "errorClass" equals "RuntimeError"
+  And the event "metaData.request.body" is null
+  And the event "metaData.request.clientIp" is not null
+  And the event "metaData.request.cookies" is null
+  And the event "metaData.request.headers.Host" is not null
+  And the event "metaData.request.headers.User-Agent" is not null
+  And the event "metaData.request.headers.Version" is not null
+  And the event "metaData.request.httpMethod" equals "GET"
+  And the event "metaData.request.httpVersion" matches "^HTTP/\d\.\d$"
+  And the event "metaData.request.params.a" equals "123"
+  And the event "metaData.request.params.b" equals "456"
+  And the event "metaData.request.referer" is null
+  And the event "metaData.request.url" ends with "/handled?a=123&b=456"
+
+Scenario: A POST request with form data sends a report with the parsed request body attached
+  Given I start the rack service
+  When I send a POST request to "/unhandled?a=123&b=456" in the rack app with the following form data:
+    | name             | baba      |
+    | favourite_letter | z         |
+    | password         | password1 |
+  And I wait to receive a request
+  Then the request is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier"
+  And the event "metaData.request.body.name" equals "baba"
+  And the event "metaData.request.body.favourite_letter" equals "z"
+  And the event "metaData.request.body.password" equals "[FILTERED]"
+  And the event "metaData.request.clientIp" is not null
+  And the event "metaData.request.cookies" is null
+  And the event "metaData.request.headers.Host" is not null
+  And the event "metaData.request.headers.User-Agent" is not null
+  And the event "metaData.request.headers.Version" is not null
+  And the event "metaData.request.httpMethod" equals "POST"
+  And the event "metaData.request.httpVersion" matches "^HTTP/\d\.\d$"
+  And the event "metaData.request.params.a" equals "123"
+  And the event "metaData.request.params.b" equals "456"
+  And the event "metaData.request.referer" is null
+  And the event "metaData.request.url" ends with "/unhandled?a=123&b=456"
+
+Scenario: A POST request with JSON sends a report with the parsed request body attached
+  Given I start the rack service
+  When I send a POST request to "/unhandled?a=123&b=456" in the rack app with the following JSON:
+    | name             | baba      |
+    | favourite_letter | z         |
+    | password         | password1 |
+  And I wait to receive a request
+  Then the request is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier"
+  And the event "metaData.request.body.name" equals "baba"
+  And the event "metaData.request.body.favourite_letter" equals "z"
+  And the event "metaData.request.body.password" equals "[FILTERED]"
+  And the event "metaData.request.clientIp" is not null
+  And the event "metaData.request.cookies" is null
+  And the event "metaData.request.headers.Host" is not null
+  And the event "metaData.request.headers.User-Agent" is not null
+  And the event "metaData.request.headers.Version" is not null
+  And the event "metaData.request.httpMethod" equals "POST"
+  And the event "metaData.request.httpVersion" matches "^HTTP/\d\.\d$"
+  And the event "metaData.request.params.a" equals "123"
+  And the event "metaData.request.params.b" equals "456"
+  And the event "metaData.request.referer" is null
+  And the event "metaData.request.url" ends with "/unhandled?a=123&b=456"

--- a/features/steps/ruby_notifier_steps.rb
+++ b/features/steps/ruby_notifier_steps.rb
@@ -94,6 +94,20 @@ When("I navigate to the route {string} on the rack app") do |route|
   }
 end
 
+When("I navigate to the route {string} on the rack app with these cookies:") do |route, data|
+  rack_version = ENV["RACK_VERSION"]
+  uri = URI("http://rack#{rack_version}:3000#{route}")
+
+  # e.g. { "a" => "b", "c" => "d" } -> "a=b;c=d"
+  cookie = data.rows_hash.map { |key, value| "#{key}=#{value}" }.join(";")
+
+  http = Net::HTTP.new(uri.host, uri.port)
+  request = Net::HTTP::Get.new(uri.request_uri)
+  request["Cookie"] = cookie
+
+  http.request(request)
+end
+
 When("I send a POST request to {string} in the rack app with the following form data:") do |route, data|
   rack_version = ENV["RACK_VERSION"]
   uri = URI("http://rack#{rack_version}:3000#{route}")

--- a/lib/bugsnag/middleware/rack_request.rb
+++ b/lib/bugsnag/middleware/rack_request.rb
@@ -1,8 +1,11 @@
+require "json"
+
 module Bugsnag::Middleware
   ##
   # Extracts and attaches rack data to an error report
   class RackRequest
     SPOOF = "[SPOOF]".freeze
+    COOKIE_HEADER = "Cookie".freeze
 
     def initialize(bugsnag)
       @bugsnag = bugsnag
@@ -42,22 +45,6 @@ module Bugsnag::Middleware
           Bugsnag.configuration.warn "RackRequest - Rescued error while cleaning request.referer: #{stde}"
         end
 
-        headers = {}
-
-        env.each_pair do |key, value|
-          if key.to_s.start_with?("HTTP_")
-            header_key = key[5..-1]
-          elsif ["CONTENT_TYPE", "CONTENT_LENGTH"].include?(key)
-            header_key = key
-          else
-            next
-          end
-
-          headers[header_key.split("_").map {|s| s.capitalize}.join("-")] = value
-        end
-
-        headers["Referer"] = referer if headers["Referer"]
-
         # Add a request tab
         report.add_tab(:request, {
           :url => url,
@@ -65,8 +52,16 @@ module Bugsnag::Middleware
           :params => params.to_hash,
           :referer => referer,
           :clientIp => client_ip,
-          :headers => headers
+          :headers => format_headers(env, referer)
         })
+
+        # add the HTTP version if present
+        if env["SERVER_PROTOCOL"]
+          report.add_metadata(:request, :httpVersion, env["SERVER_PROTOCOL"])
+        end
+
+        add_request_body(report, request, env)
+        add_cookies(report, request)
 
         # Add an environment tab
         if report.configuration.send_environment
@@ -86,6 +81,83 @@ module Bugsnag::Middleware
       end
 
       @bugsnag.call(report)
+    end
+
+    private
+
+    def format_headers(env, referer)
+      headers = {}
+
+      env.each_pair do |key, value|
+        if key.to_s.start_with?("HTTP_")
+          header_key = key[5..-1]
+        elsif ["CONTENT_TYPE", "CONTENT_LENGTH"].include?(key)
+          header_key = key
+        else
+          next
+        end
+
+        headers[header_key.split("_").map {|s| s.capitalize}.join("-")] = value
+      end
+
+      headers["Referer"] = referer if headers["Referer"]
+
+      headers
+    end
+
+    def add_request_body(report, request, env)
+      body = parsed_request_body(request, env)
+
+      # this request may not have a body
+      return unless body.is_a?(Hash) && !body.empty?
+
+      report.add_metadata(:request, :body, body)
+    end
+
+    def parsed_request_body(request, env)
+      return request.POST rescue nil if request.form_data?
+
+      content_type = env["CONTENT_TYPE"]
+
+      return nil if content_type.nil?
+
+      if content_type.include?('/json') || content_type.include?('+json')
+        begin
+          body = request.body
+
+          return JSON.parse(body.read)
+        rescue StandardError
+          return nil
+        ensure
+          # the body must be rewound so other things can read it after we do
+          body.rewind
+        end
+      end
+
+      nil
+    end
+
+    def add_cookies(report, request)
+      return unless record_cookies?(report.configuration)
+
+      cookies = request.cookies rescue nil
+
+      return unless cookies.is_a?(Hash) && !cookies.empty?
+
+      report.add_metadata(:request, :cookies, cookies)
+    end
+
+    def record_cookies?(configuration)
+      # only record cookies in the request if none of the filters match "Cookie"
+      # the "Cookie" header will be filtered as normal
+      configuration.meta_data_filters.none? do |filter|
+        case filter
+        when Regexp
+          COOKIE_HEADER.match(filter)
+        else
+          COOKIE_HEADER.include?(filter.to_s)
+        end
+      end
     end
   end
 end

--- a/spec/integrations/rack_spec.rb
+++ b/spec/integrations/rack_spec.rb
@@ -105,7 +105,7 @@ describe Bugsnag::Rack do
 
       rack_request = double
       allow(rack_request).to receive_messages(
-        params: { param: 'test' },
+        params: { param: 'test', param2: 'test2' },
         ip: "rack_ip",
         request_method: "TEST",
         path: "/TEST_PATH",
@@ -113,14 +113,17 @@ describe Bugsnag::Rack do
         host: "test_host",
         port: 80,
         referer: "https://bugsnag.com/about?email=hello@world.com&another_param=thing",
-        fullpath: "/TEST_PATH?email=hello@world.com&another_param=thing"
+        fullpath: "/TEST_PATH?email=hello@world.com&another_param=thing",
+        form_data?: true,
+        POST: { param: 'test' },
+        cookies: { session_id: 12345 }
       )
 
       expect(::Rack::Request).to receive(:new).with(rack_env).and_return(rack_request)
 
       Bugsnag.configure do |config|
         config.send_environment = true
-        config.meta_data_filters = ['email']
+        config.meta_data_filters << 'email'
         config.request_data[:rack_env] = rack_env
       end
 
@@ -135,12 +138,13 @@ describe Bugsnag::Rack do
       expect(report.request).to eq({
         url: "http://test_host/TEST_PATH?email=[FILTERED]&another_param=thing",
         httpMethod: "TEST",
-        params: { param: 'test' },
+        params: { param: 'test', param2: 'test2' },
         referer: "https://bugsnag.com/about?email=[FILTERED]&another_param=thing",
         clientIp: "rack_ip",
         headers: {
           "Referer" => "https://bugsnag.com/about?email=[FILTERED]&another_param=thing"
-        }
+        },
+        body: { param: 'test' }
       })
 
       expect(report.metadata[:request]).to be(report.request)
@@ -152,12 +156,13 @@ describe Bugsnag::Rack do
       rack_env = {
         env: true,
         HTTP_test_key: "test_key",
+        "SERVER_PROTOCOL" => "HTTP/1.0",
         "rack.session" => { session: true }
       }
 
       rack_request = double
       allow(rack_request).to receive_messages(
-        params: { param: 'test' },
+        params: { param: 'test', param2: 'test2' },
         ip: "rack_ip",
         request_method: "TEST",
         path: "/TEST_PATH",
@@ -165,7 +170,10 @@ describe Bugsnag::Rack do
         host: "test_host",
         port: 80,
         referer: "referer",
-        fullpath: "/TEST_PATH"
+        fullpath: "/TEST_PATH",
+        form_data?: true,
+        POST: { param: 'test' },
+        cookies: { session_id: 12345 }
       )
 
       expect(Rack::Request).to receive(:new).with(rack_env).and_return(rack_request)
@@ -187,10 +195,194 @@ describe Bugsnag::Rack do
       expect(report.request).to eq({
         url: "http://test_host/TEST_PATH",
         httpMethod: "TEST",
-        params: { param: 'test' },
+        httpVersion: "HTTP/1.0",
+        params: { param: 'test', param2: 'test2' },
+        referer: "referer",
+        clientIp: "rack_ip",
+        headers: { "Test-Key" => "test_key" },
+        body: { param: 'test' },
+        cookies: { session_id: 12345 }
+      })
+
+      expect(report.metadata[:request]).to be(report.request)
+      expect(report.metadata[:environment]).to eq(rack_env)
+      expect(report.metadata[:session]).to eq({ session: true })
+    end
+
+    it "doesn't extract the request body or cookies if they are empty" do
+      rack_env = {
+        env: true,
+        HTTP_test_key: "test_key",
+        "rack.session" => { session: true }
+      }
+
+      rack_request = double
+      allow(rack_request).to receive_messages(
+        params: { param: 'test', param2: 'test2' },
+        ip: "rack_ip",
+        request_method: "TEST",
+        path: "/TEST_PATH",
+        scheme: "http",
+        host: "test_host",
+        port: 80,
+        referer: "referer",
+        fullpath: "/TEST_PATH",
+        # no post data or cookies
+        form_data?: true,
+        POST: {},
+        cookies: {}
+      )
+
+      expect(Rack::Request).to receive(:new).with(rack_env).and_return(rack_request)
+
+      Bugsnag.configure do |config|
+        config.send_environment = true
+        config.meta_data_filters = []
+        config.request_data[:rack_env] = rack_env
+      end
+
+      report = Bugsnag::Report.new(RuntimeError.new('abc'), Bugsnag.configuration)
+
+      callback = double
+      expect(callback).to receive(:call).with(report)
+
+      middleware = Bugsnag::Middleware::RackRequest.new(callback)
+      middleware.call(report)
+
+      expect(report.request).to eq({
+        url: "http://test_host/TEST_PATH",
+        httpMethod: "TEST",
+        params: { param: 'test', param2: 'test2' },
         referer: "referer",
         clientIp: "rack_ip",
         headers: { "Test-Key" => "test_key" }
+      })
+
+      expect(report.metadata[:request]).to be(report.request)
+    end
+
+    it "parses JSON body if the content type is 'application/json'" do
+      rack_env = {
+        env: true,
+        HTTP_REFERER: "https://bugsnag.com/about?email=hello@world.com&another_param=thing",
+        "CONTENT_TYPE" => "application/json",
+        "rack.session" => { session: true }
+      }
+
+      request_body = StringIO.new('{ "param": "test", "another": "param" }')
+      expect(request_body.pos).to eq(0)
+
+      rack_request = double
+      allow(rack_request).to receive_messages(
+        params: { param: 'test', param2: 'test2' },
+        ip: "rack_ip",
+        request_method: "TEST",
+        path: "/TEST_PATH",
+        scheme: "http",
+        host: "test_host",
+        port: 80,
+        referer: "https://bugsnag.com/about?email=hello@world.com&another_param=thing",
+        fullpath: "/TEST_PATH?email=hello@world.com&another_param=thing",
+        form_data?: false,
+        POST: {},
+        cookies: { session_id: 12345 },
+        body: request_body
+      )
+
+      expect(::Rack::Request).to receive(:new).with(rack_env).and_return(rack_request)
+
+      Bugsnag.configure do |config|
+        config.send_environment = true
+        config.meta_data_filters << 'email'
+        config.request_data[:rack_env] = rack_env
+      end
+
+      report = Bugsnag::Report.new(RuntimeError.new('abc'), Bugsnag.configuration)
+
+      callback = double
+      expect(callback).to receive(:call).with(report)
+
+      middleware = Bugsnag::Middleware::RackRequest.new(callback)
+      middleware.call(report)
+
+      # ensure the request body was rewound
+      expect(request_body.pos).to eq(0)
+
+      expect(report.request).to eq({
+        url: "http://test_host/TEST_PATH?email=[FILTERED]&another_param=thing",
+        httpMethod: "TEST",
+        params: { param: 'test', param2: 'test2' },
+        referer: "https://bugsnag.com/about?email=[FILTERED]&another_param=thing",
+        clientIp: "rack_ip",
+        headers: {
+          "Content-Type" => "application/json",
+          "Referer" => "https://bugsnag.com/about?email=[FILTERED]&another_param=thing"
+        },
+        body: { "param" => "test", "another" => "param" }
+      })
+
+      expect(report.metadata[:request]).to be(report.request)
+      expect(report.metadata[:environment]).to eq(rack_env)
+      expect(report.metadata[:session]).to eq({ session: true })
+    end
+
+    it "doesn't crash when given an invalid JSON body" do
+      rack_env = {
+        env: true,
+        HTTP_REFERER: "https://bugsnag.com/about?email=hello@world.com&another_param=thing",
+        "CONTENT_TYPE" => "application/json",
+        "rack.session" => { session: true }
+      }
+
+      request_body = StringIO.new("{{{{{{{{{{{{{{")
+
+      rack_request = double
+      allow(rack_request).to receive_messages(
+        params: { param: 'test', param2: 'test2' },
+        ip: "rack_ip",
+        request_method: "TEST",
+        path: "/TEST_PATH",
+        scheme: "http",
+        host: "test_host",
+        port: 80,
+        referer: "https://bugsnag.com/about?email=hello@world.com&another_param=thing",
+        fullpath: "/TEST_PATH?email=hello@world.com&another_param=thing",
+        form_data?: false,
+        POST: {},
+        cookies: { session_id: 12345 },
+        body: request_body
+      )
+
+      expect(::Rack::Request).to receive(:new).with(rack_env).and_return(rack_request)
+
+      Bugsnag.configure do |config|
+        config.send_environment = true
+        config.meta_data_filters << 'email'
+        config.request_data[:rack_env] = rack_env
+      end
+
+      report = Bugsnag::Report.new(RuntimeError.new('abc'), Bugsnag.configuration)
+
+      callback = double
+      expect(callback).to receive(:call).with(report)
+
+      middleware = Bugsnag::Middleware::RackRequest.new(callback)
+      middleware.call(report)
+
+      # ensure the request body was rewound
+      expect(request_body.pos).to eq(0)
+
+      expect(report.request).to eq({
+        url: "http://test_host/TEST_PATH?email=[FILTERED]&another_param=thing",
+        httpMethod: "TEST",
+        params: { param: 'test', param2: 'test2' },
+        referer: "https://bugsnag.com/about?email=[FILTERED]&another_param=thing",
+        clientIp: "rack_ip",
+        headers: {
+          "Content-Type" => "application/json",
+          "Referer" => "https://bugsnag.com/about?email=[FILTERED]&another_param=thing"
+        }
+        # no request body as we couldn't parse it
       })
 
       expect(report.metadata[:request]).to be(report.request)


### PR DESCRIPTION
## Goal

- `cookies` — the `Cookie` header from the request, parsed into a hash
- `body` — the body of the request, parsed into a hash. Supports JSON and form data; other content types will not attach a body to the event
- `httpVersion` — the HTTP version of the request, e.g. `HTTP/1.1`

`cookies` will not be captured by default as the default `meta_data_filters` includes `/cookie/i`, however the request body and http version will be captured by default

If the `body` is form data, it is already present in `params`. In the next major release, `params` will only contain query string parameters