### PR TITLE
Add Que 1.x to CI matrix

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -971,6 +971,45 @@ steps:
     concurrency: 4
     concurrency_group: 'ruby/integrations-maze-runner-tests'
 
+  - label: ':key: Que 1.x Ruby 2.5 tests'
+    timeout_in_minutes: 30
+    plugins:
+      docker-compose#v3.1.0:
+        run: ruby-maze-runner
+        use-aliases: true
+        command: ['features/que.feature', '--tags', 'not @wip']
+    env:
+      RUBY_TEST_VERSION: '2.5'
+      QUE_VERSION: '1'
+    concurrency: 4
+    concurrency_group: 'ruby/integrations-maze-runner-tests'
+
+  - label: ':key: Que 1.x Ruby 2.6 tests'
+    timeout_in_minutes: 30
+    plugins:
+      docker-compose#v3.1.0:
+        run: ruby-maze-runner
+        use-aliases: true
+        command: ['features/que.feature', '--tags', 'not @wip']
+    env:
+      RUBY_TEST_VERSION: '2.6'
+      QUE_VERSION: '1'
+    concurrency: 4
+    concurrency_group: 'ruby/integrations-maze-runner-tests'
+
+  - label: ':key: Que 1.x Ruby 2.7 tests'
+    timeout_in_minutes: 30
+    plugins:
+      docker-compose#v3.1.0:
+        run: ruby-maze-runner
+        use-aliases: true
+        command: ['features/que.feature', '--tags', 'not @wip']
+    env:
+      RUBY_TEST_VERSION: '2.7'
+      QUE_VERSION: '1'
+    concurrency: 4
+    concurrency_group: 'ruby/integrations-maze-runner-tests'
+
   - label: ':bed: Rack 1 Ruby 1.9 tests'
     timeout_in_minutes: 30
     plugins:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -854,7 +854,7 @@ steps:
     concurrency: 4
     concurrency_group: 'ruby/integrations-maze-runner-tests'
 
-  - label: ':key: Que Ruby 2.0 tests'
+  - label: ':key: Que 0.14 Ruby 2.0 tests'
     timeout_in_minutes: 30
     plugins:
       docker-compose#v3.1.0:
@@ -863,10 +863,11 @@ steps:
         command: ['features/que.feature', '--tags', 'not @wip']
     env:
       RUBY_TEST_VERSION: '2.0'
+      QUE_VERSION: '0.14'
     concurrency: 4
     concurrency_group: 'ruby/integrations-maze-runner-tests'
 
-  - label: ':key: Que Ruby 2.1 tests'
+  - label: ':key: Que 0.14 Ruby 2.1 tests'
     timeout_in_minutes: 30
     plugins:
       docker-compose#v3.1.0:
@@ -875,10 +876,11 @@ steps:
         command: ['features/que.feature', '--tags', 'not @wip']
     env:
       RUBY_TEST_VERSION: '2.1'
+      QUE_VERSION: '0.14'
     concurrency: 4
     concurrency_group: 'ruby/integrations-maze-runner-tests'
 
-  - label: ':key: Que Ruby 2.2 tests'
+  - label: ':key: Que 0.14 Ruby 2.2 tests'
     timeout_in_minutes: 30
     plugins:
       docker-compose#v3.1.0:
@@ -887,10 +889,11 @@ steps:
         command: ['features/que.feature', '--tags', 'not @wip']
     env:
       RUBY_TEST_VERSION: '2.2'
+      QUE_VERSION: '0.14'
     concurrency: 4
     concurrency_group: 'ruby/integrations-maze-runner-tests'
 
-  - label: ':key: Que Ruby 2.3 tests'
+  - label: ':key: Que 0.14 Ruby 2.3 tests'
     timeout_in_minutes: 30
     plugins:
       docker-compose#v3.1.0:
@@ -899,10 +902,11 @@ steps:
         command: ['features/que.feature', '--tags', 'not @wip']
     env:
       RUBY_TEST_VERSION: '2.3'
+      QUE_VERSION: '0.14'
     concurrency: 4
     concurrency_group: 'ruby/integrations-maze-runner-tests'
 
-  - label: ':key: Que Ruby 2.4 tests'
+  - label: ':key: Que 0.14 Ruby 2.4 tests'
     timeout_in_minutes: 30
     plugins:
       docker-compose#v3.1.0:
@@ -911,10 +915,11 @@ steps:
         command: ['features/que.feature', '--tags', 'not @wip']
     env:
       RUBY_TEST_VERSION: '2.4'
+      QUE_VERSION: '0.14'
     concurrency: 4
     concurrency_group: 'ruby/integrations-maze-runner-tests'
 
-  - label: ':key: Que Ruby 2.5 tests'
+  - label: ':key: Que 0.14 Ruby 2.5 tests'
     timeout_in_minutes: 30
     plugins:
       docker-compose#v3.1.0:
@@ -923,10 +928,11 @@ steps:
         command: ['features/que.feature', '--tags', 'not @wip']
     env:
       RUBY_TEST_VERSION: '2.5'
+      QUE_VERSION: '0.14'
     concurrency: 4
     concurrency_group: 'ruby/integrations-maze-runner-tests'
 
