### PR TITLE
Add FeatureFlagDelegate class

### DIFF
--- a/lib/bugsnag.rb
+++ b/lib/bugsnag.rb
@@ -38,6 +38,7 @@ require "bugsnag/breadcrumbs/breadcrumbs"
 
 require "bugsnag/utility/duplicator"
 require "bugsnag/utility/metadata_delegate"
+require "bugsnag/utility/feature_flag_delegate"
 
 # rubocop:todo Metrics/ModuleLength
 module Bugsnag

--- a/lib/bugsnag/utility/feature_flag_delegate.rb
+++ b/lib/bugsnag/utility/feature_flag_delegate.rb
@@ -1,0 +1,77 @@
+module Bugsnag::Utility
+  # @api private
+  class FeatureFlagDelegate
+    def initialize
+      # feature flags are stored internally in a hash of "name" => <FeatureFlag>
+      # we don't use a Set because new feature flags should overwrite old ones
+      # that share a name, but FeatureFlag equality also uses the variant
+      @storage = {}
+    end
+
+    # Add a feature flag with the given name & variant
+    #
+    # @param name [String]
+    # @param variant [String, nil]
+    # @return [void]
+    def add(name, variant)
+      @storage[name] = Bugsnag::FeatureFlag.new(name, variant)
+    end
+
+    # Merge the given array of FeatureFlag instances into the stored feature
+    # flags
+    #
+    # New flags will be appended to the array. Flags with the same name will be
+    # overwritten, but their position in the array will not change
+    #
+    # @param feature_flags [Array<Bugsnag::FeatureFlag>]
+    # @return [void]
+    def merge(feature_flags)
+      feature_flags.each do |flag|
+        next unless flag.is_a?(Bugsnag::FeatureFlag)
+
+        @storage[flag.name] = flag
+      end
+    end
+
+    # Remove the stored flag with the given name
+    #
+    # @param name [String]
+    # @return [void]
+    def remove(name)
+      @storage.delete(name)
+    end
+
+    # Remove all the stored flags
+    #
+    # @return [void]
+    def clear
+      @storage.clear
+    end
+
+    # Get an array of FeatureFlag instances
+    #
+    # @example
+    #   [
+    #     <#Bugsnag::FeatureFlag>,
+    #     <#Bugsnag::FeatureFlag>,
+    #   ]
+    #
+    # @return [Array<Bugsnag::FeatureFlag>]
+    def to_a
+      @storage.values
+    end
+
+    # Get the feature flags in their JSON representation
+    #
+    # @example
+    #   [
+    #     { "featureFlag" => "name", "variant" => "variant" },
+    #     { "featureFlag" => "another name" },
+    #   ]
+    #
+    # @return [Array<Hash{String => String}>]
+    def as_json
+      to_a.map(&:to_h)
+    end
+  end
+end

