### PR TITLE
Run Rails 3-7 tests with Maze Runner v7

### DIFF
--- a/.github/workflows/maze-runner.yml
+++ b/.github/workflows/maze-runner.yml
@@ -132,27 +132,40 @@ jobs:
       features: features/rails_features/ --tags @rails${{ matrix.rails-version }}
       ruby-version: ${{ matrix.ruby-version }}
       rails-version: ${{ matrix.rails-version }}
+      # temporary while we have some tests on Maze Runner v7 and some on v3
+      gemfile: Gemfile-maze-runner-v7
 
-  rails-6-7-integrations-maze-runner:
+  rails-6-7-maze-runner:
     strategy:
       fail-fast: false
       matrix:
         ruby-version: ['2.7', '3.0', '3.1']
-        rails-version: ['6', '7', '_integrations']
+        rails-version: ['6', '7']
         include:
           - ruby-version: '2.5'
             rails-version: '6'
           - ruby-version: '2.6'
             rails-version: '6'
-        exclude:
-          - ruby-version: '3.1'
-            rails-version: '_integrations'
 
     uses: ./.github/workflows/run-maze-runner.yml
     with:
       features: features/rails_features/ --tags @rails${{ matrix.rails-version }}
       ruby-version: ${{ matrix.ruby-version }}
       rails-version: ${{ matrix.rails-version }}
+      # temporary while we have some tests on Maze Runner v7 and some on v3
+      gemfile: Gemfile-maze-runner-v7
+
+  rails-integrations-maze-runner:
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby-version: ['2.7', '3.0']
+
+    uses: ./.github/workflows/run-maze-runner.yml
+    with:
+      features: features/rails_features/ --tags @rails_integrations
+      ruby-version: ${{ matrix.ruby-version }}
+      rails-version: _integrations
 
   plain-maze-runner:
     strategy:

--- a/features/fixtures/docker-compose.yml
+++ b/features/fixtures/docker-compose.yml
@@ -323,6 +323,7 @@ services:
     environment:
       - BUGSNAG_API_KEY
       - BUGSNAG_ENDPOINT
+      - BUGSNAG_SESSION_ENDPOINT
       - DB_USERNAME=postgres
       - DB_PASSWORD=test_password
       - DB_HOST=postgres

--- a/features/fixtures/rails3/app/config/initializers/bugsnag.rb
+++ b/features/fixtures/rails3/app/config/initializers/bugsnag.rb
@@ -1,7 +1,7 @@
 Bugsnag.configure do |config|
   config.api_key = ENV["BUGSNAG_API_KEY"] || ENV["BUGSNAG_API_KEY"]
   config.endpoint = ENV["BUGSNAG_ENDPOINT"] || ENV["BUGSNAG_ENDPOINT"]
-  config.session_endpoint = ENV["BUGSNAG_ENDPOINT"] || ENV["BUGSNAG_ENDPOINT"]
+  config.session_endpoint = ENV["BUGSNAG_SESSION_ENDPOINT"] || ENV["BUGSNAG_SESSION_ENDPOINT"]
   config.app_type = ENV["BUGSNAG_APP_TYPE"] if ENV.include? "BUGSNAG_APP_TYPE"
   config.app_version = ENV["BUGSNAG_APP_VERSION"] if ENV.include? "BUGSNAG_APP_VERSION"
   config.auto_notify = ENV["BUGSNAG_AUTO_NOTIFY"] != "false"

--- a/features/fixtures/rails4/app/config/initializers/bugsnag.rb
+++ b/features/fixtures/rails4/app/config/initializers/bugsnag.rb
@@ -1,7 +1,7 @@
 Bugsnag.configure do |config|
   config.api_key = ENV["BUGSNAG_API_KEY"] || ENV["BUGSNAG_API_KEY"]
   config.endpoint = ENV["BUGSNAG_ENDPOINT"] || ENV["BUGSNAG_ENDPOINT"]
-  config.session_endpoint = ENV["BUGSNAG_ENDPOINT"] || ENV["BUGSNAG_ENDPOINT"]
+  config.session_endpoint = ENV["BUGSNAG_SESSION_ENDPOINT"] || ENV["BUGSNAG_SESSION_ENDPOINT"]
   config.app_type = ENV["BUGSNAG_APP_TYPE"] if ENV.include? "BUGSNAG_APP_TYPE"
   config.app_version = ENV["BUGSNAG_APP_VERSION"] if ENV.include? "BUGSNAG_APP_VERSION"
   config.auto_notify = ENV["BUGSNAG_AUTO_NOTIFY"] != "false"

--- a/features/fixtures/rails5/app/config/initializers/bugsnag.rb
+++ b/features/fixtures/rails5/app/config/initializers/bugsnag.rb
@@ -1,7 +1,7 @@
 Bugsnag.configure do |config|
   config.api_key = ENV["BUGSNAG_API_KEY"] || ENV["BUGSNAG_API_KEY"]
   config.endpoint = ENV["BUGSNAG_ENDPOINT"] || ENV["BUGSNAG_ENDPOINT"]
