### PR TITLE
Update the "plain ruby" tests to use Maze Runner v7

### DIFF
--- a/.github/workflows/maze-runner.yml
+++ b/.github/workflows/maze-runner.yml
@@ -152,3 +152,5 @@ jobs:
     with:
       features: features/plain_features/
       ruby-version: ${{ matrix.ruby-version }}
+      # temporary while we have some tests on Maze Runner v7 and some on v3
+      gemfile: Gemfile-maze-runner-v7

--- a/.github/workflows/run-maze-runner.yml
+++ b/.github/workflows/run-maze-runner.yml
@@ -21,13 +21,18 @@ on:
       sidekiq-version:
         required: false
         type: string
+      # temporary while we have some tests on Maze Runner v7 and some on v3
+      gemfile:
+        required: false
+        type: string
+        default: Gemfile-maze-runner
 
 jobs:
   maze-runner:
     runs-on: ubuntu-latest
 
     env:
-      BUNDLE_GEMFILE: Gemfile-maze-runner
+      BUNDLE_GEMFILE: ${{ inputs.gemfile }}
 
     steps:
       - uses: actions/checkout@v3

--- a/Gemfile-maze-runner-v7
+++ b/Gemfile-maze-runner-v7
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v7.5.1'

--- a/features/plain_features/add_tab.feature
+++ b/features/plain_features/add_tab.feature
@@ -3,8 +3,8 @@ Feature: Plain add tab to metadata
 Scenario Outline: Metadata can be added to a report using add_tab
   Given I set environment variable "CALLBACK_INITIATOR" to "<initiator>"
   When I run the service "plain-ruby" with the command "bundle exec ruby report_modification/add_tab.rb"
-  And I wait to receive a request
-  Then the request is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier"
+  And I wait to receive an error
+  Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
   And the event "metaData.additional_metadata.foo" equals "foo"
   And the event "metaData.additional_metadata.bar.0" equals "b"
   And the event "metaData.additional_metadata.bar.1" equals "a"
@@ -21,8 +21,8 @@ Scenario Outline: Metadata can be added to a report using add_tab
 Scenario Outline: Metadata can be added to an existing tab using add_tab
   Given I set environment variable "CALLBACK_INITIATOR" to "<initiator>"
   When I run the service "plain-ruby" with the command "bundle exec ruby report_modification/add_tab_existing.rb"
-  And I wait to receive a request
-  Then the request is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier"
+  And I wait to receive an error
+  Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
   And the event "metaData.additional_metadata.foo" equals "foo"
   And the event "metaData.additional_metadata.bar.0" equals "b"
   And the event "metaData.additional_metadata.bar.1" equals "a"
@@ -41,8 +41,8 @@ Scenario Outline: Metadata can be added to an existing tab using add_tab
 Scenario Outline: Metadata can be overwritten using add_tab
   Given I set environment variable "CALLBACK_INITIATOR" to "<initiator>"
   When I run the service "plain-ruby" with the command "bundle exec ruby report_modification/add_tab_override.rb"
-  And I wait to receive a request
-  Then the request is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier"
+  And I wait to receive an error
+  Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
   And the event "metaData.additional_metadata.foo" equals "foo"
   And the event "metaData.additional_metadata.bar" equals "bar"
 

--- a/features/plain_features/app_type.feature
+++ b/features/plain_features/app_type.feature
@@ -3,6 +3,6 @@ Feature: App type configuration option
 Scenario: The App type configuration option can be set
   Given I set environment variable "BUGSNAG_APP_TYPE" to "test_app"
   When I run the service "plain-ruby" with the command "bundle exec ruby configuration/send_handled.rb"
-  And I wait to receive a request
-  Then the request is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier"
+  And I wait to receive an error
+  Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
   And the event "app.type" equals "test_app"

--- a/features/plain_features/app_version.feature
+++ b/features/plain_features/app_version.feature
@@ -3,6 +3,6 @@ Feature: App version configuration option
 Scenario: The App version configuration option can be set
   Given I set environment variable "BUGSNAG_APP_VERSION" to "9.9.8"
   When I run the service "plain-ruby" with the command "bundle exec ruby configuration/send_handled.rb"
-  And I wait to receive a request
-  Then the request is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier"
+  And I wait to receive an error
+  Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
   And the event "app.version" equals "9.9.8"

