### PR TITLE
Fix optional group definitions in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,28 +40,32 @@ group :coverage, optional: true do
   gem 'coveralls'
 end
 
-group :rubocop, optional: true do
-  gem 'rubocop', '~> 1.0.0'
+if ruby_version >= Gem::Version.new('2.4.0')
+  group :rubocop, optional: true do
+    gem 'rubocop', '~> 1.0.0'
+  end
 end
 
-group :sidekiq, optional: true do
-  gem 'sidekiq', '~> 5.2.7'
+if ruby_version >= Gem::Version.new('2.2.0')
+  group :sidekiq, optional: true do
+    gem 'sidekiq', '~> 5.2.7'
 
-  if ruby_version < Gem::Version.new('2.3.0')
-    # redis 4.1.2 dropped support for Ruby 2.2
-    gem 'redis', '4.1.1'
-  elsif ruby_version < Gem::Version.new('2.4.0')
-    # redis 4.5.0 dropped support for Ruby 2.3
-    gem 'redis', '< 4.5.0'
-  else
-    gem 'redis'
+    if ruby_version < Gem::Version.new('2.3.0')
+      # redis 4.1.2 dropped support for Ruby 2.2
+      gem 'redis', '4.1.1'
+    elsif ruby_version < Gem::Version.new('2.4.0')
+      # redis 4.5.0 dropped support for Ruby 2.3
+      gem 'redis', '< 4.5.0'
+    else
+      gem 'redis'
+    end
+
+    # rack 2.2.0 dropped support for Ruby 2.2
+    gem 'rack', ruby_version < Gem::Version.new('2.3.0') ? '< 2.2.0' : '~> 2.2'
+
+    # rack-protection 3.0.0 requires Ruby 2.6+
+    gem 'rack-protection', '< 3.0.0' if ruby_version < Gem::Version.new('2.6.0')
   end
-
-  # rack 2.2.0 dropped support for Ruby 2.2
-  gem 'rack', ruby_version < Gem::Version.new('2.3.0') ? '< 2.2.0' : '~> 2.2'
-
-  # rack-protection 3.0.0 requires Ruby 2.6+
-  gem 'rack-protection', '< 3.0.0' if ruby_version < Gem::Version.new('2.6.0')
 end
 
 gemspec


### PR DESCRIPTION
## Goal

We define a number of optional groups in our Gemfile for various purposes (test dependencies, rubocop etc&hellip;) but the definition is broken on older rubies using non-legacy versions of Bundler

Bundler _should_ always check dependency resolution with all optional groups, even when not actually installing them. However on old versions this check didn't happen, which is intuitive but wrong

We were depending on the broken behaviour of older Bundler versions to get our tests to run on old Ruby versions. Instead, we should be upfront about these groups not installing on old Rubies by not defining them unless they will resolve

This allows us to use more up-to-date Bundler versions on old Rubies, instead of hard-coding a super old version with broken behaviour