### PR TITLE
Update remaining non-rails maze runner tests to use v7

### DIFF
--- a/.github/workflows/maze-runner.yml
+++ b/.github/workflows/maze-runner.yml
@@ -13,6 +13,8 @@ jobs:
     with:
       features: features/rake.feature
       ruby-version: ${{ matrix.ruby-version }}
+      # temporary while we have some tests on Maze Runner v7 and some on v3
+      gemfile: Gemfile-maze-runner-v7
 
   mailman-maze-runner:
     strategy:

--- a/.github/workflows/maze-runner.yml
+++ b/.github/workflows/maze-runner.yml
@@ -24,6 +24,8 @@ jobs:
     with:
       features: features/mailman.feature
       ruby-version: ${{ matrix.ruby-version }}
+      # temporary while we have some tests on Maze Runner v7 and some on v3
+      gemfile: Gemfile-maze-runner-v7
 
   rack-maze-runner:
     strategy:

--- a/.github/workflows/maze-runner.yml
+++ b/.github/workflows/maze-runner.yml
@@ -78,6 +78,8 @@ jobs:
       features: features/que.feature
       ruby-version: ${{ matrix.ruby-version }}
       que-version: ${{ matrix.que-version }}
+      # temporary while we have some tests on Maze Runner v7 and some on v3
+      gemfile: Gemfile-maze-runner-v7
 
   sidekiq-maze-runner:
     strategy:

--- a/.github/workflows/maze-runner.yml
+++ b/.github/workflows/maze-runner.yml
@@ -97,6 +97,8 @@ jobs:
       features: features/sidekiq.feature
       ruby-version: ${{ matrix.ruby-version }}
       sidekiq-version: ${{ matrix.sidekiq-version }}
+      # temporary while we have some tests on Maze Runner v7 and some on v3
+      gemfile: Gemfile-maze-runner-v7
 
   delayed-job-maze-runner:
     strategy:

--- a/.github/workflows/maze-runner.yml
+++ b/.github/workflows/maze-runner.yml
@@ -100,6 +100,8 @@ jobs:
     with:
       features: features/delayed_job.feature
       ruby-version: ${{ matrix.ruby-version }}
+      # temporary while we have some tests on Maze Runner v7 and some on v3
+      gemfile: Gemfile-maze-runner-v7
 
   rails-3-4-5-maze-runner:
     strategy:

--- a/.github/workflows/maze-runner.yml
+++ b/.github/workflows/maze-runner.yml
@@ -50,6 +50,8 @@ jobs:
       features: features/rack.feature
       ruby-version: ${{ matrix.ruby-version }}
       rack-version: ${{ matrix.rack-version }}
+      # temporary while we have some tests on Maze Runner v7 and some on v3
+      gemfile: Gemfile-maze-runner-v7
 
   que-maze-runner:
     strategy:

--- a/features/delayed_job.feature
+++ b/features/delayed_job.feature
@@ -2,8 +2,8 @@ Feature: Bugsnag detects errors in Delayed job workers
 
 Scenario: An unhandled RuntimeError sends a report with arguments
   Given I run the service "delayed_job" with the command "bundle exec rake delayed_job_tests:fail_with_args"
-  And I wait to receive a request
-  Then the request is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier"
+  And I wait to receive an error
+  Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
   And the event "unhandled" is true
   And the event "severity" equals "error"
   And the event "context" equals "TestModel.fail_with_args"
@@ -17,13 +17,13 @@ Scenario: An unhandled RuntimeError sends a report with arguments
   And the event "metaData.job.max_attempts" equals 1
   And the event "metaData.job.payload.display_name" equals "TestModel.fail_with_args"
   And the event "metaData.job.payload.method_name" equals "fail_with_args"
-  And the payload field "events.0.metaData.job.payload.args.0" equals "Test"
+  And the event "metaData.job.payload.args.0" equals "Test"
   And the event "device.runtimeVersions.delayed_job" matches "\d+\.\d+\.\d+"
 
 Scenario: A handled exception sends a report
   Given I run the service "delayed_job" with the command "bundle exec rake delayed_job_tests:notify_with_args"
-  And I wait to receive a request
-  Then the request is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier"
+  And I wait to receive an error
+  Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
   And the event "unhandled" is false
   And the event "severity" equals "warning"
   And the event "context" equals "TestModel.notify_with_args"