--- a/spec/utility/feature_flag_delegate_spec.rb
+++ b/spec/utility/feature_flag_delegate_spec.rb
@@ -1,0 +1,254 @@
+require 'spec_helper'
+
+describe Bugsnag::Utility::FeatureFlagDelegate do
+  it "contains no flags by default" do
+    delegate = Bugsnag::Utility::FeatureFlagDelegate.new
+
+    expect(delegate.as_json).to eq([])
+  end
+
+  describe "#add" do
+    it "can add flags individually" do
+      delegate = Bugsnag::Utility::FeatureFlagDelegate.new
+
+      delegate.add("abc", "xyz")
+      delegate.add("another", nil)
+      delegate.add("a third one", "1234")
+
+      expect(delegate.as_json).to eq([
+        { "featureFlag" => "abc", "variant" => "xyz" },
+        { "featureFlag" => "another" },
+        { "featureFlag" => "a third one", "variant" => "1234" },
+      ])
+    end
+
+    it "replaces flags by name when the original has no variant" do
+      delegate = Bugsnag::Utility::FeatureFlagDelegate.new
+
+      delegate.add("abc", nil)
+      delegate.add("another", nil)
+      delegate.add("abc", "123")
+
+      expect(delegate.as_json).to eq([
+        { "featureFlag" => "abc", "variant" => "123" },
+        { "featureFlag" => "another" },
+      ])
+    end
+
+    it "replaces flags by name when the replacement has no variant" do
+      delegate = Bugsnag::Utility::FeatureFlagDelegate.new
+
+      delegate.add("abc", "123")
+      delegate.add("another", nil)
+      delegate.add("abc", nil)
+
+      expect(delegate.as_json).to eq([
+        { "featureFlag" => "abc" },
+        { "featureFlag" => "another" },
+      ])
+    end
+
+    it "replaces flags by name when both have variants" do
+      delegate = Bugsnag::Utility::FeatureFlagDelegate.new
+
+      delegate.add("abc", "123")
+      delegate.add("another", nil)
+      delegate.add("abc", "987")
+
+      expect(delegate.as_json).to eq([
+        { "featureFlag" => "abc", "variant" => "987" },
+        { "featureFlag" => "another" },
+      ])
+    end
+  end
+
+  describe "#merge" do
+    it "can add multiple flags at once" do
+      delegate = Bugsnag::Utility::FeatureFlagDelegate.new
+
+      delegate.merge([
+        Bugsnag::FeatureFlag.new("a", "xyz"),
+        Bugsnag::FeatureFlag.new("b"),
+        Bugsnag::FeatureFlag.new("c", "111"),
+        Bugsnag::FeatureFlag.new("d"),
+      ])
+
+      expect(delegate.as_json).to eq([
+        { "featureFlag" => "a", "variant" => "xyz" },
+        { "featureFlag" => "b" },
+        { "featureFlag" => "c", "variant" => "111" },
+        { "featureFlag" => "d" },
+      ])
+    end
+
+    it "replaces flags by name when the original has no variant" do
+      delegate = Bugsnag::Utility::FeatureFlagDelegate.new
+
+      delegate.add("a", nil)
+
+      delegate.merge([
+        Bugsnag::FeatureFlag.new("b"),
+        Bugsnag::FeatureFlag.new("a", "123"),
+      ])
+
+      expect(delegate.as_json).to eq([
+        { "featureFlag" => "a", "variant" => "123" },
+        { "featureFlag" => "b" },
+      ])
+    end
+
+    it "replaces flags by name when the replacement has no variant" do
+      delegate = Bugsnag::Utility::FeatureFlagDelegate.new
+
+      delegate.add("a", "123")
+
+      delegate.merge([
+        Bugsnag::FeatureFlag.new("b"),
+        Bugsnag::FeatureFlag.new("a"),
+      ])
+
+      expect(delegate.as_json).to eq([
+        { "featureFlag" => "a" },
+        { "featureFlag" => "b" },
+      ])
+    end
+
+    it "replaces flags by name when both have variants" do
+      delegate = Bugsnag::Utility::FeatureFlagDelegate.new
+
+      delegate.add("a", "987")
+
+      delegate.merge([
+        Bugsnag::FeatureFlag.new("b"),
+        Bugsnag::FeatureFlag.new("a", "123"),
+      ])
+
+      expect(delegate.as_json).to eq([
+        { "featureFlag" => "a", "variant" => "123" },
+        { "featureFlag" => "b" },
+      ])
+    end
+
+    it "ignores anything that isn't a FeatureFlag instance" do
+      delegate = Bugsnag::Utility::FeatureFlagDelegate.new
+
+      delegate.merge([
+        Bugsnag::FeatureFlag.new("a", "xyz"),
+        1234,
+        Bugsnag::FeatureFlag.new("b"),
+        "hello",
+        Bugsnag::FeatureFlag.new("c", "111"),
+        RuntimeError.new("xyz"),
+        Bugsnag::FeatureFlag.new("d"),
+        nil,
+      ])
+
+      expect(delegate.as_json).to eq([
+        { "featureFlag" => "a", "variant" => "xyz" },
+        { "featureFlag" => "b" },
+        { "featureFlag" => "c", "variant" => "111" },
+        { "featureFlag" => "d" },
+      ])
+    end
+  end
+
+  describe "#remove" do
+    it "can remove flags by name" do
+      delegate = Bugsnag::Utility::FeatureFlagDelegate.new
+
+      delegate.add("abc", "xyz")
+      delegate.add("another", nil)
+      delegate.add("a third one", "1234")
+
+      delegate.remove("abc")
+      delegate.remove("a third one")
+
+      expect(delegate.as_json).to eq([
+        { "featureFlag" => "another" },
+      ])
+    end
+
+    it "does nothing when no flag exists with the given name" do
+      delegate = Bugsnag::Utility::FeatureFlagDelegate.new
+
+      delegate.add("abc", "xyz")
+      delegate.remove("xyz")
+
+      expect(delegate.as_json).to eq([
+        { "featureFlag" => "abc", "variant" => "xyz" },
+      ])
+    end
+  end
+
+  describe "#clear" do
+    it "can remove all flags at once" do
+      delegate = Bugsnag::Utility::FeatureFlagDelegate.new
+
+      delegate.add("abc", "xyz")
+      delegate.add("another", nil)
+      delegate.add("a third one", "1234")
+
+      delegate.clear
+
+      expect(delegate.as_json).to eq([])
+    end
+
+    it "does nothing when there are no flags" do
+      delegate = Bugsnag::Utility::FeatureFlagDelegate.new
+
+      delegate.clear
+
+      expect(delegate.as_json).to eq([])
+    end
+  end
+
+  describe "#to_a" do
+    it "returns an empty array when there are no feature flags" do
+      delegate = Bugsnag::Utility::FeatureFlagDelegate.new
+
+      expect(delegate.to_a).to eq([])
+    end
+
+    it "returns an array of feature flags" do
+      delegate = Bugsnag::Utility::FeatureFlagDelegate.new
+
+      delegate.add("abc", "xyz")
+      delegate.add("another", nil)
+      delegate.add("a third one", "1234")
+
+      expect(delegate.to_a).to eq([
+        Bugsnag::FeatureFlag.new("abc", "xyz"),
+        Bugsnag::FeatureFlag.new("another"),
+        Bugsnag::FeatureFlag.new("a third one", "1234"),
+      ])
+    end
+
+    it "can be mutated without affecting the internal storage" do
+      delegate = Bugsnag::Utility::FeatureFlagDelegate.new
+
+      delegate.add("abc", "xyz")
+      delegate.add("another", nil)
+      delegate.add("a third one", "1234")
+
+      flags = delegate.to_a
+
+      expected = [
+        Bugsnag::FeatureFlag.new("abc", "xyz"),
+        Bugsnag::FeatureFlag.new("another"),
+        Bugsnag::FeatureFlag.new("a third one", "1234"),
+      ]
+
+      expect(flags).to eq(expected)
+
+      flags.pop
+      flags.pop
+      flags.push(1234)
+
+      expect(delegate.to_a).to eq(expected)
+      expect(flags).to eq([
+        Bugsnag::FeatureFlag.new("abc", "xyz"),
+        1234,
+      ])
+    end
+  end
+end


### PR DESCRIPTION
## Goal

Add the `FeatureFlagDelegate` class, which is used to manipulate stored feature flags in much the same way as [the `MetadataDelegate`](https://github.com/bugsnag/bugsnag-ruby/blob/caf3ecc9aa812af4df0275861a739da297e83398/lib/bugsnag/utility/metadata_delegate.rb) works for metadata values