### PR TITLE
Allow pausing and resuming sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Changelog
   | [#700](https://github.com/bugsnag/bugsnag-ruby/pull/700)
 * Add `Configuration#endpoints` for reading the notify and sessions endpoints and `Configuration#endpoints=` for setting them
   | [#701](https://github.com/bugsnag/bugsnag-ruby/pull/701)
+* Allow pausing and resuming sessions, giving more control over stability score
+  | [#704](https://github.com/bugsnag/bugsnag-ruby/pull/704)
 
 ### Deprecated
 

--- a/lib/bugsnag.rb
+++ b/lib/bugsnag.rb
@@ -197,11 +197,34 @@ module Bugsnag
     end
 
     ##
-    # Starts a session.
+    # Starts a new session, which allows Bugsnag to track error rates across
+    # releases
     #
-    # Allows Bugsnag to track error rates across releases.
+    # @return [void]
     def start_session
       session_tracker.start_session
+    end
+
+    ##
+    # Stop any events being attributed to the current session until it is
+    # resumed or a new session is started
+    #
+    # @see resume_session
+    #
+    # @return [void]
+    def pause_session
+      session_tracker.pause_session
+    end
+
+    ##
+    # Resume the current session if it was previously paused. If there is no
+    # current session, a new session will be started
+    #
+    # @see pause_session
+    #
+    # @return [Boolean] true if a paused session was resumed
+    def resume_session
+      session_tracker.resume_session
     end
 
     ##

--- a/lib/bugsnag/middleware/session_data.rb
+++ b/lib/bugsnag/middleware/session_data.rb
@@ -9,7 +9,7 @@ module Bugsnag::Middleware
     def call(report)
       session = Bugsnag::SessionTracker.get_current_session
 
-      if session
+      if session && !session[:paused?]
         if report.unhandled
           session[:events][:unhandled] += 1
         else

--- a/spec/session_tracker_spec.rb
+++ b/spec/session_tracker_spec.rb
@@ -151,4 +151,77 @@ describe Bugsnag::SessionTracker do
     expect(device["hostname"]).to eq(Bugsnag.configuration.hostname)
     expect(device["runtimeVersions"]["ruby"]).to eq(Bugsnag.configuration.runtime_versions["ruby"])
   end
+
+  context "#pause_session" do
+    it "does nothing if there is no current session" do
+      Bugsnag.pause_session
+
+      expect(Bugsnag::SessionTracker.get_current_session).to be(nil)
+    end
+
+    it "marks the current session as paused if one exists" do
+      Bugsnag.start_session
+
+      expect(Bugsnag::SessionTracker.get_current_session[:paused?]).to be(false)
+
+      Bugsnag.pause_session
+
+      expect(Bugsnag::SessionTracker.get_current_session[:paused?]).to be(true)
+    end
+
+    it "does nothing if the current session is already paused" do
+      Bugsnag.start_session
+
+      expect(Bugsnag::SessionTracker.get_current_session[:paused?]).to be(false)
+
+      Bugsnag.pause_session
+
+      expect(Bugsnag::SessionTracker.get_current_session[:paused?]).to be(true)
+
+      Bugsnag.pause_session
+
+      expect(Bugsnag::SessionTracker.get_current_session[:paused?]).to be(true)
+    end
+  end
+
+  context "#resume_session" do
+    it "returns false and does nothing when there is a current session" do
+      Bugsnag.start_session
+
+      expect(Bugsnag::SessionTracker.get_current_session[:paused?]).to be(false)
+
+      expect(Bugsnag.resume_session).to be(false)
+
+      expect(Bugsnag::SessionTracker.get_current_session[:paused?]).to be(false)
+    end
+
+    it "returns false and does nothing when a session is started after one has been paused" do
+      Bugsnag.start_session
+      Bugsnag.pause_session
+      Bugsnag.start_session
+
+      expect(Bugsnag::SessionTracker.get_current_session[:paused?]).to be(false)
+
+      expect(Bugsnag.resume_session).to be(false)
+
+      expect(Bugsnag::SessionTracker.get_current_session[:paused?]).to be(false)
+    end
+
+    it "returns false and starts a new session when there is no current or paused session" do
+      expect(Bugsnag.resume_session).to be(false)
+
+      expect(Bugsnag::SessionTracker.get_current_session).not_to be(nil)
+    end
+
+    it "returns true and makes the paused session the active session when there is no current session" do
+      Bugsnag.start_session
+      Bugsnag.pause_session
+
+      expect(Bugsnag::SessionTracker.get_current_session[:paused?]).to be(true)
+
+      expect(Bugsnag.resume_session).to be(true)
+
+      expect(Bugsnag::SessionTracker.get_current_session).not_to be(nil)
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -59,6 +59,8 @@ RSpec.configure do |config|
     Bugsnag.instance_variable_set(:@session_tracker, Bugsnag::SessionTracker.new)
     Bugsnag.instance_variable_set(:@cleaner, Bugsnag::Cleaner.new(Bugsnag.configuration))
 
+    Thread.current[Bugsnag::SessionTracker::THREAD_SESSION] = nil
+
     Bugsnag.configure do |bugsnag|
       bugsnag.api_key = "c9d60ae4c7e70c4b6c4ebd3e8056d2b8"
       bugsnag.release_stage = "production"


### PR DESCRIPTION
## Goal

This PR adds `Bugsnag#pause_session` and `Bugsnag#resume_session`, which allow more control over the stability score. When a session is paused, events won't be attributed to it until it is resumed or a new session is started. `resume_session` can also be used to start a new session if no session exists

To tell if the current session is paused, check the `:paused?` key in the session hash:

```ruby
current_session = Bugsnag::SessionTracker.get_current_session

if current_session
  is_paused = current_session[:paused?]
end
```