@@ -36,13 +36,13 @@ Scenario: A handled exception sends a report
   And the event "metaData.job.max_attempts" equals 1
   And the event "metaData.job.payload.display_name" equals "TestModel.notify_with_args"
   And the event "metaData.job.payload.method_name" equals "notify_with_args"
-  And the payload field "events.0.metaData.job.payload.args.0" equals "Test"
+  And the event "metaData.job.payload.args.0" equals "Test"
   And the event "device.runtimeVersions.delayed_job" matches "\d+\.\d+\.\d+"
 
 Scenario: The report context uses the class name if no display name is available
   Given I run the service "delayed_job" with the command "bundle exec rake delayed_job_tests:report_context"
-  And I wait to receive a request
-  Then the request is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier"
+  And I wait to receive an error
+  Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
   And the event "unhandled" is true
   And the event "severity" equals "error"
   And the event "context" equals "TestReportContextJob"

--- a/features/fixtures/delayed_job/app/Rakefile
+++ b/features/fixtures/delayed_job/app/Rakefile
@@ -20,9 +20,9 @@ namespace :delayed_job_tests do
 end
 
 def run_delayed_job_test(command)
-  fork do
-    system("rake jobs:work")
-  end
+  # queue the job with rails' runner
   system("rails runner #{command}")
-  Process.wait
+
+  # run the queued jobs and exit
+  system("rake jobs:workoff")
 end

--- a/features/mailman.feature
+++ b/features/mailman.feature
@@ -4,8 +4,8 @@ Scenario: An unhandled RuntimeError sends a report
   Given I set environment variable "TARGET_EMAIL" to "emails/unhandled_error.eml"
   And I set environment variable "APP_PATH" to "/usr/src"
   And I start the service "mailman"
-  And I wait to receive a request
-  Then the request is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier"
+  And I wait to receive an error
+  Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
   And the event "unhandled" is true
   And the event "severity" equals "error"
   And the event "severityReason.type" equals "unhandledExceptionMiddleware"
@@ -17,8 +17,8 @@ Scenario: A handled RuntimeError sends a report
   Given I set environment variable "TARGET_EMAIL" to "emails/handled_error.eml"
   And I set environment variable "APP_PATH" to "/usr/src"
   And I start the service "mailman"
-  And I wait to receive a request
-  Then the request is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier"
+  And I wait to receive an error
+  Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
   And the event "unhandled" is false
   And the event "severity" equals "warning"
   And the event "severityReason.type" equals "handledException"

--- a/features/que.feature
+++ b/features/que.feature
@@ -2,9 +2,9 @@ Feature: Errors are delivered to Bugsnag from Que
 
 Scenario: Que will deliver unhandled errors
   Given I run the service "que" with the command "bundle exec ruby app.rb unhandled"
-  And I run the service "que" with the command "bundle exec que ./app.rb"
-  And I wait to receive a request
-  Then the request is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier"
+  And I run the service "que" with the command "timeout 5 bundle exec que ./app.rb"
+  And I wait to receive an error
+  Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
   And the event "unhandled" is true
   And the event "severity" equals "error"
   And the event "severityReason.type" equals "unhandledExceptionMiddleware"
@@ -15,9 +15,9 @@ Scenario: Que will deliver unhandled errors
 
 Scenario: Que will deliver handled errors
   Given I run the service "que" with the command "bundle exec ruby app.rb handled"
-  And I run the service "que" with the command "bundle exec que ./app.rb"
-  And I wait to receive a request
-  Then the request is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier"
+  And I run the service "que" with the command "timeout 5 bundle exec que ./app.rb"
+  And I wait to receive an error
+  Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
   And the event "unhandled" is false
   And the event "severity" equals "warning"
   And the event "severityReason.type" equals "handledException"

--- a/features/rack.feature
+++ b/features/rack.feature
@@ -3,8 +3,8 @@ Feature: Bugsnag raises errors in Rack
 Scenario: An unhandled RuntimeError sends a report
   Given I start the rack service
   When I navigate to the route "/unhandled?a=123&b=456" on the rack app
-  And I wait to receive a request
-  Then the request is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier"
+  And I wait to receive an error
+  Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
   And the event "unhandled" is true
   And the event "severity" equals "error"
   And the event "severityReason.type" equals "unhandledExceptionMiddleware"
@@ -27,8 +27,8 @@ Scenario: An unhandled RuntimeError sends a report
 Scenario: A handled RuntimeError sends a report
   Given I start the rack service
   When I navigate to the route "/handled?a=123&b=456" on the rack app
