### PR TITLE
Tweak when we include the AR transaction callback rescuing

### DIFF
--- a/lib/bugsnag/integrations/railtie.rb
+++ b/lib/bugsnag/integrations/railtie.rb
@@ -70,8 +70,15 @@ module Bugsnag
       end
 
       ActiveSupport.on_load(:active_record) do
-        require "bugsnag/integrations/rails/active_record_rescue"
-        include Bugsnag::Rails::ActiveRecordRescue
+        if Rails::VESION::MAJOR == 4
+          if ActiveRecord::Base.errors_in_transactional_callbacks == :raise
+            require "bugsnag/integrations/rails/active_record_rescue"
+            include Bugsnag::Rails::ActiveRecordRescue
+          end
+        elsif Rails::VESION::MAJOR < 4
+          require "bugsnag/integrations/rails/active_record_rescue"
+          include Bugsnag::Rails::ActiveRecordRescue
+        end
       end
 
       ActiveSupport.on_load(:active_job) do

--- a/spec/integrations/active_record_spec.rb
+++ b/spec/integrations/active_record_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
-
+require "bugsnag/integrations/rails/active_record_rescue"
 describe Bugsnag::Rails::ActiveRecordRescue do
   it "does not include module in rails 5 and newer" do
-    if Rails::VERSION::MAJOR < 5
+    if ::Rails::VERSION::MAJOR < 5
       skip "test not for this version"
     else
       expect(ActiveRecord::Base.ancestors).not_to include(Bugsnag::Rails::ActiveRecordRescue)
@@ -10,7 +10,7 @@ describe Bugsnag::Rails::ActiveRecordRescue do
   end
 
   it "includes it if the exception behavior is to not raise" do
-    if Rails::VERSION::MAJOR != 4
+    if ::Rails::VERSION::MAJOR != 4
       skip "test not for this version"
     else
       ActiveRecord::Base.errors_in_transactional_callbacks = :log
@@ -19,7 +19,7 @@ describe Bugsnag::Rails::ActiveRecordRescue do
   end
 
   it "does not include it if the exception behavior is to raise" do
-    if Rails::VERSION::MAJOR != 4
+    if ::Rails::VERSION::MAJOR != 4
       skip "test not for this version"
     else
       ActiveRecord::Base.errors_in_transactional_callbacks = :raise
@@ -28,7 +28,7 @@ describe Bugsnag::Rails::ActiveRecordRescue do
   end
 
   it "includes it in rails 3" do
-    if Rails::VERSION::MAJOR != 3
+    if ::Rails::VERSION::MAJOR != 3
       skip "test not for this version"
     else
       expect(ActiveRecord::Base.ancestors).to include(Bugsnag::Rails::ActiveRecordRescue)

--- a/spec/integrations/active_record_spec.rb
+++ b/spec/integrations/active_record_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+describe Bugsnag::Rails::ActiveRecordRescue do
+  it "does not include module in rails 5 and newer" do
+    if Rails::VERSION::MAJOR < 5
+      skip "test not for this version"
+    else
+      expect(ActiveRecord::Base.ancestors).not_to include(Bugsnag::Rails::ActiveRecordRescue)
+    end
+  end
+
+  it "includes it if the exception behavior is to not raise" do
+    if Rails::VERSION::MAJOR != 4
+      skip "test not for this version"
+    else
+      ActiveRecord::Base.errors_in_transactional_callbacks = :log
+      expect(ActiveRecord::Base.ancestors).to include(Bugsnag::Rails::ActiveRecordRescue)
+    end
+  end
+
+  it "does not include it if the exception behavior is to raise" do
+    if Rails::VERSION::MAJOR != 4
+      skip "test not for this version"
+    else
+      ActiveRecord::Base.errors_in_transactional_callbacks = :raise
+      expect(ActiveRecord::Base.ancestors).not_to include(Bugsnag::Rails::ActiveRecordRescue)
+    end
+  end
+
+  it "includes it in rails 3" do
+    if Rails::VERSION::MAJOR != 3
+      skip "test not for this version"
+    else
+      expect(ActiveRecord::Base.ancestors).to include(Bugsnag::Rails::ActiveRecordRescue)
+    end
+  end
+end


### PR DESCRIPTION
## Goal

Bugsnag notifies when we see an exception in a transaction (or rollback) callback.  This is unnecessary as Rails now raises exceptions out of transaction callbacks.  This Bugsnag  behaviour means that certain errors are always sent to bugsnag instead of potentially handled elsewhere.  

Bugsnag behaviour can be seen here: https://github.com/apalmblad/bugsnag-ruby/blob/master/lib/bugsnag/integrations/rails/active_record_rescue.rb#L14

Rails has stopped swallowing exceptions in these callbacks, making in configurable in Rails 4, and then the default behaviour in Rails 5.
[Rails allowing exceptions to be raised](https://github.com/rails/rails/pull/16537)
[Rails 5 removing configuration for not raising callback exceptions](https://github.com/rails/rails/commit/07d3d402341e81ada0214f2cb2be1da69eadfe72)
## Design

To minimize changes needed, I consider the rails version and the various configuration values and conditionally include the file.

## Changeset

The rails integration behaviour was changed, and we stop including it.

## Testing

I've added a spec to check whether or not its included.