### PR TITLE
Support running maze runner locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ doc
 # bundler
 .bundle
 Gemfile.lock
+Gemfile-maze-runner.lock
 
 # jeweler generated
 pkg

--- a/Gemfile-maze-runner
+++ b/Gemfile-maze-runner
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v3.0.2'

--- a/TESTING.md
+++ b/TESTING.md
@@ -29,30 +29,12 @@ End to end tests are written in cucumber-style `.feature` files, and need Ruby-b
 
 Maze runner's CLI and the test fixtures are containerised so you'll need Docker (and Docker Compose) to run them.
 
-__Note: only Bugsnag employees can run the end-to-end tests.__ We have dedicated test infrastructure and private BrowserStack credentials which can't be shared outside of the organisation.
-
-##### Authenticating with the private container registry
-
-You'll need to set the credentials for the aws profile in order to access the private docker registry:
-
-```
-aws configure --profile=opensource
-```
-
-Subsequently you'll need to run the following commmand to authenticate with the registry:
-
-```
-aws ecr get-login-password --profile=opensource | docker login --username AWS --password-stdin 855461928731.dkr.ecr.us-west-1.amazonaws.com
-```
-
-__Your session will periodically expire__, so you'll need to run this command to re-authenticate when that happens.
-
 ### Running the end to end tests
 
-Once registered with the remote repository, build the test container:
+Install Maze Runner:
 
 ```
-docker-compose build ruby-maze-runner
+$ BUNDLE_GEMFILE=Gemfile-maze-runner bundle install
 ```
 
 Configure the tests to be run in the following way:
@@ -61,10 +43,13 @@ Configure the tests to be run in the following way:
 - If testing rails, set the rails version to be tested using the environment variable `RAILS_VERSION` e.g. `RAILS_VERSION=3`
 - If testing sidekiq, set the version to be tested using the environment variable `SIDEKIQ_VERSION`,  e.g. `SIDEKIQ_VERSION=2`
 
-When running the end-to-end tests, you'll want to restrict the feature files run to the specific test features for the platform.  This is done using the Cucumber CLI syntax at the end of the `docker-compose run ruby-maze-runner` command, i.e:
+When running the end-to-end tests, you'll want to restrict the feature files run to the specific test features for the platform.  This is done using the Cucumber CLI syntax, i.e:
 
 ```
-RUBY_TEST_VERSION=2.6 RAILS_VERSION=6 docker-compose run --use-aliases ruby-maze-runner features/rails_features --tags "@rails6"
+RUBY_TEST_VERSION=2.6 \
+  RAILS_VERSION=6 \
+  BUNDLE_GEMFILE=Gemfile-maze-runner \
+  bundle exec maze-runner features/rails_features --tags "@rails6"
 ```
 
 - Plain ruby tests should target `features/plain_features`
@@ -75,7 +60,10 @@ RUBY_TEST_VERSION=2.6 RAILS_VERSION=6 docker-compose run --use-aliases ruby-maze
 In order to target specific features the exact `.feature` file can be specified, i.e:
 
 ```
-RUBY_TEST_VERSION=2.6 RAILS_VERSION=6 docker-compose run --use-aliases ruby-maze-runner features/rails_features/app_version.feature --tags "@rails6"
+RUBY_TEST_VERSION=2.6 \
+  RAILS_VERSION=6 \
+  BUNDLE_GEMFILE=Gemfile-maze-runner \
+  bundle exec maze-runner features/rails_features/app_version.feature --tags "@rails6"
 ```
 
 In order to avoid running flakey or unfinished tests, the tag `"not @wip"` can be added to the tags option. This is recommended for all CI runs. If a tag is already specified, this should be added using the `and` keyword, e.g. `--tags "@rails6 and not @wip"`

--- a/features/fixtures/docker-compose.yml
+++ b/features/fixtures/docker-compose.yml
@@ -88,6 +88,9 @@ services:
       - BUGSNAG_ENDPOINT
       - BUGSNAG_METADATA_FILTERS
     restart: "no"
+    ports:
+      - target: 3000
+        published: 7251
 
   rack2:
     build:
