### PR TITLE
Loosen assertions on `Time.now` calls

### DIFF
--- a/spec/breadcrumbs/breadcrumb_spec.rb
+++ b/spec/breadcrumbs/breadcrumb_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe Bugsnag::Breadcrumbs::Breadcrumb do
   describe "#to_h" do
     it "outputs as a hash" do
       fake_now = Time.gm(2020, 1, 2, 3, 4, 5, 123456)
-      expect(Time).to receive(:now).and_return(fake_now)
+      expect(Time).to receive(:now).at_least(:once).and_return(fake_now)
 
       breadcrumb = Bugsnag::Breadcrumbs::Breadcrumb.new(
         "my message",

--- a/spec/bugsnag_spec.rb
+++ b/spec/bugsnag_spec.rb
@@ -580,7 +580,7 @@ describe Bugsnag do
   describe "request headers" do
     it "Bugsnag-Sent-At should use the current time" do
       fake_now = Time.gm(2020, 1, 2, 3, 4, 5, 123456)
-      expect(Time).to receive(:now).at_most(6).times.and_return(fake_now)
+      expect(Time).to receive(:now).at_least(6).times.and_return(fake_now)
 
       Bugsnag.notify(BugsnagTestException.new("It crashed"))
 

--- a/spec/report_spec.rb
+++ b/spec/report_spec.rb
@@ -49,7 +49,7 @@ shared_examples "Report or Event tests" do |class_to_test|
 
   it "#headers should return the correct request headers" do
     fake_now = Time.gm(2020, 1, 2, 3, 4, 5, 123456)
-    expect(Time).to receive(:now).twice.and_return(fake_now)
+    expect(Time).to receive(:now).at_least(:twice).and_return(fake_now)
 
     report_or_event = class_to_test.new(
       BugsnagTestException.new("It crashed"),


### PR DESCRIPTION
## Goal

Some of our tests mock `Time.now` because it's used in e.g. the `Bugsnag-Sent-At` header. Sometimes it gets called more than these tests allowed, making them flakey on CI. I haven't been able to debug why this happens, but it's likely not even Bugsnag code calling it