### PR TITLE
Fix Resque metadata when run outside of Active Job

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,6 +19,9 @@ Metrics/ClassLength:
   Exclude:
     - 'lib/bugsnag/configuration.rb'
 
+Style/RescueModifier:
+  Enabled: false
+
 # We can't use ".freeze" on our constants in case users are monkey patching
 # them — this would be a BC break
 Style/MutableConstant:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+## TBD
+
+### Fixes
+
+* Fix metadata not being recorded when using Resque outside of Active Job
+  | [#710](https://github.com/bugsnag/bugsnag-ruby/pull/710)
+  | [isnotajoke](https://github.com/isnotajoke)
+
 ## v6.24.0 (6 October 2021)
 
 ### Enhancements

--- a/features/fixtures/rails_integrations/app/app/workers/resque_worker.rb
+++ b/features/fixtures/rails_integrations/app/app/workers/resque_worker.rb
@@ -1,7 +1,7 @@
 class ResqueWorker
   @queue = :crash
 
-  def self.perform
+  def self.perform(*arguments, **named_arguments)
     raise 'broken'
   end
 end

--- a/features/rails_features/integrations.feature
+++ b/features/rails_features/integrations.feature
@@ -72,7 +72,7 @@ Scenario: Rake
 @rails_integrations
 Scenario: Resque (no on_exit hooks)
   When I run "bundle exec rake resque:work" in the rails app
-  And I run "Resque.enqueue(ResqueWorker)" with the rails runner
+  And I run "Resque.enqueue(ResqueWorker, 123, %(abc), x: true, y: false)" with the rails runner
   And I wait to receive a request
   Then the request is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier"
   And the event "unhandled" is true
@@ -85,6 +85,10 @@ Scenario: Resque (no on_exit hooks)
   And the event "metaData.config.delivery_method" equals "synchronous"
   And the event "metaData.context" equals "ResqueWorker@crash"
   And the event "metaData.payload.class" equals "ResqueWorker"
+  And the event "metaData.payload.args.0" equals 123
+  And the event "metaData.payload.args.1" equals "abc"
+  And the event "metaData.payload.args.2.x" is true
+  And the event "metaData.payload.args.2.y" is false
   And the event "metaData.rake_task.name" equals "resque:work"
   And the event "metaData.rake_task.description" equals "Start a Resque worker"
   And the event "metaData.rake_task.arguments" is null
@@ -93,7 +97,7 @@ Scenario: Resque (no on_exit hooks)
 Scenario: Resque (with on_exit hooks)
   Given I set environment variable "RUN_AT_EXIT_HOOKS" to "1"
   When I run "bundle exec rake resque:work" in the rails app
-  And I run "Resque.enqueue(ResqueWorker)" with the rails runner
+  And I run "Resque.enqueue(ResqueWorker, %(xyz), [7, 8, 9], a: 4, b: 5)" with the rails runner
   And I wait to receive a request
   Then the request is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier"
   And the event "unhandled" is true
@@ -106,6 +110,12 @@ Scenario: Resque (with on_exit hooks)
   And the event "metaData.config.delivery_method" equals "thread_queue"
   And the event "metaData.context" equals "ResqueWorker@crash"
   And the event "metaData.payload.class" equals "ResqueWorker"
+  And the event "metaData.payload.args.0" equals "xyz"
+  And the event "metaData.payload.args.1.0" equals 7
+  And the event "metaData.payload.args.1.1" equals 8
+  And the event "metaData.payload.args.1.2" equals 9
+  And the event "metaData.payload.args.2.a" equals 4
+  And the event "metaData.payload.args.2.b" equals 5
   And the event "metaData.rake_task.name" equals "resque:work"
   And the event "metaData.rake_task.description" equals "Start a Resque worker"
   And the event "metaData.rake_task.arguments" is null

--- a/features/rails_features/integrations.feature
+++ b/features/rails_features/integrations.feature
@@ -160,7 +160,7 @@ Scenario: Using Sidekiq as the Active Job queue adapter for a job that raises
   And the event "metaData.sidekiq.queue" equals "default"
 
 @rails_integrations
-Scenario: Using Rescue as the Active Job queue adapter for a job that raises
+Scenario: Using Resque as the Active Job queue adapter for a job that raises
   When I set environment variable "ACTIVE_JOB_QUEUE_ADAPTER" to "resque"
   And I run "bundle exec rake resque:work" in the rails app
   And I run "UnhandledJob.perform_later(1, yes: true)" with the rails runner
@@ -231,7 +231,7 @@ Scenario: Using Sidekiq as the Active Job queue adapter for a job that works
   Then I should receive no requests
 
 @rails_integrations
-Scenario: Using Rescue as the Active Job queue adapter for a job that works
+Scenario: Using Resque as the Active Job queue adapter for a job that works
   When I set environment variable "ACTIVE_JOB_QUEUE_ADAPTER" to "resque"
   And I run "bundle exec rake resque:work" in the rails app
   And I run "WorkingJob.perform_later" with the rails runner

--- a/lib/bugsnag/integrations/resque.rb
+++ b/lib/bugsnag/integrations/resque.rb
@@ -45,13 +45,17 @@ module Bugsnag
         }
 
         metadata = payload
-        class_name = payload['class']
+        class_name = metadata['class']
 
         # when using Active Job the payload "class" will always be the Resque
-        # "JobWrapper", not the actual job class so we need to fix this here
-        if class_name == 'ActiveJob::QueueAdapters::ResqueAdapter::JobWrapper' && metadata['args'] && metadata['args'][0] && metadata['args'][0]['job_class']
-          class_name = metadata['args'][0]['job_class']
-          metadata['wrapped'] ||= class_name
+        # "JobWrapper", so we need to unwrap the actual class name
+        if class_name == "ActiveJob::QueueAdapters::ResqueAdapter::JobWrapper"
+          unwrapped_class_name = metadata['args'][0]['job_class'] rescue nil
+
+          if unwrapped_class_name
+            class_name = unwrapped_class_name
+            metadata['wrapped'] ||= unwrapped_class_name
+          end
         end
 
         context = "#{class_name}@#{queue}"

--- a/lib/bugsnag/integrations/resque.rb
+++ b/lib/bugsnag/integrations/resque.rb
@@ -49,7 +49,7 @@ module Bugsnag
 
         # when using Active Job the payload "class" will always be the Resque
         # "JobWrapper", not the actual job class so we need to fix this here
-        if metadata['args'] && metadata['args'][0] && metadata['args'][0]['job_class']
+        if class_name == 'ActiveJob::QueueAdapters::ResqueAdapter::JobWrapper' && metadata['args'] && metadata['args'][0] && metadata['args'][0]['job_class']
           class_name = metadata['args'][0]['job_class']
           metadata['wrapped'] ||= class_name
         end

--- a/spec/integrations/resque_spec.rb
+++ b/spec/integrations/resque_spec.rb
@@ -118,6 +118,33 @@ describe 'Bugsnag::Resque', :order => :defined do
     }
   end
 
+  it "handles when args[0] does not respond to '[]'" do
+    resque = Bugsnag::Resque.new
+    exception = RuntimeError.new("hello")
+
+    allow(resque).to receive(:exception).and_return(exception)
+    allow(resque).to receive(:queue).and_return("queue")
+    allow(resque).to receive(:payload).and_return({
+      "class" => "ResqueJob",
+      "args" => [1234]
+    })
+
+    report = Bugsnag::Report.new(exception, Bugsnag.configuration)
+
+    resque.save
+
+    expect(Bugsnag).to have_sent_notification { |payload, headers|
+      event = get_event_from_payload(payload)
+
+      expect(event["context"]).to eq("ResqueJob@queue")
+      expect(event["metaData"]["context"]).to eq("ResqueJob@queue")
+      expect(event["metaData"]["payload"]).to eq({
+        "args" => [1234],
+        "class" => "ResqueJob",
+      })
+    }
+  end
+
   after do
     Object.send(:remove_const, :Resque) if @mocked_resque
     module Kernel


### PR DESCRIPTION
## Goal

This is PR #710 with some tests and a small change to the implementation

This fixes an issue preventing metadata from being recorded when running a Resque job outside of Active Job