-  - label: ':key: Que Ruby 2.6 tests'
+  - label: ':key: Que 0.14 Ruby 2.6 tests'
     timeout_in_minutes: 30
     plugins:
       docker-compose#v3.1.0:
@@ -935,10 +941,11 @@ steps:
         command: ['features/que.feature', '--tags', 'not @wip']
     env:
       RUBY_TEST_VERSION: '2.6'
+      QUE_VERSION: '0.14'
     concurrency: 4
     concurrency_group: 'ruby/integrations-maze-runner-tests'
 
-  - label: ':key: Que Ruby 2.7 tests'
+  - label: ':key: Que 0.14 Ruby 2.7 tests'
     timeout_in_minutes: 30
     plugins:
       docker-compose#v3.1.0:
@@ -947,10 +954,11 @@ steps:
         command: ['features/que.feature', '--tags', 'not @wip']
     env:
       RUBY_TEST_VERSION: '2.7'
+      QUE_VERSION: '0.14'
     concurrency: 4
     concurrency_group: 'ruby/integrations-maze-runner-tests'
 
-  - label: ':key: Que Ruby 3.0 tests'
+  - label: ':key: Que 0.14 Ruby 3.0 tests'
     timeout_in_minutes: 30
     plugins:
       docker-compose#v3.1.0:
@@ -958,7 +966,8 @@ steps:
         use-aliases: true
         command: ['features/que.feature', '--tags', 'not @wip']
     env:
-      RUBY_TEST_VERSION: "3.0"
+      RUBY_TEST_VERSION: '3.0'
+      QUE_VERSION: '0.14'
     concurrency: 4
     concurrency_group: 'ruby/integrations-maze-runner-tests'
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,7 @@ services:
       RAILS_VERSION:
       RACK_VERSION:
       SIDEKIQ_VERSION:
+      QUE_VERSION:
       RUBY_TEST_VERSION:
       VERBOSE:
       DEBUG:

--- a/features/fixtures/docker-compose.yml
+++ b/features/fixtures/docker-compose.yml
@@ -375,6 +375,7 @@ services:
       context: que
       args:
         - RUBY_TEST_VERSION
+        - QUE_VERSION
     depends_on:
       - postgres
     environment:

--- a/features/fixtures/que/Dockerfile
+++ b/features/fixtures/que/Dockerfile
@@ -6,6 +6,10 @@ COPY temp-bugsnag-lib ./
 
 WORKDIR /usr/src/app
 COPY app/Gemfile /usr/src/app/
+
+ARG QUE_VERSION
+ENV QUE_VERSION $QUE_VERSION
+
 RUN bundle install
 
 COPY app/ /usr/src/app

--- a/features/fixtures/que/app/Gemfile
+++ b/features/fixtures/que/app/Gemfile
@@ -2,7 +2,8 @@ source "https://rubygems.org"
 
 gem "bugsnag", path: "/bugsnag"
 
-gem "que", "~> 0.14.3"
+que_version = ENV.fetch("QUE_VERSION")
+gem "que", "~> #{que_version}"
 
 gem "pg", RUBY_VERSION < "2.2.0" ? "0.21.0" : "> 0.21.0"
 gem "activerecord", RUBY_VERSION < "2.2.0" ? "4.2.11" : "> 4.2.11"

--- a/features/que.feature
+++ b/features/que.feature
@@ -10,6 +10,7 @@ Scenario: Que will deliver unhandled errors
   And the event "severityReason.type" equals "unhandledExceptionMiddleware"
   And the event "severityReason.attributes.framework" equals "Que"
   And the event "app.type" equals "que"
+  And the event "device.runtimeVersions.que" matches the current Que version
   And the exception "errorClass" equals "RuntimeError"
 
 Scenario: Que will deliver handled errors
@@ -21,4 +22,5 @@ Scenario: Que will deliver handled errors
   And the event "severity" equals "warning"
   And the event "severityReason.type" equals "handledException"
   And the event "app.type" equals "que"
+  And the event "device.runtimeVersions.que" matches the current Que version
   And the exception "errorClass" equals "RuntimeError"

--- a/features/steps/ruby_notifier_steps.rb
+++ b/features/steps/ruby_notifier_steps.rb
@@ -15,7 +15,6 @@ Then(/^the total sessionStarted count equals (\d+)$/) do |value|
   assert_equal(value, total_count)
 end
 
-
 # Due to an ongoing discussion on whether the `payload_version` needs to be present within the headers
 # and body of the payload, this step is a local replacement for the similar step present in the main
 # maze-runner library. Once the discussion is resolved this step should be removed and replaced in scenarios

--- a/features/steps/ruby_notifier_steps.rb
+++ b/features/steps/ruby_notifier_steps.rb
@@ -195,3 +195,13 @@ Then("in Rails versions {string} {int} the event {string} is a timestamp") do |o
     }
   end
 end
+
+Then("the event {string} matches the current Que version") do |path|
+  # append a '.' to make this assertion stricter, e.g. if QUE_VERSION is '1'
+  # we'll use '1.'
+  que_version = ENV.fetch("QUE_VERSION") + "."
+
+  steps %Q{
+    And the event "#{path}" starts with "#{que_version}"
+  }
+end


### PR DESCRIPTION
## Goal

Adds tests with the recently released Que 1.0 to CI. This uses the same fixture as Que 0.14 with an environment variable to control the version of Que we install