### PR TITLE
Bring endpoint configuration in line with other notifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,13 @@ Changelog
   | [#699](https://github.com/bugsnag/bugsnag-ruby/pull/699)
 * Add `cookies`, `body` and `httpVersion` to the automatically captured request data for Rack apps
   | [#700](https://github.com/bugsnag/bugsnag-ruby/pull/700)
+* Add `Configuration#endpoints` for reading the notify and sessions endpoints and `Configuration#endpoints=` for setting them
+  | [#701](https://github.com/bugsnag/bugsnag-ruby/pull/701)
 
 ### Deprecated
 
 * In the next major release, `params` will only contain query string parameters. Currently it also contains the request body for form data requests, but this is deprecated in favour of the new `body` property
+* The `Configuration#set_endpoints` method is now deprecated in favour of `Configuration#endpoints=`
 
 ## v6.23.0 (21 September 2021)
 

--- a/lib/bugsnag.rb
+++ b/lib/bugsnag.rb
@@ -406,6 +406,8 @@ module Bugsnag
     private
 
     def should_deliver_notification?(exception, auto_notify)
+      return false unless configuration.enable_events
+
       reason = abort_reason(exception, auto_notify)
       configuration.debug(reason) unless reason.nil?
       reason.nil?

--- a/lib/bugsnag/endpoint_configuration.rb
+++ b/lib/bugsnag/endpoint_configuration.rb
@@ -1,0 +1,11 @@
+module Bugsnag
+  class EndpointConfiguration
+    attr_reader :notify
+    attr_reader :sessions
+
+    def initialize(notify, sessions)
+      @notify = notify
+      @sessions = sessions
+    end
+  end
+end

--- a/lib/bugsnag/endpoint_validator.rb
+++ b/lib/bugsnag/endpoint_validator.rb
@@ -22,12 +22,12 @@ module Bugsnag
     class Result
       # rubocop:disable Layout/LineLength
       MISSING_URLS = "Invalid configuration. endpoints must be set with both a notify and session URL. Bugsnag will not send any requests.".freeze
-      MISSING_NOTIFY_URL = "Invalid configuration. endpoints.notify cannot be set without also setting endpoints.sessions. Sessions will not be sent to Bugsnag.".freeze
-      MISSING_SESSION_URL = "Invalid configuration. endpoints.sessions cannot be set without also setting endpoints.notify. Bugsnag will not send any requests.".freeze
+      MISSING_NOTIFY_URL = "Invalid configuration. endpoints.sessions cannot be set without also setting endpoints.notify. Bugsnag will not send any requests.".freeze
+      MISSING_SESSION_URL = "Invalid configuration. endpoints.notify cannot be set without also setting endpoints.sessions. Bugsnag will not send any sessions.".freeze
 
       INVALID_URLS = "Invalid configuration. endpoints should be valid URLs, got empty strings. Bugsnag will not send any requests.".freeze
-      INVALID_NOTIFY_URL = "Invalid configuration. endpoints.notify should be a valid URL, got empty string. Sessions will not be sent to Bugsnag.".freeze
-      INVALID_SESSION_URL = "Invalid configuration. endpoints.sessions should be a valid URL, got empty string. Bugsnag will not send any requests.".freeze
+      INVALID_NOTIFY_URL = "Invalid configuration. endpoints.notify should be a valid URL, got empty string. Bugsnag will not send any requests.".freeze
+      INVALID_SESSION_URL = "Invalid configuration. endpoints.sessions should be a valid URL, got empty string. Bugsnag will not send any sessions.".freeze
       # rubocop:enable Layout/LineLength
 
       attr_reader :reason

--- a/lib/bugsnag/endpoint_validator.rb
+++ b/lib/bugsnag/endpoint_validator.rb
@@ -1,0 +1,80 @@
+module Bugsnag
+  # @api private
+  class EndpointValidator
+    def self.validate(endpoints)
+      # ensure we have an EndpointConfiguration object
+      return Result.missing_urls unless endpoints.is_a?(EndpointConfiguration)
+
+      # check for missing URLs
+      return Result.missing_urls if endpoints.notify.nil? && endpoints.sessions.nil?
+      return Result.missing_notify if endpoints.notify.nil?
+      return Result.missing_session if endpoints.sessions.nil?
+
+      # check for empty URLs
+      return Result.invalid_urls if endpoints.notify.empty? && endpoints.sessions.empty?
+      return Result.invalid_notify if endpoints.notify.empty?
+      return Result.invalid_session if endpoints.sessions.empty?
+
+      Result.valid
+    end
+
+    # @api private
+    class Result
+      # rubocop:disable Layout/LineLength
+      MISSING_URLS = "Invalid configuration. endpoints must be set with both a notify and session URL. Bugsnag will not send any requests.".freeze
+      MISSING_NOTIFY_URL = "Invalid configuration. endpoints.notify cannot be set without also setting endpoints.sessions. Sessions will not be sent to Bugsnag.".freeze
+      MISSING_SESSION_URL = "Invalid configuration. endpoints.sessions cannot be set without also setting endpoints.notify. Bugsnag will not send any requests.".freeze
+
+      INVALID_URLS = "Invalid configuration. endpoints should be valid URLs, got empty strings. Bugsnag will not send any requests.".freeze
+      INVALID_NOTIFY_URL = "Invalid configuration. endpoints.notify should be a valid URL, got empty string. Sessions will not be sent to Bugsnag.".freeze
+      INVALID_SESSION_URL = "Invalid configuration. endpoints.sessions should be a valid URL, got empty string. Bugsnag will not send any requests.".freeze
+      # rubocop:enable Layout/LineLength
+
+      attr_reader :reason
+
+      def initialize(valid, keep_events_enabled_for_backwards_compatibility = true, reason = nil)
+        @valid = valid
+        @keep_events_enabled_for_backwards_compatibility = keep_events_enabled_for_backwards_compatibility
+        @reason = reason
+      end
+
+      def valid?
+        @valid
+      end
+
+      def keep_events_enabled_for_backwards_compatibility?
+        @keep_events_enabled_for_backwards_compatibility
+      end
+
+      # factory functions
+
+      def self.valid
+        new(true)
+      end
+
+      def self.missing_urls
+        new(false, false, MISSING_URLS)
+      end
+
+      def self.missing_notify
+        new(false, false, MISSING_NOTIFY_URL)
+      end
+
+      def self.missing_session
+        new(false, true, MISSING_SESSION_URL)
+      end
+
+      def self.invalid_urls
+        new(false, false, INVALID_URLS)
+      end
+
+      def self.invalid_notify
+        new(false, false, INVALID_NOTIFY_URL)
+      end
+
+      def self.invalid_session
+        new(false, true, INVALID_SESSION_URL)
+      end
+    end
+  end
+end

--- a/spec/bugsnag_spec.rb
+++ b/spec/bugsnag_spec.rb
@@ -121,6 +121,7 @@ describe Bugsnag do
     end
 
     it "warns and disables sessions if a notify endpoint is set without a session endpoint" do
+      expect(Bugsnag.configuration).to receive(:warn).with(Bugsnag::EndpointValidator::Result::MISSING_SESSION_URL)
       expect(Bugsnag.configuration).to receive(:warn).with("The session endpoint has not been set, all further session capturing will be disabled")
       expect(Bugsnag.configuration).to receive(:disable_sessions)
       Bugsnag.configuration.set_endpoints(custom_notify_endpoint, nil)
@@ -133,9 +134,10 @@ describe Bugsnag do
     end
 
     it "is called after the configuration block has returned" do
-      expect(Bugsnag.configuration).to receive(:warn).with("The 'endpoint' configuration option is deprecated. The 'set_endpoints' method should be used instead").once
-      expect(Bugsnag.configuration).to receive(:warn).with("The 'session_endpoint' configuration option is deprecated. The 'set_endpoints' method should be used instead").once
+      expect(Bugsnag.configuration).to receive(:warn).with("The 'endpoint' configuration option is deprecated. Set both endpoints with the 'endpoints=' method instead").once
+      expect(Bugsnag.configuration).to receive(:warn).with("The 'session_endpoint' configuration option is deprecated. Set both endpoints with the 'endpoints=' method instead").once
       expect(Bugsnag.configuration).not_to receive(:warn).with("The session endpoint has not been set, all further session capturing will be disabled")
+
       Bugsnag.configure do |configuration|
         configuration.endpoint = custom_notify_endpoint
         configuration.session_endpoint = custom_session_endpoint

--- a/spec/endpoint_configuration_spec.rb
+++ b/spec/endpoint_configuration_spec.rb
@@ -1,0 +1,19 @@
+require "spec_helper"
+
+require "bugsnag/endpoint_configuration"
+
+describe Bugsnag::EndpointConfiguration do
+  it "has notify & session URLs" do
+    configuration = Bugsnag::EndpointConfiguration.new("notify", "session")
+
+    expect(configuration.notify).to eq("notify")
+    expect(configuration.sessions).to eq("session")
+  end
+
+  it "is immutable" do
+    configuration = Bugsnag::EndpointConfiguration.new("notify", "session")
+
+    expect(configuration).not_to respond_to(:notify=)
+    expect(configuration).not_to respond_to(:session=)
+  end
+end

--- a/spec/endpoint_validator_spec.rb
+++ b/spec/endpoint_validator_spec.rb
@@ -1,0 +1,106 @@
+require "spec_helper"
+
+require "bugsnag/endpoint_configuration"
+require "bugsnag/endpoint_validator"
+
+describe Bugsnag::EndpointValidator do
+  describe "#validate" do
+    it "returns an invalid result if given nil" do
+      result = Bugsnag::EndpointValidator.validate(nil)
+
+      expect(result).to have_attributes({
+        valid?: false,
+        keep_events_enabled_for_backwards_compatibility?: false,
+        reason: Bugsnag::EndpointValidator::Result::MISSING_URLS,
+      })
+    end
+
+    it "returns an invalid result if no URL is set" do
+      endpoint_configuration = Bugsnag::EndpointConfiguration.new(nil, nil)
+      result = Bugsnag::EndpointValidator.validate(endpoint_configuration)
+
+      expect(result).to have_attributes({
+        valid?: false,
+        keep_events_enabled_for_backwards_compatibility?: false,
+        reason: Bugsnag::EndpointValidator::Result::MISSING_URLS,
+      })
+    end
+
+    it "returns an invalid result if notify URL is not set" do
+      endpoint_configuration = Bugsnag::EndpointConfiguration.new(nil, "sessions.example.com")
+      result = Bugsnag::EndpointValidator.validate(endpoint_configuration)
+
+      expect(result).to have_attributes({
+        valid?: false,
+        keep_events_enabled_for_backwards_compatibility?: false,
+        reason: Bugsnag::EndpointValidator::Result::MISSING_NOTIFY_URL,
+      })
+    end
+
+    it "returns an invalid result if session URL is not set" do
+      endpoint_configuration = Bugsnag::EndpointConfiguration.new("notify.example.com", nil)
+      result = Bugsnag::EndpointValidator.validate(endpoint_configuration)
+
+      expect(result).to have_attributes({
+        valid?: false,
+        keep_events_enabled_for_backwards_compatibility?: true,
+        reason: Bugsnag::EndpointValidator::Result::MISSING_SESSION_URL,
+      })
+    end
+
+    it "returns an invalid result if both URLs are empty" do
+      endpoint_configuration = Bugsnag::EndpointConfiguration.new("", "")
+      result = Bugsnag::EndpointValidator.validate(endpoint_configuration)
+
+      expect(result).to have_attributes({
+        valid?: false,
+        keep_events_enabled_for_backwards_compatibility?: false,
+        reason: Bugsnag::EndpointValidator::Result::INVALID_URLS,
+      })
+    end
+
+    it "returns an invalid result if notify URL is empty" do
+      endpoint_configuration = Bugsnag::EndpointConfiguration.new("", "session.example.com")
+      result = Bugsnag::EndpointValidator.validate(endpoint_configuration)
+
+      expect(result).to have_attributes({
+        valid?: false,
+        keep_events_enabled_for_backwards_compatibility?: false,
+        reason: Bugsnag::EndpointValidator::Result::INVALID_NOTIFY_URL,
+      })
+    end
+
+    it "returns an invalid result if session URL is empty" do
+      endpoint_configuration = Bugsnag::EndpointConfiguration.new("notify.example.com", "")
+      result = Bugsnag::EndpointValidator.validate(endpoint_configuration)
+
+      expect(result).to have_attributes({
+        valid?: false,
+        keep_events_enabled_for_backwards_compatibility?: true,
+        reason: Bugsnag::EndpointValidator::Result::INVALID_SESSION_URL,
+      })
+    end
+
+    it "returns a valid result when given two valid URLs" do
+      endpoint_configuration = Bugsnag::EndpointConfiguration.new("notify.example.com", "session.example.com")
+      result = Bugsnag::EndpointValidator.validate(endpoint_configuration)
+
+      expect(result).to have_attributes({
+        valid?: true,
+        keep_events_enabled_for_backwards_compatibility?: true,
+        reason: nil,
+      })
+    end
+
+    it "returns a valid result when given two non-empty strings" do
+      endpoint_configuration = Bugsnag::EndpointConfiguration.new("a b c", "x y z")
+      result = Bugsnag::EndpointValidator.validate(endpoint_configuration)
+
+      expect(result).to have_attributes({
+        valid?: true,
+        keep_events_enabled_for_backwards_compatibility?: true,
+        reason: nil,
+      })
+    end
+  end
+end


### PR DESCRIPTION
## Goal

This PR introduces `Configuration#endpoints`/`Configuration#endpoints=`, bringing endpoint configuration in line with other notifiers (e.g. [Cocoa](https://docs.bugsnag.com/platforms/ios/configuration-options/#endpoints), [Android](https://docs.bugsnag.com/platforms/android/configuration-options/#endpoints) & [JS](https://docs.bugsnag.com/platforms/javascript/configuration-options/#endpoints))

Setting the endpoints is done with a new `Bugsnag::EndpointConfiguration` class:

```ruby
Bugsnag.configure do |config|
  config.endpoints = Bugsnag::EndpointConfiguration.new(
    "<notify endpoint>",
    "<sessions endpoint>"
  )
end
```

The endpoints can then be read from `Configuration#endpoints`:

```ruby
puts Bugsnag.configuration.endpoints.notify # => <notify endpoint>
puts Bugsnag.configuration.endpoints.sessions # => <sessions endpoint>
```

When the endpoints are set, we validate that two non-empty strings have been given (i.e. `nil` & `""` fail validation, all other values pass). If validation fails then we will avoid sending requests to prevent leaking data to the cloud Bugsnag instance. The exception to this rule is that we will still send events if the notify endpoint is set without the sessions endpoint. This is for backwards compatibility — it's entirely possible for users of Bugsnag before sessions existed to still only be setting the notify endpoint. This exception will be removed in the next major version; all requests will be avoided if either URL is not valid