### PR TITLE
Fix Que tests on Ruby versions < 2.4

### DIFF
--- a/features/fixtures/docker-compose.yml
+++ b/features/fixtures/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     image: redis
 
   postgres:
-    image: postgres
+    image: postgres:13
     environment:
       - POSTGRES_PASSWORD=test_password
 


### PR DESCRIPTION
## Goal

Our Que tests started failing after the release of Postgres v14 as the PG gem/ActiveRecord were no longer able to authenticate with the server

There doesn't seem to be a combination of dependencies that are compatible with Ruby 2.0-2.3 AND Postgres 14, so I've restricted the Postgres docker image to v13 instead