### PR TITLE
Add 'payloadVersion' to report body

### DIFF
--- a/lib/bugsnag/report.rb
+++ b/lib/bugsnag/report.rb
@@ -239,6 +239,7 @@ module Bugsnag
           :version => NOTIFIER_VERSION,
           :url => NOTIFIER_URL
         },
+        :payloadVersion => CURRENT_PAYLOAD_VERSION,
         :events => [payload_event]
       }
     end

--- a/spec/report_spec.rb
+++ b/spec/report_spec.rb
@@ -2089,5 +2089,14 @@ describe Bugsnag::Report do
       })
     end
   end
+
+  it "reports the payload version in the header and body" do
+    Bugsnag.notify(BugsnagTestException.new("It crashed"))
+
+    expect(Bugsnag).to(have_sent_notification { |payload, headers|
+      expect(headers["Bugsnag-Payload-Version"]).to eq("4.0")
+      expect(payload["payloadVersion"]).to eq("4.0")
+    })
+  end
 end
 # rubocop:enable Metrics/BlockLength


### PR DESCRIPTION
## Goal

This is currently reported in a header, but the Event API prefers it to be in the request body. Supplying it in both is recommended by the docs: https://bugsnagerrorreportingapi.docs.apiary.io/#reference/0/notify/send-error-reports

<img width="668" alt="image" src="https://user-images.githubusercontent.com/282732/201072335-b94256be-478a-4281-9e19-733894eafc57.png">

The other motivation for this change is to allow the Maze Runner tests to use the built in `the error payload contains the payloadVersion {string}` step, which only supports the payload being the body:

https://github.com/bugsnag/maze-runner/blob/53be8d2e47440832e5b0466bf39db391cfd21c8a/lib/features/steps/error_reporting_steps.rb#L90-L105

We could update Maze Runner to support reading the header as well, but I think ti makes more sense to update the notifier when the body is preferred by the API