### PR TITLE
Move specs, linting & license auditing to GH Actions

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -13,36 +13,6 @@ steps:
 
   - wait
 
-  - label: ':ruby: Ruby 1.9 unit tests'
-    timeout_in_minutes: 30
-    plugins:
-      docker-compose#v3.1.0:
-        run: ruby-unit-tests
-        use-aliases: true
-    env:
-      RUBY_TEST_VERSION: "1.9.3"
-      BUNDLE_VERSION: "1.12.0"
-
-  - label: ':ruby: Ruby 2.7 unit tests'
-    timeout_in_minutes: 30
-    plugins:
-      docker-compose#v3.1.0:
-        run: ruby-unit-tests
-        use-aliases: true
-    env:
-      RUBY_TEST_VERSION: "2.7"
-      GEMSETS: "test sidekiq coverage"
-  - label: ':ruby: Ruby 2.7 linting'
-    timeout_in_minutes: 30
-    plugins:
-      docker-compose#v3.1.0:
-        run: ruby-unit-tests
-        use-aliases: true
-    env:
-      RUBY_TEST_VERSION: "2.7"
-      GEMSETS: "test rubocop"
-    command: "bundle exec ./bin/rubocop lib/"
-
   - label: ':ruby: Ruby 2.7 plain tests'
     timeout_in_minutes: 30
     plugins:
@@ -107,76 +77,6 @@ steps:
       SIDEKIQ_VERSION: "6"
 
   - wait
-
-  - label: ':ruby: JRuby unit tests'
-    timeout_in_minutes: 30
-    plugins:
-      docker-compose#v3.1.0:
-        run: jruby-unit-tests
-        use-aliases: true
-    concurrency: 4
-    concurrency_group: 'ruby/unit-tests'
-
-  - label: ':ruby: Ruby {{matrix}} unit tests'
-    matrix:
-      - '2.0'
-      - '2.1'
-    timeout_in_minutes: 30
-    plugins:
-      docker-compose#v3.1.0:
-        run: ruby-unit-tests
-        use-aliases: true
-    env:
-      RUBY_TEST_VERSION: "{{matrix}}"
-      BUNDLE_VERSION: "1.12.0"
-    concurrency: 4
-    concurrency_group: 'ruby/unit-tests'
-
-  - label: ':ruby: Ruby {{matrix}} unit tests'
-    matrix:
-      - '2.2'
-      - '2.3'
-    timeout_in_minutes: 30
-    plugins:
-      docker-compose#v3.1.0:
-        run: ruby-unit-tests
-        use-aliases: true
-    env:
-      RUBY_TEST_VERSION: "{{matrix}}"
-      BUNDLE_VERSION: "1.12.0"
-      GEMSETS: "test sidekiq"
-    concurrency: 4
-    concurrency_group: 'ruby/unit-tests'
-
-  - label: ':ruby: Ruby {{matrix}} unit tests'
-    matrix:
-      - '2.4'
-      - '2.5'
-      - '2.6'
-    timeout_in_minutes: 30
-    plugins:
-      docker-compose#v3.1.0:
-        run: ruby-unit-tests
-        use-aliases: true
-    env:
-      RUBY_TEST_VERSION: "{{matrix}}"
-      GEMSETS: "test sidekiq"
-    concurrency: 4
-    concurrency_group: 'ruby/unit-tests'
-
-  - label: ':ruby: Ruby {{matrix}} unit tests'
-    matrix:
-      - '3.0'
-      - '3.1'
-    timeout_in_minutes: 30
-    plugins:
-      docker-compose#v3.1.0:
-        run: ruby-unit-tests
-        use-aliases: true
-    env:
-      RUBY_TEST_VERSION: "{{matrix}}"
-    concurrency: 4
-    concurrency_group: 'ruby/unit-tests'
 
   - label: ':ruby: Ruby {{matrix}} plain tests'
     matrix:
@@ -490,9 +390,3 @@ steps:
       RACK_VERSION: '2'
     concurrency: 4
     concurrency_group: 'ruby/integrations-maze-runner-tests'
-
-  - name: ':copyright: License Audit'
-    plugins:
-      docker-compose#v3.7.0:
-        run: license_finder
-    command: /bin/bash -lc '/scan/scripts/license_finder.sh'

--- a/.github/workflows/license-audit.yml
+++ b/.github/workflows/license-audit.yml
@@ -1,0 +1,24 @@
+name: license audit
+
+on: [push, pull_request]
+
+jobs:
+  license-audit:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: fetch decisions.yml
+        run: |
+          curl https://raw.githubusercontent.com/bugsnag/license-audit/master/config/decision_files/global.yml -o config/decisions.yml
+          curl https://raw.githubusercontent.com/bugsnag/license-audit/master/config/decision_files/bugsnag-ruby.yml >> config/decisions.yml
+
+      - name: run license finder
+        # for some reason license finder doesn't run without a login shell (-l)
+        run: >
+          docker run -v $PWD:/scan licensefinder/license_finder /bin/bash -lc "
+            cd /scan &&
+            bundle install &&
+            license_finder --decisions-file config/decisions.yml
+          "

--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -32,3 +32,20 @@ jobs:
       - run: bundle install --with "${{ matrix.optional-groups }}" --binstubs
 
       - run: ./bin/rake spec
+
+  linting:
+    runs-on: ubuntu-latest
+
+    env:
+      BUNDLE_WITH: rubocop
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: install Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.7
+          bundler-cache: true
+
+      - run: bundle exec rubocop lib/

--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -1,0 +1,34 @@
+name: test
+
+on: [push, pull_request]
+
+jobs:
+  specs:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby-version: ['2.2', '2.3', '2.4', '2.5', '2.6', '2.7', '3.0', '3.1']
+        optional-groups: ['test sidekiq']
+        include:
+          - ruby-version: '1.9'
+            optional-groups: 'test'
+          - ruby-version: '2.0'
+            optional-groups: 'test'
+          - ruby-version: '2.1'
+            optional-groups: 'test'
+          - ruby-version: 'jruby'
+            optional-groups: 'test'
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: install Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby-version }}
+
+      - run: bundle install --with "${{ matrix.optional-groups }}" --binstubs
+
+      - run: ./bin/rake spec

--- a/dockerfiles/Dockerfile.audit
+++ b/dockerfiles/Dockerfile.audit
@@ -1,5 +1,0 @@
-FROM licensefinder/license_finder
-
-WORKDIR /scan
-
-CMD /scan/scripts/license_finder.sh

--- a/scripts/license_finder.sh
+++ b/scripts/license_finder.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-curl https://raw.githubusercontent.com/bugsnag/license-audit/master/config/decision_files/global.yml -o config/decisions.yml
-curl https://raw.githubusercontent.com/bugsnag/license-audit/master/config/decision_files/bugsnag-ruby.yml >> config/decisions.yml
-
-bundle install
-license_finder --decisions-file=config/decisions.yml


### PR DESCRIPTION
## Goal

This PR moves all of the non-MazeRunner tests out of Buildkite and into GH Actions, i.e.:

- specs
- linting
- license auditing

I've removed the license auditing docker file and script as it's unused, but the unit test docker files are potentially still useful for running different ruby versions so they're still present

The existing instructions in TESTING.md are still accurate so they haven't been changed