### PR TITLE
resque: be more specific when handling ActiveJob wrapped jobs

### DIFF
--- a/lib/bugsnag/integrations/resque.rb
+++ b/lib/bugsnag/integrations/resque.rb
@@ -49,7 +49,7 @@ module Bugsnag
 
         # when using Active Job the payload "class" will always be the Resque
         # "JobWrapper", not the actual job class so we need to fix this here
-        if metadata['args'] && metadata['args'][0] && metadata['args'][0]['job_class']
+        if class_name == 'ActiveJob::QueueAdapters::ResqueAdapter::JobWrapper' && metadata['args'] && metadata['args'][0] && metadata['args'][0]['job_class']
           class_name = metadata['args'][0]['job_class']
           metadata['wrapped'] ||= class_name
         end


### PR DESCRIPTION
## Goal

The Resque Bugsnag integration adds helpful context and payload information to reports from Resque tasks. A check within the integration attempts to unwrap `ActiveJob` jobs run via Resque. The check used to perform this unwrapping assumes that all jobs will run via `ActiveJob`, and causes errors when used with jobs other than `ActiveJob` whose first argument does not respond sensibly to `[]`. For example:

```
Error in internal notify block: no implicit conversion of String into Integer
```

after bubbling up to the top-level [Bugsnag notify method](https://github.com/bugsnag/bugsnag-ruby/blob/94da895ad148b9cd132099a6a0be5710a5f03e35/lib/bugsnag.rb#L89). This occurs before any Resque-specific context can be added to the report, and yields reports that are less useful than they could be. We want to prevent these errors so Resque reports have more uniform context.

## Design

The comment in the current implementation asserts an expectation about the payload of ActiveJob reports, but doesn't actually assert it or guard the following code by checking that assumption. It seemed reasonable to me to guard the error-producing conditional with an explicit assertion following the comment – restricting it to only those payloads for which it makes sense.
<!-- Why was this approach used? -->

## Changeset

* Guard ActiveJob-specific Resque handling with an assertion that we're handling an ActiveJob report.
<!-- What changed? -->

## Testing

- [ ] Confirmed in my environment that Resque jobs more reliably have Resque context associated with them
- [ ] Confirmed in my environment that "Error in internal notify block" errors (associated with this issue) are reduced/eliminated after this fix
- [ ] Confirmed in my environment that errors originating in ActiveJob tasks are properly unwrapped
- [ ] Added specs for this case
<!-- How was it tested? What manual and automated tests were
     run/added? -->