@@ -99,6 +102,9 @@ services:
       - BUGSNAG_ENDPOINT
       - BUGSNAG_METADATA_FILTERS
     restart: "no"
+    ports:
+      - target: 3000
+        published: 7252
 
   rails3:
     build:
@@ -134,6 +140,9 @@ services:
       - USE_DEFAULT_AUTO_CAPTURE_SESSIONS
       - ADD_REQUEST_ON_ERROR
     restart: "no"
+    ports:
+      - target: 3000
+        published: 7253
 
   rails4:
     build:
@@ -171,6 +180,9 @@ services:
       - USE_DEFAULT_AUTO_CAPTURE_SESSIONS
       - ADD_REQUEST_ON_ERROR
     restart: "no"
+    ports:
+      - target: 3000
+        published: 7254
 
   rails5:
     build:
@@ -208,6 +220,9 @@ services:
       - USE_DEFAULT_AUTO_CAPTURE_SESSIONS
       - ADD_REQUEST_ON_ERROR
     restart: "no"
+    ports:
+      - target: 3000
+        published: 7255
 
   rails6:
     build:
@@ -249,6 +264,9 @@ services:
       default:
         aliases:
           - rails6
+    ports:
+      - target: 3000
+        published: 7256
 
   rails7:
     build:
@@ -290,6 +308,9 @@ services:
       default:
         aliases:
           - rails7
+    ports:
+      - target: 3000
+        published: 7257
 
   rails_integrations:
     build:

--- a/features/fixtures/rails6/app/config/environments/rails_env.rb
+++ b/features/fixtures/rails6/app/config/environments/rails_env.rb
@@ -53,4 +53,5 @@ Rails.application.configure do
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
   config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
   config.hosts << "rails6"
+  config.hosts << "localhost"
 end

--- a/features/lib/fixture.rb
+++ b/features/lib/fixture.rb
@@ -1,0 +1,94 @@
+class Fixture
+  def initialize(name, version)
+    @name = name
+    @version = version
+  end
+
+  def docker_service
+    "#{@name}#{@version}"
+  end
+
+  def host
+    if running_in_docker?
+      docker_service
+    else
+      "localhost"
+    end
+  end
+
+  def port
+    # the rails integrations tests run with a version of "_integrations" and
+    # bind to port 3000 even when running outside of docker
+    if running_in_docker? || @version == "_integrations"
+      "3000"
+    else
+      "725#{@version}"
+    end
+  end
+
+  def version_matches?(operator, version_to_compare)
+    @version.to_i.send(operator, version_to_compare)
+  end
+
+  def uri_for(route)
+    URI("http://#{host}:#{port}#{route}")
+  end
+
+  def navigate_to(route, headers = {})
+    uri = uri_for(route)
+
+    make_request(uri) do |http|
+      request = Net::HTTP::Get.new(uri.request_uri)
+
+      headers.each do |key, value|
+        request[key] = value
+      end
+
+      request
+    end
+  end
+
+  def post_form(route, form_data)
+    uri = uri_for(route)
+
+    make_request(uri) do |http|
+      request = Net::HTTP::Post.new(uri)
+      request.set_form_data(form_data)
+
+      request
+    end
+  end
+
+  def post_json(route, json_data)
+    uri = uri_for(route)
+
+    make_request(uri) do |http|
+      request = Net::HTTP::Post.new(uri)
+      request.body = JSON.generate(json_data)
+      request["Content-Type"] = "application/json"
+
+      request
+    end
+  end
+
+  private
+
+  def make_request(uri, &block)
+    attempts = 0
+
+    begin
+      Net::HTTP.start(uri.host, uri.port) do |http|
+        request = block.call(http)
+
+        http.request(request)
+      end
+    rescue => e
+      raise e if attempts > 10
+
+      attempts += 1
+      sleep 1
+
+      retry
+    end
+  end
+end

--- a/features/plain_features/proxies.feature
+++ b/features/plain_features/proxies.feature
@@ -1,24 +1,21 @@
 Feature: proxy configuration options
 
 Scenario: Proxy settings are provided as configuration options
