### PR TITLE
Avoid YARD pulling in WEBrick on Ruby < 2.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ group :test, optional: true do
   gem 'rake', ruby_version <= Gem::Version.new('1.9.3') ? '~> 11.3.0' : '~> 12.3.0'
   gem 'rspec'
   gem 'rspec-mocks'
-  gem 'yard', '~> 0.9.25'
+  gem 'yard', ruby_version < Gem::Version.new('2.3.0') ? '< 0.9.27' : '~> 0.9.25'
   gem 'pry'
   gem 'addressable', '~> 2.3.8'
 


### PR DESCRIPTION
## Goal

A new YARD release depends on a WEBrick version that requires Ruby 2.3, so we need to avoid installing this on 2.2 and below