### PR TITLE
Add `Configuration#vendor_paths` to replace `Configuration#vendor_path`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,12 +17,15 @@ Changelog
   | [#703](https://github.com/bugsnag/bugsnag-ruby/pull/703)
 * Allow pausing and resuming sessions, giving more control over the stability score
   | [#704](https://github.com/bugsnag/bugsnag-ruby/pull/704)
+* Add `Configuration#vendor_paths` to replace `Configuration#vendor_path`
+  | [#705](https://github.com/bugsnag/bugsnag-ruby/pull/705)
 
 ### Deprecated
 
 * In the next major release, `params` will only contain query string parameters. Currently it also contains the request body for form data requests, but this is deprecated in favour of the new `body` property
 * The `Configuration#set_endpoints` method is now deprecated in favour of `Configuration#endpoints=`
 * The `Configuration#meta_data_filters` option is now deprecated in favour of `Configuration#redacted_keys`
+* The `Configuration#vendor_path` option is now deprecated in favour of `Configuration#vendor_paths`
 
 ## v6.23.0 (21 September 2021)
 

--- a/lib/bugsnag/configuration.rb
+++ b/lib/bugsnag/configuration.rb
@@ -155,9 +155,17 @@ module Bugsnag
     # @return [Integer]
     attr_reader :max_breadcrumbs
 
-    #
+    # @deprecated Use {vendor_paths} instead
     # @return [Regexp]
     attr_accessor :vendor_path
+
+    # An array of paths within the {project_root} that should not be considered
+    # as "in project"
+    #
+    # These paths should be relative to the {project_root}
+    #
+    # @return [Array<String>]
+    attr_accessor :vendor_paths
 
     # The default context for all future events
     # Setting this will disable automatic context setting
@@ -259,6 +267,7 @@ module Bugsnag
       # Stacktrace lines that matches regex will be marked as "out of project"
       # will only appear in the full trace.
       self.vendor_path = DEFAULT_VENDOR_PATH
+      @vendor_paths = []
 
       # Set up logging
       self.logger = Logger.new(STDOUT)

--- a/lib/bugsnag/configuration.rb
+++ b/lib/bugsnag/configuration.rb
@@ -162,7 +162,8 @@ module Bugsnag
     # An array of paths within the {project_root} that should not be considered
     # as "in project"
     #
-    # These paths should be relative to the {project_root}
+    # These paths should be relative to the {project_root} and will only match
+    # whole directory names
     #
     # @return [Array<String>]
     attr_accessor :vendor_paths

--- a/lib/bugsnag/stacktrace.rb
+++ b/lib/bugsnag/stacktrace.rb
@@ -43,7 +43,7 @@ module Bugsnag
         if defined?(configuration.project_root) && configuration.project_root.to_s != ''
           trace_hash[:inProject] = true if file.start_with?(configuration.project_root.to_s)
           file.sub!(/#{configuration.project_root}\//, "")
-          trace_hash.delete(:inProject) if file.match(configuration.vendor_path)
+          trace_hash.delete(:inProject) if vendor_path?(configuration, file)
         end
 
         # Strip common gem path prefixes
@@ -66,6 +66,15 @@ module Bugsnag
       code_extractor.extract! if configuration.send_code
 
       processed_backtrace
+    end
+
+    # @api private
+    def self.vendor_path?(configuration, file_path)
+      return true if configuration.vendor_path && file_path.match(configuration.vendor_path)
+
+      configuration.vendor_paths.any? do |vendor_path|
+        file_path.start_with?("#{vendor_path.sub(/\/$/, '')}/")
+      end
     end
   end
 end


### PR DESCRIPTION
## Goal

This PR adds `Configuration#vendor_paths` to replace `Configuration#vendor_path`

`vendor_paths` is an array of strings which will mark a stack frame as out of project if the frame's file path starts with any of the strings, after removing the project root (if a file is outside of the project root, it wouldn't be marked as in project in the first place)

For example, with this stacktrace:

```ruby
[
  "/foo/bar/app/models/user.rb:1:in `something'",
  "/foo/bar/abc/lib/ignore_me.rb:1:in `to_s'",
  "/foo/bar/xyz/lib/ignore_me.rb:1:in `to_s'",
]
```

and this configuration:

```ruby
Bugsnag.configure do |config|
  config.project_root = "/foo/bar"
  config.vendor_paths = ["abc", "xyz"]
end
```

only `/foo/bar/app/models/user.rb` will be marked as in project, as the other paths are matched by `vendor_paths`

Note that matches are done on entire directories, for example `abc` does not match `abc_xyz`