-  When I set environment variable "BUGSNAG_PROXY_HOST" to "maze-runner"
-  And I set environment variable "BUGSNAG_PROXY_PORT" to "9339"
-  And I set environment variable "BUGSNAG_PROXY_USER" to "tester"
-  And I set environment variable "BUGSNAG_PROXY_PASSWORD" to "testpass"
+  Given I configure the BUGSNAG_PROXY environment variables
   When I run the service "plain-ruby" with the command "bundle exec ruby configuration/proxy.rb"
   Then I wait to receive a request
   And the "proxy-authorization" header equals "Basic dGVzdGVyOnRlc3RwYXNz"
   And the event "metaData.proxy.user" equals "tester"
 
 Scenario: Proxy settings are provided as the HTTP_PROXY environment variable
-  Given I set environment variable "http_proxy" to "http://tester:testpass@maze-runner:9339"
+  Given I configure the http_proxy environment variable
   When I run the service "plain-ruby" with the command "bundle exec ruby configuration/proxy.rb"
   Then I wait to receive a request
   And the "proxy-authorization" header equals "Basic dGVzdGVyOnRlc3RwYXNz"
   And the event "metaData.proxy.user" equals "tester"
 
 Scenario: Proxy settings are provided as the HTTPS_PROXY environment variable
-  Given I set environment variable "https_proxy" to "http://tester:testpass@maze-runner:9339"
+  Given I configure the https_proxy environment variable
   When I run the service "plain-ruby" with the command "bundle exec ruby configuration/proxy.rb"
   Then I wait to receive a request
   And the "proxy-authorization" header equals "Basic dGVzdGVyOnRlc3RwYXNz"