--- a/features/plain_features/auto_notify.feature
+++ b/features/plain_features/auto_notify.feature
@@ -3,5 +3,4 @@ Feature: Auto notify configuration option
 Scenario: When Auto-notify is false notifications are not sent
   Given I set environment variable "BUGSNAG_AUTO_NOTIFY" to "false"
   When I run the service "plain-ruby" with the command "bundle exec ruby configuration/send_unhandled.rb"
-  And I wait for 1 second
   Then I should receive no requests

--- a/features/plain_features/delivery.feature
+++ b/features/plain_features/delivery.feature
@@ -2,19 +2,19 @@ Feature: delivery_method configuration option
 
 Scenario: When the delivery_method is set to :synchronous
   When I run the service "plain-ruby" with the command "bundle exec ruby delivery/synchronous.rb"
-  And I wait to receive a request
-  Then the request is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier"
+  And I wait to receive an error
+  Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
   And the event "metaData.config" matches the JSON fixture in "features/fixtures/plain/json/delivery_synchronous.json"
 
 Scenario: When the delivery_method is set to :thread_queue
   When I run the service "plain-ruby" with the command "bundle exec ruby delivery/threadpool.rb"
-  And I wait to receive a request
-  Then the request is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier"
+  And I wait to receive an error
+  Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
   And the event "metaData.config" matches the JSON fixture in "features/fixtures/plain/json/delivery_threadpool.json"
 
 Scenario: When the delivery_method is set to :thread_queue in a fork
   When I run the service "plain-ruby" with the command "bundle exec ruby delivery/fork_threadpool.rb"
-  And I wait to receive 2 requests
-  Then the request is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier"
+  And I wait to receive 2 errors
+  Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
   And the exception "errorClass" equals "RuntimeError"
   And the event "metaData.config" matches the JSON fixture in "features/fixtures/plain/json/delivery_fork.json"

--- a/features/plain_features/exception_data.feature
+++ b/features/plain_features/exception_data.feature
@@ -2,8 +2,8 @@ Feature: Plain exception data
 
 Scenario Outline: An error has built in meta-data
   When I run the service "plain-ruby" with the command "bundle exec ruby exception_data/<state>_meta_data.rb"
-  And I wait to receive a request
-  Then the request is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier"
+  And I wait to receive an error
+  Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
   And the exception "errorClass" equals "CustomError"
   And the event "metaData.exception.exception_type" equals "FATAL"
   And the event "metaData.exception.exception_base" equals "RuntimeError"
@@ -15,8 +15,8 @@ Scenario Outline: An error has built in meta-data
 
 Scenario Outline: An error has built in context
   When I run the service "plain-ruby" with the command "bundle exec ruby exception_data/<state>_context.rb"
-  And I wait to receive a request
-  Then the request is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier"
+  And I wait to receive an error
+  Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
   And the exception "errorClass" equals "CustomError"
   And the event "context" equals "IntegrationTests"
 
@@ -27,8 +27,8 @@ Scenario Outline: An error has built in context
 
 Scenario Outline: An error has built in grouping hash
   When I run the service "plain-ruby" with the command "bundle exec ruby exception_data/<state>_hash.rb"
-  And I wait to receive a request
-  Then the request is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier"
+  And I wait to receive an error
+  Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
   And the exception "errorClass" equals "CustomError"
   And the event "groupingHash" equals "ABCDE12345"
 
@@ -39,8 +39,8 @@ Scenario Outline: An error has built in grouping hash
 
 Scenario Outline: An error has built in user id
   When I run the service "plain-ruby" with the command "bundle exec ruby exception_data/<state>_user_id.rb"
-  And I wait to receive a request
-  Then the request is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier"
+  And I wait to receive an error
+  Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
   And the exception "errorClass" equals "CustomError"
   And the event "user.id" equals "000001"
 

--- a/features/plain_features/filters.feature
+++ b/features/plain_features/filters.feature
@@ -2,20 +2,20 @@ Feature: Plain filtering of metadata
 
 Scenario: Metadata is filtered through the default filters
   When I run the service "plain-ruby" with the command "bundle exec ruby filters/default_filters.rb"
-  And I wait to receive a request
-  Then the request is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier"
+  And I wait to receive an error
+  Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
   And the event "metaData.filter" matches the JSON fixture in "features/fixtures/plain/json/filters_default_metadata_filters.json"
 
 Scenario: Additional filters can be added to the filter list
   Given I set environment variable "BUGSNAG_META_DATA_FILTERS" to "filter_me"
   When I run the service "plain-ruby" with the command "bundle exec ruby filters/additional_filters.rb"