-  And I wait to receive a request
-  Then the request is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier"
+  And I wait to receive an error
+  Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
   And the event "unhandled" is false
   And the event "severity" equals "warning"
   And the event "severityReason.type" equals "handledException"
@@ -53,8 +53,8 @@ Scenario: A POST request with form data sends a report with the parsed request b
     | name             | baba      |
     | favourite_letter | z         |
     | password         | password1 |
-  And I wait to receive a request
-  Then the request is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier"
+  And I wait to receive an error
+  Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
   And the event "metaData.request.body.name" equals "baba"
   And the event "metaData.request.body.favourite_letter" equals "z"
   And the event "metaData.request.body.password" equals "[FILTERED]"
@@ -76,8 +76,8 @@ Scenario: A POST request with JSON sends a report with the parsed request body a
     | name             | baba      |
     | favourite_letter | z         |
     | password         | password1 |
-  And I wait to receive a request
-  Then the request is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier"
+  And I wait to receive an error
+  Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
   And the event "metaData.request.body.name" equals "baba"
   And the event "metaData.request.body.favourite_letter" equals "z"
   And the event "metaData.request.body.password" equals "[FILTERED]"
@@ -99,8 +99,8 @@ Scenario: A request with cookies will be filtered out by default
     | a | b |
     | c | d |
     | e | f |
-  And I wait to receive a request
-  Then the request is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier"
+  And I wait to receive an error
+  Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
   And the event "metaData.request.cookie" is null
   And the event "metaData.request.headers.Cookie" equals "[FILTERED]"
   And the event "metaData.request.clientIp" is not null
@@ -121,8 +121,8 @@ Scenario: A request with cookies and no matching filter will set cookies in meta
     | a | b |
     | c | d |
     | e | f |
-  And I wait to receive a request
-  Then the request is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier"
+  And I wait to receive an error
+  Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
   And the event "metaData.request.cookies.a" equals "b"
   And the event "metaData.request.cookies.c" equals "d"
   And the event "metaData.request.cookies.e" equals "f"

--- a/features/rake.feature
+++ b/features/rake.feature
@@ -2,8 +2,8 @@ Feature: Bugsnag raises errors in Rake
 
 Scenario: An unhandled RuntimeError sends a report
   Given I run the service "rake" with the command "bundle exec rake unhandled"
-  And I wait to receive a request
-  Then the request is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier"
+  And I wait to receive an error
+  Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
   And the event "unhandled" is true
   And the event "severity" equals "error"
   And the event "severityReason.type" equals "unhandledExceptionMiddleware"
@@ -13,8 +13,8 @@ Scenario: An unhandled RuntimeError sends a report
 
 Scenario: A handled RuntimeError sends a report
   Given I run the service "rake" with the command "bundle exec rake handled"
-  And I wait to receive a request
-  Then the request is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier"
+  And I wait to receive an error
+  Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
   And the event "unhandled" is false
   And the event "severity" equals "warning"
   And the event "severityReason.type" equals "handledException"

--- a/features/sidekiq.feature
+++ b/features/sidekiq.feature
@@ -1,9 +1,9 @@
 Feature: Bugsnag raises errors in Sidekiq workers
 
 Scenario: An unhandled RuntimeError sends a report
-  Given I run the service "sidekiq" with the command "bundle exec rake sidekiq_tests:unhandled_error"
-  And I wait to receive a request
-  Then the request is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier"
+  Given I run the service "sidekiq" with the command "timeout 5 bundle exec rake sidekiq_tests:unhandled_error"
+  And I wait to receive an error
+  Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
   And the event "unhandled" is true
   And the event "severity" equals "error"
   And the event "context" equals "UnhandledError@default"
@@ -13,38 +13,38 @@ Scenario: An unhandled RuntimeError sends a report
   And the exception "errorClass" equals "RuntimeError"
   And the "file" of stack frame 0 equals "/app/app.rb"
   And the "lineNumber" of stack frame 0 equals 44
-  And the payload field "events.0.metaData.sidekiq" matches the appropriate Sidekiq unhandled payload
+  And the event "metaData.sidekiq" matches the appropriate Sidekiq unhandled payload
   And the event "metaData.sidekiq.msg.created_at" is a parsable timestamp in seconds
   And the event "metaData.sidekiq.msg.enqueued_at" is a parsable timestamp in seconds
   And the event "metaData.config.delivery_method" equals "thread_queue"
 
 Scenario: A handled RuntimeError can be notified