--- a/features/steps/ruby_notifier_steps.rb
+++ b/features/steps/ruby_notifier_steps.rb
@@ -40,24 +40,14 @@ Then("the request is valid for the error reporting API version {string} for the 
 end
 
 Given("I start the rails service") do
-  rails_version = ENV["RAILS_VERSION"]
   steps %Q{
-    When I start the service "rails#{rails_version}"
-    And I wait for the host "rails#{rails_version}" to open port "3000"
+    When I start the service "#{RAILS_FIXTURE.docker_service}"
+    And I wait for the host "#{RAILS_FIXTURE.host}" to open port "#{RAILS_FIXTURE.port}"
   }
 end
 
-# When running tests against Rails on Ruby 3, the base Maze Runner step
-# "I open the url {string}" commonly flakes due to a "Errno::ECONNREFUSED"
-# error, which MR doesn't rescue. The notifier request is still fired so the
-# test passes when these errors are rescued and there's no risk of swallowing an
-# actual failure because any assertion steps will fail if the notifier request
-# isn't fired. This may become unnecessary in future, when running Rails on
-# Ruby 3 is more stable
 When("I navigate to the route {string} on the rails app") do |route|
-  URI.open("http://rails#{ENV["RAILS_VERSION"]}:3000#{route}", &:read)
-rescue => e
-  $logger.debug(e.inspect)
+  RAILS_FIXTURE.navigate_to(route)
 end
 
 When("I run {string} in the rails app") do |command|
@@ -79,49 +69,29 @@ When("I run {string} with the rails runner") do |code|
 end
 
 Given("I start the rack service") do
-  rack_version = ENV["RACK_VERSION"]
   steps %Q{
-    When I start the service "rack#{rack_version}"
-    And I wait for the host "rack#{rack_version}" to open port "3000"
+    When I start the service "#{RACK_FIXTURE.docker_service}"
+    And I wait for the host "#{RACK_FIXTURE.host}" to open port "#{RACK_FIXTURE.port}"
   }
 end
 
 When("I navigate to the route {string} on the rack app") do |route|
-  rack_version = ENV["RACK_VERSION"]
-  steps %Q{
-    When I open the URL "http://rack#{rack_version}:3000#{route}"
-  }
+  RACK_FIXTURE.navigate_to(route)
 end
 
 When("I navigate to the route {string} on the rack app with these cookies:") do |route, data|
-  rack_version = ENV["RACK_VERSION"]
-  uri = URI("http://rack#{rack_version}:3000#{route}")
-
   # e.g. { "a" => "b", "c" => "d" } -> "a=b;c=d"
   cookie = data.rows_hash.map { |key, value| "#{key}=#{value}" }.join(";")
 
-  http = Net::HTTP.new(uri.host, uri.port)
-  request = Net::HTTP::Get.new(uri.request_uri)
-  request["Cookie"] = cookie
-
-  http.request(request)
+  RACK_FIXTURE.navigate_to(route, { "Cookie" => cookie })
 end
 
 When("I send a POST request to {string} in the rack app with the following form data:") do |route, data|
-  rack_version = ENV["RACK_VERSION"]
-  uri = URI("http://rack#{rack_version}:3000#{route}")
-
-  Net::HTTP.post_form(uri, data.rows_hash)
+  RACK_FIXTURE.post_form(route, data.rows_hash)
 end
 
 When("I send a POST request to {string} in the rack app with the following JSON:") do |route, data|
-  rack_version = ENV["RACK_VERSION"]
-
-  Net::HTTP.post(
-    URI("http://rack#{rack_version}:3000#{route}"),
-    JSON.generate(data.rows_hash),
-    { "Content-Type" => "application/json" }
-  )
+  RACK_FIXTURE.post_json(route, data.rows_hash)
 end
 
 Then("the payload field {string} matches the appropriate Sidekiq handled payload") do |field|
@@ -142,14 +112,8 @@ Then("the payload field {string} matches the appropriate Sidekiq unhandled paylo
   }
 end
 
-def rails_version_matches?(operator, version_to_compare)
-  # send the given operator as a method to the current rails version
-  # this will evaluate to e.g. '6.send(">=", 5)', which is the same as '6 >= 5'
-  ENV["RAILS_VERSION"].to_i.send(operator, version_to_compare)
-end
-
 Then("in Rails versions {string} {int} the event {string} equals {string}") do |operator, version, path, expected|
-  if rails_version_matches?(operator, version)
+  if RAILS_FIXTURE.version_matches?(operator, version)
     steps %Q{
       And the event "#{path}" equals "#{expected}"
     }
@@ -161,7 +125,7 @@ Then("in Rails versions {string} {int} the event {string} equals {string}") do |
 end
 
 Then("in Rails versions {string} {int} the event {string} equals {int}") do |operator, version, path, expected|
-  if rails_version_matches?(operator, version)
+  if RAILS_FIXTURE.version_matches?(operator, version)
     steps %Q{
       And the event "#{path}" equals #{expected}
     }
@@ -173,7 +137,7 @@ Then("in Rails versions {string} {int} the event {string} equals {int}") do |ope
 end
 
 Then("in Rails versions {string} {int} the event {string} matches {string}") do |operator, version, path, expected|
-  if rails_version_matches?(operator, version)
+  if RAILS_FIXTURE.version_matches?(operator, version)
     steps %Q{
       And the event "#{path}" matches "#{expected}"
     }
@@ -185,7 +149,7 @@ Then("in Rails versions {string} {int} the event {string} matches {string}") do 
 end
 
 Then("in Rails versions {string} {int} the event {string} is a timestamp") do |operator, version, path|
-  if rails_version_matches?(operator, version)
+  if RAILS_FIXTURE.version_matches?(operator, version)
     steps %Q{
       And the event "#{path}" is a timestamp
     }
@@ -203,5 +167,32 @@ Then("the event {string} matches the current Que version") do |path|
 
   steps %Q{
     And the event "#{path}" starts with "#{que_version}"
+  }
+end
+
+Given("I configure the BUGSNAG_PROXY environment variables") do
+  host = running_in_docker? ? "maze-runner" : current_ip
+
+  steps %Q{
+    When I set environment variable "BUGSNAG_PROXY_HOST" to "#{host}"
+    And I set environment variable "BUGSNAG_PROXY_PORT" to "#{MOCK_API_PORT}"
+    And I set environment variable "BUGSNAG_PROXY_USER" to "tester"
+    And I set environment variable "BUGSNAG_PROXY_PASSWORD" to "testpass"
+  }
+end
+
+Given("I configure the http_proxy environment variable") do
+  host = running_in_docker? ? "maze-runner" : current_ip
+
+  steps %Q{
+    Given I set environment variable "http_proxy" to "http://tester:testpass@#{host}:#{MOCK_API_PORT}"
+  }
+end
+
+Given("I configure the https_proxy environment variable") do
+  host = running_in_docker? ? "maze-runner" : current_ip
+
+  steps %Q{
+    Given I set environment variable "https_proxy" to "https://tester:testpass@#{host}:#{MOCK_API_PORT}"
   }
 end

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -1,15 +1,43 @@
+require 'os'
 require 'fileutils'
+require_relative "./../lib/fixture"
+
+RACK_FIXTURE = Fixture.new("rack", ENV["RACK_VERSION"])
+RAILS_FIXTURE = Fixture.new("rails", ENV["RAILS_VERSION"])
+
+def running_in_docker?
+  File.exist?("/app/bugsnag.gem")
+end
 
 def install_fixture_gems
-  throw Error.new("Bugsnag.gem not found. Is this running in a docker-container?") unless File.exist?("/app/bugsnag.gem")
+  if running_in_docker?
+    # running in docker so the gem is built already
+    bugsnag_gem_path = "/app/bugsnag.gem"
+  else
+    # running locally so we need to build the gem
+    `gem build bugsnag.gemspec -o bugsnag.gem`
+    bugsnag_gem_path = "#{__dir__}/../../bugsnag.gem"
+  end
+
   Dir.entries('features/fixtures').reject { |entry| ['.', '..'].include?(entry) }.each do |entry|
     target_dir = "features/fixtures/#{entry}"
     if File.directory?(target_dir)
-      `cp /app/bugsnag.gem #{target_dir}`
+      `cp #{bugsnag_gem_path} #{target_dir}`
       `gem unpack #{target_dir}/bugsnag.gem --target #{target_dir}/temp-bugsnag-lib`
     end
   end
+ensure
+  File.unlink(bugsnag_gem_path) unless running_in_docker?
 end
+
+def current_ip
+  return "host.docker.internal" if OS.mac?
+
+  ip_addr = `ifconfig | grep -Eo 'inet (addr:)?([0-9]*\\\.){3}[0-9]*' | grep -v '127.0.0.1'`
+  ip_list = /((?:[0-9]*\.){3}[0-9]*)/.match(ip_addr)
+  ip_list.captures.first
+end
+
 
 AfterConfiguration do |config|
   install_fixture_gems
@@ -19,5 +47,10 @@ Before do
   Docker.compose_project_name = "#{rand.to_s}:#{Time.new.strftime("%s")}"
   Runner.environment.clear
   Runner.environment["BUGSNAG_API_KEY"] = $api_key
-  Runner.environment["BUGSNAG_ENDPOINT"] = "http://maze-runner:#{MOCK_API_PORT}"
+
+  if running_in_docker?
+    Runner.environment["BUGSNAG_ENDPOINT"] = "http://maze-runner:#{MOCK_API_PORT}"
+  else
+    Runner.environment["BUGSNAG_ENDPOINT"] = "http://#{current_ip}:#{MOCK_API_PORT}"
+  end
 end


### PR DESCRIPTION
## Goal

This PR contains various changes to support running Maze Runner locally instead of using the docker image

## Changeset

- the fixtures now publish their port so they are reachable outside of a docker network
- various thing such as the hostname or port of the fixtures now supports both dockerised and local versions (e.g. on docker the host is `rails6` but when running locally it'll be `localhost`)
- when running outside of docker the gem needs to be built, which happens automatically in the `env.rb` file

## Testing

Maze Runner is installed in a separate Gemfile to our other dependencies and can be installed by running:

```sh
$ BUNDLE_GEMFILE=Gemfile-maze-runner bundle install
```

Then Maze Runner can be run by running:

```sh
$ BUNDLE_GEMFILE=Gemfile-maze-runner [other env variables] bundle exec maze-runner [feature files]
```

TESTING.md has been updated with these instructions