### PR TITLE
Fix specs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -49,8 +49,17 @@ end
 
 group :sidekiq, optional: true do
   gem 'sidekiq', '~> 5.2.7'
-  # redis 4.1.2 dropped support for Ruby 2.2
-  gem 'redis', ruby_version < Gem::Version.new('2.3.0') ? '4.1.1' : '>= 4.1.2'
+
+  if ruby_version < Gem::Version.new('2.3.0')
+    # redis 4.1.2 dropped support for Ruby 2.2
+    gem 'redis', '4.1.1'
+  elsif ruby_version < Gem::Version.new('2.4.0')
+    # redis 4.5.0 dropped support for Ruby 2.3
+    gem 'redis', '< 4.5.0'
+  else
+    gem 'redis'
+  end
+
   # rack 2.2.0 dropped support for Ruby 2.2
   gem 'rack', ruby_version < Gem::Version.new('2.3.0') ? '< 2.2.0' : '~> 2.2'
 end

--- a/spec/integrations/clearance_user_spec.rb
+++ b/spec/integrations/clearance_user_spec.rb
@@ -1,7 +1,7 @@
 require "spec_helper"
 
 describe Bugsnag::Middleware::ClearanceUser do
-  it "updates the reports user with warden parameters" do
+  it "updates the reports user with clearance parameters" do
     callback = double
 
     user = double

--- a/spec/integrations/warden_user_spec.rb
+++ b/spec/integrations/warden_user_spec.rb
@@ -12,10 +12,10 @@ describe Bugsnag::Middleware::WardenUser do
     )
 
     warden = double
-    allow(warden).to receive(:user).with(
+    allow(warden).to receive(:user).with({
       :scope => "user",
       :run_callbacks => false
-    ).and_return(user)
+    }).and_return(user)
 
     report = double("Bugsnag::Report") 
     expect(report).to receive(:request_data).exactly(3).times.and_return({


### PR DESCRIPTION
## Goal

Fixes CI, which was failing because of an incompatible redis gem version on Ruby 2.3 and a hash vs keyword parameter issue on Ruby 3.0