-  config.session_endpoint = ENV["BUGSNAG_ENDPOINT"] || ENV["BUGSNAG_ENDPOINT"]
+  config.session_endpoint = ENV["BUGSNAG_SESSION_ENDPOINT"] || ENV["BUGSNAG_SESSION_ENDPOINT"]
   config.app_type = ENV["BUGSNAG_APP_TYPE"] if ENV.include? "BUGSNAG_APP_TYPE"
   config.app_version = ENV["BUGSNAG_APP_VERSION"] if ENV.include? "BUGSNAG_APP_VERSION"
   config.auto_notify = ENV["BUGSNAG_AUTO_NOTIFY"] != "false"

--- a/features/fixtures/rails6/app/config/initializers/bugsnag.rb
+++ b/features/fixtures/rails6/app/config/initializers/bugsnag.rb
@@ -1,7 +1,7 @@
 Bugsnag.configure do |config|
   config.api_key = ENV["BUGSNAG_API_KEY"] || ENV["BUGSNAG_API_KEY"]
   config.endpoint = ENV["BUGSNAG_ENDPOINT"] || ENV["BUGSNAG_ENDPOINT"]
-  config.session_endpoint = ENV["BUGSNAG_ENDPOINT"] || ENV["BUGSNAG_ENDPOINT"]
+  config.session_endpoint = ENV["BUGSNAG_SESSION_ENDPOINT"] || ENV["BUGSNAG_SESSION_ENDPOINT"]
   config.app_type = ENV["BUGSNAG_APP_TYPE"] if ENV.include? "BUGSNAG_APP_TYPE"
   config.app_version = ENV["BUGSNAG_APP_VERSION"] if ENV.include? "BUGSNAG_APP_VERSION"
   config.auto_notify = ENV["BUGSNAG_AUTO_NOTIFY"] != "false"

--- a/features/fixtures/rails7/app/config/initializers/bugsnag.rb
+++ b/features/fixtures/rails7/app/config/initializers/bugsnag.rb
@@ -1,7 +1,7 @@
 Bugsnag.configure do |config|
   config.api_key = ENV["BUGSNAG_API_KEY"]
   config.endpoint = ENV["BUGSNAG_ENDPOINT"]
-  config.session_endpoint = ENV["BUGSNAG_ENDPOINT"]
+  config.session_endpoint = ENV["BUGSNAG_SESSION_ENDPOINT"]
   config.app_type = ENV["BUGSNAG_APP_TYPE"] if ENV.include? "BUGSNAG_APP_TYPE"
   config.app_version = ENV["BUGSNAG_APP_VERSION"] if ENV.include? "BUGSNAG_APP_VERSION"
   config.auto_notify = ENV["BUGSNAG_AUTO_NOTIFY"] != "false"

--- a/features/fixtures/rails_integrations/app/config/initializers/bugsnag.rb
+++ b/features/fixtures/rails_integrations/app/config/initializers/bugsnag.rb
@@ -1,7 +1,7 @@
 Bugsnag.configure do |config|
   config.api_key = ENV['BUGSNAG_API_KEY']
   config.endpoint = ENV['BUGSNAG_ENDPOINT']