-  Given I run the service "sidekiq" with the command "bundle exec rake sidekiq_tests:handled_error"
-  And I wait to receive a request
-  Then the request is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier"
+  Given I run the service "sidekiq" with the command "timeout 5 bundle exec rake sidekiq_tests:handled_error"
+  And I wait to receive an error
+  Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
   And the event "unhandled" is false
   And the event "context" equals "HandledError@default"
   And the event "severity" equals "warning"
   And the event "severityReason.type" equals "handledException"
   And the event "app.type" equals "sidekiq"
   And the exception "errorClass" equals "RuntimeError"
-  And the payload field "events.0.metaData.sidekiq" matches the appropriate Sidekiq handled payload
+  And the event "metaData.sidekiq" matches the appropriate Sidekiq handled payload
   And the event "metaData.sidekiq.msg.created_at" is a parsable timestamp in seconds
   And the event "metaData.sidekiq.msg.enqueued_at" is a parsable timestamp in seconds
   And the event "metaData.config.delivery_method" equals "thread_queue"
 
 Scenario: Synchronous delivery can be used
   Given I set environment variable "BUGSNAG_DELIVERY_METHOD" to "synchronous"
-  And I run the service "sidekiq" with the command "bundle exec rake sidekiq_tests:handled_error"
-  And I wait to receive a request
-  Then the request is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier"
+  And I run the service "sidekiq" with the command "timeout 5 bundle exec rake sidekiq_tests:handled_error"
+  And I wait to receive an error
+  Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
   And the event "unhandled" is false
   And the event "context" equals "HandledError@default"
   And the event "severity" equals "warning"
   And the event "severityReason.type" equals "handledException"
   And the event "app.type" equals "sidekiq"
   And the exception "errorClass" equals "RuntimeError"
-  And the payload field "events.0.metaData.sidekiq" matches the appropriate Sidekiq handled payload
+  And the event "metaData.sidekiq" matches the appropriate Sidekiq handled payload
   And the event "metaData.sidekiq.msg.created_at" is a parsable timestamp in seconds
   And the event "metaData.sidekiq.msg.enqueued_at" is a parsable timestamp in seconds
   And the event "metaData.config.delivery_method" equals "synchronous"

--- a/features/steps/ruby_notifier_steps.rb
+++ b/features/steps/ruby_notifier_steps.rb
@@ -102,21 +102,21 @@ When("I send a POST request to {string} in the rack app with the following JSON:
   RACK_FIXTURE.post_json(route, data.rows_hash)
 end
 
-Then("the payload field {string} matches the appropriate Sidekiq handled payload") do |field|
+Then("the event {string} matches the appropriate Sidekiq handled payload") do |field|
   # Sidekiq 2 doesn't include the "created_at" field
   created_at_present = ENV["SIDEKIQ_VERSION"] > "2"
 
   steps %Q{
-    And the payload field "#{field}" matches the JSON fixture in "features/fixtures/sidekiq/payloads/handled_metadata_ca_#{created_at_present}.json"
+    And the event "#{field}" matches the JSON fixture in "features/fixtures/sidekiq/payloads/handled_metadata_ca_#{created_at_present}.json"
   }
 end
 
-Then("the payload field {string} matches the appropriate Sidekiq unhandled payload") do |field|
+Then("the event {string} matches the appropriate Sidekiq unhandled payload") do |field|
   # Sidekiq 2 doesn't include the "created_at" field
   created_at_present = ENV["SIDEKIQ_VERSION"] > "2"
 
   steps %Q{
-    And the payload field "#{field}" matches the JSON fixture in "features/fixtures/sidekiq/payloads/unhandled_metadata_ca_#{created_at_present}.json"
+    And the event "#{field}" matches the JSON fixture in "features/fixtures/sidekiq/payloads/unhandled_metadata_ca_#{created_at_present}.json"
   }
 end
 


### PR DESCRIPTION
## Goal

This updates the remaining non-rails maze runner tests to use v7:

- delayed_job
- mailman
- que
- rack
- rake
- sidekiq

Most of the changes are but a couple of the commands that were being run also had to change as Maze Runner doesn't run commands in the background as of v3.2.0: https://github.com/bugsnag/maze-runner/commit/78425e016960ce50cab593991a03187d9e79f067