### PR TITLE
Use dig instead of rescue nil

### DIFF
--- a/lib/bugsnag/integrations/resque.rb
+++ b/lib/bugsnag/integrations/resque.rb
@@ -50,7 +50,7 @@ module Bugsnag
         # when using Active Job the payload "class" will always be the Resque
         # "JobWrapper", so we need to unwrap the actual class name
         if class_name == "ActiveJob::QueueAdapters::ResqueAdapter::JobWrapper"
-          unwrapped_class_name = metadata['args'][0]['job_class'] rescue nil
+          unwrapped_class_name = metadata.dig('args', 0, 'job_class')
 
           if unwrapped_class_name
             class_name = unwrapped_class_name


### PR DESCRIPTION
## Goal

Avoid using bad practices in the code

Generally `rescue nil` is not considered as a recommended approach, for example https://thoughtbot.com/blog/don-t-inline-rescue-in-ruby

For most cases in ruby we should have more explicit ways to write code.

## Design

Using `.dig` seems to be very suitable for this particular case. 
https://ruby-doc.org/core-3.0.0/Hash.html#method-i-dig

I was also considering refactoring the code to be even more explicit, like:
```ruby
        if class_name == "ActiveJob::QueueAdapters::ResqueAdapter::JobWrapper"
          first_arg = metadata['args'][0]
          unwrapped_class_name = first_arg['job_class'] if first_arg
          ...
```

To explicitly show which part is expected to be nilable and which part will never be `nil` but I don't have enough context to make a correct change

## Testing

No changes in logic so should be covered by existing tests