-  config.session_endpoint = ENV['BUGSNAG_ENDPOINT']
+  config.session_endpoint = ENV['BUGSNAG_SESSION_ENDPOINT']
 
   config.add_on_error(proc do |report|
     report.add_tab(:config, {

--- a/features/rails_features/active_job.feature
+++ b/features/rails_features/active_job.feature
@@ -4,8 +4,8 @@ Feature: Active Job
 Scenario: A handled error will be delivered
   Given I start the rails service
   When I navigate to the route "/active_job/handled" on the rails app
-  And I wait to receive a request
-  Then the request is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier"
+  And I wait to receive an error
+  Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
   And the event "unhandled" is false
   And the event "severity" equals "warning"
   And the event "context" equals "NotifyJob@default"
@@ -30,8 +30,8 @@ Scenario: A handled error will be delivered
 Scenario: An unhandled error will be delivered
   Given I start the rails service
   When I navigate to the route "/active_job/unhandled" on the rails app
-  And I wait to receive 2 requests
-  Then the request is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier"
+  And I wait to receive 2 errors
+  Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
   And the event "unhandled" is true
   And the event "severity" equals "error"
   And the event "context" equals "UnhandledJob@default"
@@ -51,8 +51,8 @@ Scenario: An unhandled error will be delivered
   And in Rails versions ">=" 5 the event "metaData.active_job.executions" equals 1
   And in Rails versions ">=" 6 the event "metaData.active_job.timezone" equals "UTC"
   And in Rails versions ">=" 6 the event "metaData.active_job.enqueued_at" is a timestamp
-  When I discard the oldest request
-  Then the request is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier"
+  When I discard the oldest error
+  Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
   And the event "unhandled" is true
   And the event "severity" equals "error"
   And the event "context" equals "UnhandledJob@default"

--- a/features/rails_features/active_record.feature
+++ b/features/rails_features/active_record.feature
@@ -4,8 +4,8 @@ Feature: Active Record
 Scenario: An unhandled error in a transaction callback will be delivered
   Given I start the rails service
   When I navigate to the route "/unhandled/error_in_active_record_callback" on the rails app
-  And I wait to receive a request
-  Then the request is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier"
+  And I wait to receive an error
+  Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
   And the event "unhandled" is true
   And the exception "errorClass" equals "RuntimeError"
   And the exception "message" equals "Oh no!"
@@ -19,8 +19,8 @@ Scenario: An unhandled error in a transaction callback will be delivered when ra
   Given I set environment variable "RAISE_IN_TRANSACTIONAL_CALLBACKS" to "false"
   And I start the rails service
   When I navigate to the route "/unhandled/error_in_active_record_callback" on the rails app
-  And I wait to receive a request
-  Then the request is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier"
+  And I wait to receive an error
+  Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
   And the event "unhandled" is true
   And the exception "errorClass" equals "RuntimeError"
   And the exception "message" equals "Oh no!"

--- a/features/rails_features/api_key.feature
+++ b/features/rails_features/api_key.feature
@@ -4,12 +4,12 @@ Feature: API key
 Scenario: Setting api_key in environment variable works
   Given I start the rails service
   When I navigate to the route "/api_key/environment" on the rails app
-  And I wait to receive a request
-  Then the request is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier"
+  And I wait to receive an error
+  Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
 
 @rails3 @rails4 @rails5 @rails6 @rails7
  Scenario Outline: Changing api_key after initializer works
   Given I start the rails service
   When I navigate to the route "/api_key/changing?api_key=c35a2a72bd230ac0aa0f52715bbdc6ac" on the rails app
-  And I wait to receive a request
-  Then the request is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier"
+  And I wait to receive an error
+  Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier with the apiKey "c35a2a72bd230ac0aa0f52715bbdc6ac"

--- a/features/rails_features/app_type.feature
+++ b/features/rails_features/app_type.feature
@@ -5,8 +5,8 @@ Scenario: Setting app_type in initializer works
   Given I set environment variable "BUGSNAG_APP_TYPE" to "custom_app_type"
   And I start the rails service
   When I navigate to the route "/app_type/initializer" on the rails app
-  And I wait to receive a request
-  Then the request is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier"
+  And I wait to receive an error
+  Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
   And the exception "errorClass" equals "RuntimeError"
   And the exception "message" starts with "handled string"
   And the event "metaData.request.url" ends with "/app_type/initializer"
@@ -16,8 +16,8 @@ Scenario: Setting app_type in initializer works
 Scenario: Changing app_type after initializer works
   Given I start the rails service
   When I navigate to the route "/app_type/after?type=maze_after_initializer" on the rails app
-  And I wait to receive a request
-  Then the request is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier"
+  And I wait to receive an error
+  Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
   And the exception "errorClass" equals "RuntimeError"
   And the exception "message" starts with "handled string"
   And the event "metaData.request.url" ends with "/app_type/after?type=maze_after_initializer"
@@ -27,8 +27,8 @@ Scenario: Changing app_type after initializer works
 Scenario: Should default to "rails" for handled errors
   Given I start the rails service
   When I navigate to the route "/app_type/handled" on the rails app
-  And I wait to receive a request
-  Then the request is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier"
+  And I wait to receive an error
+  Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
   And the event "metaData.request.url" ends with "/app_type/handled"
   And the event "app.type" equals "rails"
 
@@ -36,7 +36,7 @@ Scenario: Should default to "rails" for handled errors
 Scenario: Should default to "rails" for unhandled errors
   Given I start the rails service
   When I navigate to the route "/app_type/unhandled" on the rails app
-  And I wait to receive a request
-  Then the request is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier"
+  And I wait to receive an error
+  Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
   And the event "metaData.request.url" ends with "/app_type/unhandled"
   And the event "app.type" equals "rails"

--- a/features/rails_features/app_version.feature
+++ b/features/rails_features/app_version.feature
@@ -4,8 +4,8 @@ Feature: App version configuration
 Scenario: App_version is nil by default
   Given I start the rails service
   When I navigate to the route "/app_version/default" on the rails app
-  And I wait to receive a request
-  Then the request is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier"
+  And I wait to receive an error
+  Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
   And the event "app.version" is null
 
 @rails3 @rails4 @rails5 @rails6 @rails7
@@ -13,14 +13,14 @@ Scenario: Setting app_version in initializer works
   Given I set environment variable "BUGSNAG_APP_VERSION" to "1.0.0"
   And I start the rails service
   When I navigate to the route "/app_version/initializer" on the rails app
-  And I wait to receive a request
-  Then the request is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier"
+  And I wait to receive an error
+  Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
   And the event "app.version" equals "1.0.0"
 
 @rails3 @rails4 @rails5 @rails6 @rails7
 Scenario: Setting app_version after initializer works
   Given I start the rails service
   When I navigate to the route "/app_version/after?version=1.1.0" on the rails app
-  And I wait to receive a request
-  Then the request is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier"
+  And I wait to receive an error
+  Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
   And the event "app.version" equals "1.1.0"

--- a/features/rails_features/auto_capture_sessions.feature
+++ b/features/rails_features/auto_capture_sessions.feature
@@ -5,15 +5,14 @@ Scenario: Auto_capture_sessions defaults to true
   Given I set environment variable "USE_DEFAULT_AUTO_CAPTURE_SESSIONS" to "true"
   And I start the rails service
   When I navigate to the route "/session_tracking/initializer" on the rails app
-  And I wait to receive a request
-  Then the request is valid for the session reporting API version "1.0" for the "Ruby Bugsnag Notifier" notifier
+  And I wait to receive a session
+  Then the session is valid for the session reporting API version "1.0" for the "Ruby Bugsnag Notifier" notifier
 
 @rails3 @rails4 @rails5 @rails6 @rails7
 Scenario: Auto_capture_sessions can be set to false in the initializer
   Given I set environment variable "BUGSNAG_AUTO_CAPTURE_SESSIONS" to "false"
   And I start the rails service
   When I navigate to the route "/session_tracking/initializer" on the rails app
-  And I wait for 3 seconds
   Then I should receive no requests
 
 @rails3 @rails4 @rails5 @rails6 @rails7
@@ -21,14 +20,14 @@ Scenario: Manual sessions are still sent if Auto_capture_sessions is false
   Given I set environment variable "BUGSNAG_AUTO_CAPTURE_SESSIONS" to "false"
   And I start the rails service
   When I navigate to the route "/session_tracking/manual" on the rails app
-  And I wait to receive a request
-  Then the request is valid for the session reporting API version "1.0" for the "Ruby Bugsnag Notifier" notifier
+  And I wait to receive a session
+  Then the session is valid for the session reporting API version "1.0" for the "Ruby Bugsnag Notifier" notifier
 
 @rails3 @rails4 @rails5 @rails6 @rails7
 Scenario: 100 session calls results in 100 sessions
   Given I set environment variable "BUGSNAG_AUTO_CAPTURE_SESSIONS" to "false"
   And I start the rails service
   When I navigate to the route "/session_tracking/multi_sessions" on the rails app
-  And I wait to receive a request
-  Then the request is valid for the session reporting API version "1.0" for the "Ruby Bugsnag Notifier" notifier
+  And I wait to receive a session
+  Then the session is valid for the session reporting API version "1.0" for the "Ruby Bugsnag Notifier" notifier
   And the total sessionStarted count equals 100

--- a/features/rails_features/auto_notify.feature
+++ b/features/rails_features/auto_notify.feature
@@ -5,7 +5,6 @@ Scenario: Auto_notify set to false in the initializer prevents unhandled error s
   Given I set environment variable "BUGSNAG_AUTO_NOTIFY" to "false"
   And I start the rails service
   When I navigate to the route "/auto_notify/unhandled" on the rails app
-  And I wait for 3 seconds
   Then I should receive no requests
 
 @rails3 @rails4 @rails5 @rails6 @rails7
@@ -13,8 +12,8 @@ Scenario: Auto_notify set to false in the initializer still sends handled errors
   Given I set environment variable "BUGSNAG_AUTO_NOTIFY" to "false"
   And I start the rails service
   When I navigate to the route "/auto_notify/handled" on the rails app
-  And I wait to receive a request
-  Then the request is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier"
+  And I wait to receive an error
+  Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
   And the event "unhandled" is false
   And the exception "errorClass" equals "RuntimeError"
   And the exception "message" starts with "handled string"
@@ -25,15 +24,14 @@ Scenario: Auto_notify set to false in the initializer still sends handled errors
 Scenario: Auto_notify set to false after the initializer prevents unhandled error sending
   Given I start the rails service
   When I navigate to the route "/auto_notify/unhandled_after" on the rails app
-  And I wait for 3 seconds
   Then I should receive no requests
 
 @rails3 @rails4 @rails5 @rails6 @rails7
 Scenario: Auto_notify set to false after the initializer still sends handled errors
   Given I start the rails service
   When I navigate to the route "/auto_notify/handled_after" on the rails app
-  And I wait to receive a request
-  Then the request is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier"
+  And I wait to receive an error
+  Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
   And the exception "errorClass" equals "RuntimeError"
   And the exception "message" starts with "handled string"
   And the event "unhandled" is false

--- a/features/rails_features/before_notify.feature
+++ b/features/rails_features/before_notify.feature
@@ -4,8 +4,8 @@ Feature: Before notify callbacks
 Scenario: Rails before_notify controller method works on handled errors
   Given I start the rails service
   When I navigate to the route "/before_notify/handled" on the rails app
-  And I wait to receive a request
-  Then the request is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier"
+  And I wait to receive an error
+  Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
   And the exception "errorClass" equals "RuntimeError"
   And the exception "message" starts with "handled string"
   And the event "unhandled" is false
@@ -18,8 +18,8 @@ Scenario: Rails before_notify controller method works on handled errors
 Scenario: Rails before_notify controller method works on unhandled errors
   Given I start the rails service
   When I navigate to the route "/before_notify/unhandled" on the rails app
-  And I wait to receive a request
-  Then the request is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier"
+  And I wait to receive an error
+  Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
   And the exception "errorClass" equals "NameError"
   And the exception "message" starts with "undefined local variable or method `generate_unhandled_error' for #<BeforeNotifyController"
   And the event "unhandled" is true
@@ -32,8 +32,8 @@ Scenario: Rails before_notify controller method works on unhandled errors
 Scenario: Inline block on handled errors is called
   Given I start the rails service
   When I navigate to the route "/before_notify/inline" on the rails app
-  And I wait to receive a request
-  Then the request is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier"
+  And I wait to receive an error
+  Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
   And the exception "errorClass" equals "RuntimeError"
   And the exception "message" starts with "handled string"
   And the event "unhandled" is false

--- a/features/rails_features/breadcrumbs.feature
+++ b/features/rails_features/breadcrumbs.feature
@@ -4,8 +4,8 @@ Feature: Rails automatic breadcrumbs
 Scenario: Request breadcrumb
   Given I start the rails service
   When I navigate to the route "/breadcrumbs/handled" on the rails app
-  And I wait to receive a request
-  Then the request is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier"
+  And I wait to receive an error
+  Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
   And the event contains a breadcrumb matching the JSON fixture in "features/fixtures/expected_breadcrumbs/request.json"
 
 @rails3 @rails4
@@ -13,8 +13,8 @@ Scenario: SQL Breadcrumb without bindings
   Given I set environment variable "SQL_ONLY_BREADCRUMBS" to "true"
   And I start the rails service
   When I navigate to the route "/breadcrumbs/sql_breadcrumb" on the rails app
-  And I wait to receive a request
-  Then the request is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier"
+  And I wait to receive an error
+  Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
   And the event contains a breadcrumb matching the JSON fixture in "features/fixtures/expected_breadcrumbs/sql_without_bindings.json"
 
 @rails5 @rails6 @rails7
@@ -22,22 +22,22 @@ Scenario: SQL Breadcrumb with bindings
   Given I set environment variable "SQL_ONLY_BREADCRUMBS" to "true"
   And I start the rails service
   When I navigate to the route "/breadcrumbs/sql_breadcrumb" on the rails app
-  And I wait to receive a request
-  Then the request is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier"
+  And I wait to receive an error
+  Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
   And the event contains a breadcrumb matching the JSON fixture in "features/fixtures/expected_breadcrumbs/sql_with_bindings.json"
 
 @rails4 @rails5 @rails6 @rails7
 Scenario: Active job breadcrumb
   Given I start the rails service
   When I navigate to the route "/breadcrumbs/active_job" on the rails app
-  And I wait to receive a request
-  Then the request is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier"
+  And I wait to receive an error
+  Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
   And the event contains a breadcrumb matching the JSON fixture in "features/fixtures/expected_breadcrumbs/active_job.json"
 
 @rails4 @rails5 @rails6 @rails7
 Scenario: Cache read
   Given I start the rails service
   When I navigate to the route "/breadcrumbs/cache_read" on the rails app
-  And I wait to receive a request
-  Then the request is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier"
+  And I wait to receive an error
+  Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
   And the event has a "process" breadcrumb named "Read cache"

--- a/features/rails_features/handled.feature
+++ b/features/rails_features/handled.feature
@@ -4,8 +4,8 @@ Feature: Rails handled errors
 Scenario: Unhandled RuntimeError
   Given I start the rails service
   When I navigate to the route "/handled/unthrown" on the rails app
-  And I wait to receive a request
-  Then the request is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier"
+  And I wait to receive an error
+  Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
   And the event "unhandled" is false
   And the exception "errorClass" equals "RuntimeError"
   And the exception "message" starts with "handled unthrown error"
@@ -18,8 +18,8 @@ Scenario: Unhandled RuntimeError
 Scenario: Thrown handled NameError
   Given I start the rails service
   When I navigate to the route "/handled/thrown" on the rails app
-  And I wait to receive a request
-  Then the request is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier"
+  And I wait to receive an error
+  Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
   And the exception "errorClass" equals "NameError"
   And the exception "message" starts with "undefined local variable or method `generate_unhandled_error' for #<HandledController"
   And the event "unhandled" is false
@@ -32,8 +32,8 @@ Scenario: Thrown handled NameError
 Scenario: Manual string notify
   Given I start the rails service
   When I navigate to the route "/handled/string_notify" on the rails app
-  And I wait to receive a request
-  Then the request is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier"
+  And I wait to receive an error
+  Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
   And the exception "errorClass" equals "RuntimeError"
   And the exception "message" starts with "handled string"
   And the event "unhandled" is false

--- a/features/rails_features/meta_data_filters.feature
+++ b/features/rails_features/meta_data_filters.feature
@@ -4,8 +4,8 @@ Feature: Metadata filters
 Scenario: Meta_data_filters should include Rails.configuration.filter_parameters
   Given I start the rails service
   When I navigate to the route "/metadata_filters/filter?filtered_parameter=foo&other_parameter=bar" on the rails app
-  And I wait to receive a request
-  Then the request is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier"
+  And I wait to receive an error
+  Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
   And the event "unhandled" is false
   And the exception "errorClass" equals "RuntimeError"
   And the exception "message" starts with "handled string"

--- a/features/rails_features/mongo_breadcrumbs.feature
+++ b/features/rails_features/mongo_breadcrumbs.feature
@@ -4,16 +4,16 @@ Feature: Mongo automatic breadcrumbs
 Scenario: Successful breadcrumbs
   Given I start the rails service
   When I navigate to the route "/mongo/success_crash" on the rails app
-  And I wait to receive a request
-  Then the request is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier"
+  And I wait to receive an error
+  Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
   And the event contains a breadcrumb matching the JSON fixture in "features/fixtures/expected_breadcrumbs/mongo_success.json"
 
 @rails4 @rails5 @rails6
 Scenario: Breadcrumb with filter parameters
   Given I start the rails service
   When I navigate to the route "/mongo/get_crash" on the rails app
-  And I wait to receive a request
-  Then the request is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier"
+  And I wait to receive an error
+  Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
   And the event contains a breadcrumb matching the JSON fixture in "features/fixtures/expected_breadcrumbs/mongo_filtered_request.json"
   And the event contains a breadcrumb matching the JSON fixture in "features/fixtures/expected_breadcrumbs/mongo_filtered_result.json"
 
@@ -21,6 +21,6 @@ Scenario: Breadcrumb with filter parameters
 Scenario: Failure breadcrumbs
   Given I start the rails service
   When I navigate to the route "/mongo/failure_crash" on the rails app
-  And I wait to receive a request
-  Then the request is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier"
+  And I wait to receive an error
+  Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
   And the event contains a breadcrumb matching the JSON fixture in "features/fixtures/expected_breadcrumbs/mongo_failed.json"

--- a/features/rails_features/on_error.feature
+++ b/features/rails_features/on_error.feature
@@ -5,8 +5,8 @@ Scenario: Rails on_error works on handled errors
   Given I set environment variable "ADD_ON_ERROR" to "true"
   And I start the rails service
   When I navigate to the route "/handled/unthrown" on the rails app
-  And I wait to receive a request
-  Then the request is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier"
+  And I wait to receive an error
+  Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
   And the exception "errorClass" equals "RuntimeError"
   And the exception "message" starts with "handled unthrown error"
   And the event "unhandled" is false
@@ -19,8 +19,8 @@ Scenario: Rails on_error works on unhandled errors
   Given I set environment variable "ADD_ON_ERROR" to "true"
   And I start the rails service
   When I navigate to the route "/unhandled/error" on the rails app
-  And I wait to receive a request
-  Then the request is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier"
+  And I wait to receive an error
+  Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
   And the exception "errorClass" equals "NameError"
   And the exception "message" starts with "undefined local variable or method `generate_unhandled_error' for #<UnhandledController"
   And the event "unhandled" is true

--- a/features/rails_features/project_root.feature
+++ b/features/rails_features/project_root.feature
@@ -4,8 +4,8 @@ Feature: Project root configuration
 Scenario: Project_root should default to Rails.root
   Given I start the rails service
   When I navigate to the route "/project_root/default" on the rails app
-  And I wait to receive a request
-  Then the request is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier"
+  And I wait to receive an error
+  Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
   And the exception "errorClass" equals "RuntimeError"
   And the exception "message" starts with "handled string"
   And the event "metaData.request.url" ends with "/project_root/default"
@@ -16,8 +16,8 @@ Scenario: Project_root can be set in an initializer
   Given I set environment variable "BUGSNAG_PROJECT_ROOT" to "/foo/bar"
   And I start the rails service
   When I navigate to the route "/project_root/initializer" on the rails app
-  And I wait to receive a request
-  Then the request is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier"
+  And I wait to receive an error
+  Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
   And the exception "errorClass" equals "RuntimeError"
   And the exception "message" starts with "handled string"
   And the event "metaData.request.url" ends with "/project_root/initializer"
@@ -27,8 +27,8 @@ Scenario: Project_root can be set in an initializer
 Scenario: Project_root can be set after an initializer
   Given I start the rails service
   When I navigate to the route "/project_root/after" on the rails app
-  And I wait to receive a request
-  Then the request is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier"
+  And I wait to receive an error
+  Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
   And the exception "errorClass" equals "RuntimeError"
   And the exception "message" starts with "handled string"
   And the event "metaData.request.url" ends with "/project_root/after"

--- a/features/rails_features/release_stage.feature
+++ b/features/rails_features/release_stage.feature
@@ -5,8 +5,8 @@ Scenario: Release_stage should default to RAILS_ENV
   Given I set environment variable "RAILS_ENV" to "rails_env"
   And I start the rails service
   When I navigate to the route "/release_stage/default" on the rails app
-  And I wait to receive a request
-  Then the request is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier"
+  And I wait to receive an error
+  Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
   And the event "app.releaseStage" equals "rails_env"
 
 @rails3 @rails4 @rails5 @rails6 @rails7
@@ -14,14 +14,14 @@ Scenario: Release_stage can be set in an initializer
   Given I set environment variable "BUGSNAG_RELEASE_STAGE" to "maze_release_stage_env"
   And I start the rails service
   When I navigate to the route "/release_stage/default" on the rails app
-  And I wait to receive a request
-  Then the request is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier"
+  And I wait to receive an error
+  Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
   And the event "app.releaseStage" equals "maze_release_stage_env"
 
 @rails3 @rails4 @rails5 @rails6 @rails7
 Scenario: Release_stage can be set after an initializer
   Given I start the rails service
   When I navigate to the route "/release_stage/after?stage=set_after_env" on the rails app
-  And I wait to receive a request
-  Then the request is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier"
+  And I wait to receive an error
+  Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
   And the event "app.releaseStage" equals "set_after_env"

--- a/features/rails_features/request.feature
+++ b/features/rails_features/request.feature
@@ -4,8 +4,8 @@ Feature: Request data
 Scenario: Request data is collected automatically
   Given I start the rails service
   When I navigate to the route "/unhandled/error?a=123&b=456" on the rails app
-  And I wait to receive a request
-  Then the request is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier"
+  And I wait to receive an error
+  Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
   And the event "unhandled" is true
   And the exception "errorClass" equals "NameError"
   And the exception "message" starts with "undefined local variable or method `generate_unhandled_error' for #<UnhandledController"
@@ -29,8 +29,8 @@ Scenario: Request data can be modified in callbacks
   Given I set environment variable "ADD_REQUEST_ON_ERROR" to "true"
   And I start the rails service
   When I navigate to the route "/unhandled/error?a=123&b=456" on the rails app
-  And I wait to receive a request
-  Then the request is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier"
+  And I wait to receive an error
+  Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
   And the event "unhandled" is true
   And the exception "errorClass" equals "NameError"
   And the exception "message" starts with "undefined local variable or method `generate_unhandled_error' for #<UnhandledController"

--- a/features/rails_features/send_code.feature
+++ b/features/rails_features/send_code.feature
@@ -5,14 +5,14 @@ Scenario: Send_code can be updated in an initializer
   Given I set environment variable "BUGSNAG_SEND_CODE" to "false"
   And I start the rails service
   When I navigate to the route "/send_code/initializer" on the rails app
-  And I wait to receive a request
-  Then the request is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier"
+  And I wait to receive an error
+  Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
   And the event "exceptions.0.stacktrace.0.code" is null
 
 @rails3 @rails4 @rails5 @rails6 @rails7
 Scenario: Send_code can be updated after an initializer
   Given I start the rails service
   When I navigate to the route "/send_code/after" on the rails app
-  And I wait to receive a request
-  Then the request is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier"
+  And I wait to receive an error
+  Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
   And the event "exceptions.0.stacktrace.0.code" is null

--- a/features/rails_features/send_environment.feature
+++ b/features/rails_features/send_environment.feature
@@ -5,8 +5,8 @@ Scenario: Send_environment should send environment in handled errors when true
   Given I set environment variable "BUGSNAG_SEND_ENVIRONMENT" to "true"
   And I start the rails service
   When I navigate to the route "/send_environment/initializer" on the rails app
-  And I wait to receive a request
-  Then the request is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier"
+  And I wait to receive an error
+  Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
   And the exception "errorClass" equals "RuntimeError"
   And the exception "message" starts with "handled string"
   And the event "metaData.environment.REQUEST_METHOD" equals "GET"

--- a/features/rails_features/unhandled.feature
+++ b/features/rails_features/unhandled.feature
@@ -4,8 +4,8 @@ Feature: Unhandled exceptions support
 Scenario: Unhandled RuntimeError
   Given I start the rails service
   When I navigate to the route "/unhandled/error" on the rails app
-  And I wait to receive a request
-  Then the request is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier"
+  And I wait to receive an error
+  Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
   And the event "unhandled" is true
   And the exception "errorClass" equals "NameError"
   And the exception "message" starts with "undefined local variable or method `generate_unhandled_error' for #<UnhandledController"

--- a/features/rails_features/user_info.feature
+++ b/features/rails_features/user_info.feature
@@ -5,8 +5,8 @@ Scenario Outline: Warden user information is sent
   Given I start the rails service
   When I navigate to the route "/warden/create" on the rails app
   And I navigate to the route "/warden/<route>?email=testtest@test.test" on the rails app
-  And I wait to receive a request
-  Then the request is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier"
+  And I wait to receive an error
+  Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
   And the event "user.email" equals "testtest@test.test"
   And the event "user.name" equals "Warden User"
   And the event "user.first_name" equals "Warden"
@@ -22,8 +22,8 @@ Scenario Outline: Devise user information is sent
   Given I start the rails service
   When I navigate to the route "/devise/create" on the rails app
   And I navigate to the route "/devise/<route>" on the rails app
-  And I wait to receive a request
-  Then the request is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier"
+  And I wait to receive an error
+  Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
   And the event "user.email" equals "test+test@test.test"
   And the event "user.name" equals "Devise User"
   And the event "user.first_name" equals "Devise"
@@ -39,8 +39,8 @@ Scenario Outline: Clearance user information is sent
   Given I start the rails service
   When I navigate to the route "/clearance/create" on the rails app
   And I navigate to the route "/clearance/<route>" on the rails app
-  And I wait to receive a request
-  Then the request is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier"
+  And I wait to receive an error
+  Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
   And the event "user.email" equals "testtest@test.test"
   And the event "user.name" equals "Clearance User"
   And the event "user.first_name" equals "Clearance"

--- a/features/steps/ruby_notifier_steps.rb
+++ b/features/steps/ruby_notifier_steps.rb
@@ -18,8 +18,15 @@ Then(/^the "(.+)" of the top non-bugsnag stackframe equals (\d+|".+")$/) do |ele
 end
 
 Then(/^the total sessionStarted count equals (\d+)$/) do |value|
-  session_counts = read_key_path(Server.current_request[:body], "sessionCounts")
-  total_count = session_counts.inject(0) { |count, session| count += session["sessionsStarted"] }
+  if using_maze_runner_v7?
+    body = Maze::Server.sessions.current[:body]
+    session_counts = Maze::Helper.read_key_path(body, "sessionCounts")
+  else
+    body = Server.current_request[:body]
+    session_counts = read_key_path(body, "sessionCounts")
+  end
+
+  total_count = session_counts.sum { |session| session["sessionsStarted"] }
   assert_equal(value, total_count)
 end
 

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -63,11 +63,10 @@ if using_maze_runner_v7?
 
     Maze::Runner.environment["BUGSNAG_API_KEY"] = $api_key
 
-    if running_in_docker?
-      Maze::Runner.environment["BUGSNAG_ENDPOINT"] = "http://maze-runner:#{Maze.config.port}/notify"
-    else
-      Maze::Runner.environment["BUGSNAG_ENDPOINT"] = "http://#{current_ip}:#{Maze.config.port}/notify"
-    end
+    host = running_in_docker? ? "maze-runner" : current_ip
+
+    Maze::Runner.environment["BUGSNAG_ENDPOINT"] = "http://#{host}:#{Maze.config.port}/notify"
+    Maze::Runner.environment["BUGSNAG_SESSION_ENDPOINT"] = "http://#{host}:#{Maze.config.port}/sessions"
   end
 else
   AfterConfiguration do |config|
@@ -79,10 +78,9 @@ else
     Runner.environment.clear
     Runner.environment["BUGSNAG_API_KEY"] = $api_key
 
-    if running_in_docker?
-      Runner.environment["BUGSNAG_ENDPOINT"] = "http://maze-runner:#{MOCK_API_PORT}"
-    else
-      Runner.environment["BUGSNAG_ENDPOINT"] = "http://#{current_ip}:#{MOCK_API_PORT}"
-    end
+    host = running_in_docker? ? "maze-runner" : current_ip
+
+    Runner.environment["BUGSNAG_ENDPOINT"] = "http://#{host}:#{MOCK_API_PORT}"
+    Runner.environment["BUGSNAG_SESSION_ENDPOINT"] = "http://#{host}:#{MOCK_API_PORT}"
   end
 end


### PR DESCRIPTION
## Goal

This PR changes the Rails 3-7 tests to run with Maze Runner v7

The only tests left using Maze Runner v3 are the Rails integrations tests, which will be updated separately