-  And I wait to receive a request
-  Then the request is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier"
+  And I wait to receive an error
+  Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
   And the event "metaData.filter.filter_me" equals "[FILTERED]"
 
 Scenario: Redacted keys can also be used to filter sensitive data
   Given I set environment variable "BUGSNAG_REDACTED_KEYS" to "filter_me"
   When I run the service "plain-ruby" with the command "bundle exec ruby filters/additional_filters.rb"
-  And I wait to receive a request
-  Then the request is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier"
+  And I wait to receive an error
+  Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
   And the event "metaData.filter.filter_me" equals "[FILTERED]"

--- a/features/plain_features/handled_errors.feature
+++ b/features/plain_features/handled_errors.feature
@@ -2,8 +2,8 @@ Feature: Plain handled errors
 
 Scenario: A rescued exception sends a report
   When I run the service "plain-ruby" with the command "bundle exec ruby handled/notify_exception.rb"
-  And I wait to receive a request
-  Then the request is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier"
+  And I wait to receive an error
+  Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
   And the event "unhandled" is false
   And the event "severity" equals "warning"
   And the event "severityReason.type" equals "handledException"
@@ -14,8 +14,8 @@ Scenario: A rescued exception sends a report
 
 Scenario: A notified string sends a report
   When I run the service "plain-ruby" with the command "bundle exec ruby handled/notify_string.rb"
-  And I wait to receive a request
-  Then the request is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier"
+  And I wait to receive an error
+  Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
   And the event "unhandled" is false
   And the event "severity" equals "warning"
   And the event "severityReason.type" equals "handledException"
@@ -26,13 +26,12 @@ Scenario: A notified string sends a report
 
 Scenario: A handled error doesn't send a report when the :skip_bugsnag flag is set
   When I run the service "plain-ruby" with the command "bundle exec ruby handled/ignore_exception.rb"
-  And I wait for 1 second
   Then I should receive no requests
 
 Scenario: A handled error can attach metadata in a block
   When I run the service "plain-ruby" with the command "bundle exec ruby handled/block_metadata.rb"
-  And I wait to receive a request
-  Then the request is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier"
+  And I wait to receive an error
+  Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
   And the event "unhandled" is false
   And the event "severity" equals "warning"
   And the event "severityReason.type" equals "handledException"

--- a/features/plain_features/ignore_classes.feature
+++ b/features/plain_features/ignore_classes.feature
@@ -2,7 +2,6 @@ Feature: Plain ignore classes
 
 Scenario Outline: An errors class is in the ignore_classes array
   When I run the service "plain-ruby" with the command "bundle exec ruby ignore_classes/<state>.rb"
-  And I wait for 1 second
   Then I should receive no requests
 
   Examples:

--- a/features/plain_features/ignore_report.feature
+++ b/features/plain_features/ignore_report.feature
@@ -3,7 +3,6 @@ Feature: Plain ignore report
 Scenario Outline: A reports severity can be modified
   Given I set environment variable "CALLBACK_INITIATOR" to "<initiator>"
   When I run the service "plain-ruby" with the command "bundle exec ruby report_modification/ignore_report.rb"
-  And I wait for 1 second
   Then I should receive no requests
 
   Examples:

--- a/features/plain_features/proxies.feature
+++ b/features/plain_features/proxies.feature
@@ -3,20 +3,20 @@ Feature: proxy configuration options
 Scenario: Proxy settings are provided as configuration options
   Given I configure the BUGSNAG_PROXY environment variables
   When I run the service "plain-ruby" with the command "bundle exec ruby configuration/proxy.rb"
-  Then I wait to receive a request
-  And the "proxy-authorization" header equals "Basic dGVzdGVyOnRlc3RwYXNz"
+  Then I wait to receive an error
+  And the error "proxy-authorization" header equals "Basic dGVzdGVyOnRlc3RwYXNz"
   And the event "metaData.proxy.user" equals "tester"
 
 Scenario: Proxy settings are provided as the HTTP_PROXY environment variable
   Given I configure the http_proxy environment variable
   When I run the service "plain-ruby" with the command "bundle exec ruby configuration/proxy.rb"
-  Then I wait to receive a request
-  And the "proxy-authorization" header equals "Basic dGVzdGVyOnRlc3RwYXNz"
+  Then I wait to receive an error
+  And the error "proxy-authorization" header equals "Basic dGVzdGVyOnRlc3RwYXNz"
   And the event "metaData.proxy.user" equals "tester"
 
 Scenario: Proxy settings are provided as the HTTPS_PROXY environment variable
   Given I configure the https_proxy environment variable
   When I run the service "plain-ruby" with the command "bundle exec ruby configuration/proxy.rb"
-  Then I wait to receive a request
-  And the "proxy-authorization" header equals "Basic dGVzdGVyOnRlc3RwYXNz"
+  Then I wait to receive an error
+  And the error "proxy-authorization" header equals "Basic dGVzdGVyOnRlc3RwYXNz"
   And the event "metaData.proxy.user" equals "tester"

--- a/features/plain_features/release_stages.feature
+++ b/features/plain_features/release_stages.feature
@@ -4,15 +4,14 @@ Scenario: Doesn't notify in the wrong release stage
   Given I set environment variable "BUGSNAG_NOTIFY_RELEASE_STAGE" to "stage_one"
   And I set environment variable "BUGSNAG_RELEASE_STAGE" to "stage_two"
   When I run the service "plain-ruby" with the command "bundle exec ruby configuration/send_unhandled.rb"
-  And I wait for 1 second
   Then I should receive no requests
 
 Scenario: Does notify in the correct release stage
   Given I set environment variable "BUGSNAG_NOTIFY_RELEASE_STAGE" to "stage_one"
   And I set environment variable "BUGSNAG_RELEASE_STAGE" to "stage_one"
   When I run the service "plain-ruby" with the command "bundle exec ruby configuration/send_unhandled.rb"
-  And I wait to receive a request
-  Then the request is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier"
+  And I wait to receive an error
+  Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
   And the event "unhandled" is true
   And the event "severity" equals "error"
   And the event "severityReason.type" equals "unhandledException"

--- a/features/plain_features/report_api_key.feature
+++ b/features/plain_features/report_api_key.feature
@@ -3,9 +3,9 @@ Feature: Plain report modify api key
 Scenario Outline: A report can have its api_key modified
   Given I set environment variable "CALLBACK_INITIATOR" to "<initiator>"
   When I run the service "plain-ruby" with the command "bundle exec ruby report_modification/modify_api_key.rb"
-  And I wait to receive a request
-  Then the "Bugsnag-Api-Key" header equals "abcdefghijklmnopqrstuvwxyz123456"
-  And the payload field "apiKey" equals "abcdefghijklmnopqrstuvwxyz123456"
+  And I wait to receive an error
+  Then the error "Bugsnag-Api-Key" header equals "abcdefghijklmnopqrstuvwxyz123456"
+  And the error payload field "apiKey" equals "abcdefghijklmnopqrstuvwxyz123456"
 
   Examples:
   | initiator               |

--- a/features/plain_features/report_severity.feature
+++ b/features/plain_features/report_severity.feature
@@ -3,8 +3,8 @@ Feature: Plain report modify severity
 Scenario Outline: A reports severity can be modified
   Given I set environment variable "CALLBACK_INITIATOR" to "<initiator>"
   When I run the service "plain-ruby" with the command "bundle exec ruby report_modification/modify_severity.rb"
-  And I wait to receive a request
-  Then the request is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier"
+  And I wait to receive an error
+  Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
   And the event "severity" equals "info"
   And the event "severityReason.type" equals "userCallbackSetSeverity"
 

--- a/features/plain_features/report_stack_frames.feature
+++ b/features/plain_features/report_stack_frames.feature
@@ -3,8 +3,8 @@ Feature: Plain report modify stack frames
 Scenario Outline: Stack frames can be removed
   Given I set environment variable "CALLBACK_INITIATOR" to "<initiator>"
   When I run the service "plain-ruby" with the command "bundle exec ruby stack_frame_modification/remove_stack_frame.rb"
-  And I wait to receive a request
-  Then the request is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier"
+  And I wait to receive an error
+  Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
   And the "file" of the top non-bugsnag stackframe equals "/usr/src/app/stack_frame_modification/initiators/<initiator>.rb"
   And the "lineNumber" of stack frame 0 equals <lineNumber>
 
@@ -18,16 +18,16 @@ Scenario Outline: Stack frames can be removed
 Scenario: Stack frames can be removed from a notified string
   Given I set environment variable "CALLBACK_INITIATOR" to "handled_block"
   When I run the service "plain-ruby" with the command "bundle exec ruby stack_frame_modification/remove_stack_frame.rb"
-  And I wait to receive a request
-  Then the request is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier"
+  And I wait to receive an error
+  Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
   And the "file" of the top non-bugsnag stackframe equals "/usr/src/app/stack_frame_modification/initiators/handled_block.rb"
   And the "lineNumber" of the top non-bugsnag stackframe equals 19
 
 Scenario Outline: Stack frames can be marked as in project
   Given I set environment variable "CALLBACK_INITIATOR" to "<initiator>"
   When I run the service "plain-ruby" with the command "bundle exec ruby stack_frame_modification/mark_frames_in_project.rb"
-  And I wait to receive a request
-  Then the request is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier"
+  And I wait to receive an error
+  Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
   And the "file" of stack frame 0 equals "/usr/src/app/stack_frame_modification/initiators/<initiator>.rb"
   And the event "exceptions.0.stacktrace.0.inProject" is null
   And the event "exceptions.0.stacktrace.1.inProject" is true
@@ -44,8 +44,8 @@ Scenario Outline: Stack frames can be marked as in project
 Scenario: Stack frames can be marked as in project with a handled string
   Given I set environment variable "CALLBACK_INITIATOR" to "handled_block"
   And I run the service "plain-ruby" with the command "bundle exec ruby stack_frame_modification/mark_frames_in_project.rb"
-  And I wait to receive a request
-  Then the request is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier"
+  And I wait to receive an error
+  Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
   And the "file" of the top non-bugsnag stackframe equals "/usr/src/app/stack_frame_modification/initiators/handled_block.rb"
   And the event "exceptions.0.stacktrace.0.inProject" is null
   And the event "exceptions.0.stacktrace.1.inProject" is true

--- a/features/plain_features/report_user.feature
+++ b/features/plain_features/report_user.feature
@@ -3,8 +3,8 @@ Feature: Plain report modify user
 Scenario Outline: A report can have a user name, email, and id set
   Given I set environment variable "CALLBACK_INITIATOR" to "<initiator>"
   When I run the service "plain-ruby" with the command "bundle exec ruby report_modification/set_user_details.rb"
-  And I wait to receive a request
-  Then the request is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier"
+  And I wait to receive an error
+  Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
   And the event "user.name" equals "leo testman"
   And the event "user.email" equals "test@test.com"
   And the event "user.id" equals "0001"
@@ -20,8 +20,8 @@ Scenario Outline: A report can have a user name, email, and id set
 Scenario Outline: A report can have custom info set
   Given I set environment variable "CALLBACK_INITIATOR" to "<initiator>"
   And I run the service "plain-ruby" with the command "bundle exec ruby report_modification/set_custom_user_details.rb"
-  And I wait to receive a request
-  Then the request is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier"
+  And I wait to receive an error
+  Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
   And the event "user.type" equals "amateur"
   And the event "user.location" equals "testville"
   And the event "user.details.a" equals "foo"
@@ -38,8 +38,8 @@ Scenario Outline: A report can have custom info set
 Scenario Outline: A report can have its user info removed
   Given I set environment variable "CALLBACK_INITIATOR" to "<initiator>"
   When I run the service "plain-ruby" with the command "bundle exec ruby report_modification/remove_user_details.rb"
-  And I wait to receive a request
-  Then the request is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier"
+  And I wait to receive an error
+  Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
   And the event "user" is null
 
   Examples:

--- a/features/plain_features/unhandled_errors.feature
+++ b/features/plain_features/unhandled_errors.feature
@@ -2,8 +2,8 @@ Feature: Plain unhandled errors
 
 Scenario Outline: An unhandled error sends a report
   Given I run the service "plain-ruby" with the command "<command> unhandled/<file>.rb"
-  And I wait to receive a request
-  Then the request is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier"
+  And I wait to receive an error
+  Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
   And the event "unhandled" is true
   And the event "severity" equals "error"
   And the event "severityReason.type" equals "unhandledException"
@@ -33,7 +33,6 @@ Scenario Outline: An unhandled error sends a report
 
 Scenario Outline: An unhandled error doesn't send a report
   When I run the service "plain-ruby" with the command "<command> unhandled/<file>.rb"
-  And I wait for 1 second
   Then I should receive no requests
 
   Examples:


### PR DESCRIPTION
## Goal

This PR migrates the plain ruby tests to use Maze Runner v7. This required some compatibility code in our custom steps as well as updating the feature files themselves. When all of our tests are running on v7, we can remove the compatibility code