### PR TITLE
Add feature flags to events

### DIFF
--- a/lib/bugsnag/report.rb
+++ b/lib/bugsnag/report.rb
@@ -143,6 +143,7 @@ module Bugsnag
       self.user = {}
 
       @metadata_delegate = Utility::MetadataDelegate.new
+      @feature_flags = Utility::FeatureFlagDelegate.new
     end
 
     ##
@@ -220,6 +221,7 @@ module Bugsnag
           time: @created_at
         },
         exceptions: exceptions,
+        featureFlags: @feature_flags.as_json,
         groupingHash: grouping_hash,
         metaData: meta_data,
         session: session,
@@ -356,6 +358,49 @@ module Bugsnag
     # @return [void]
     def clear_metadata(section, *args)
       @metadata_delegate.clear_metadata(@meta_data, section, *args)
+    end
+
+    # Get the array of stored feature flags
+    #
+    # @return [Array<Bugsnag::FeatureFlag>]
+    def feature_flags
+      @feature_flags.to_a
+    end
+
+    # Add a feature flag with the given name & variant
+    #
+    # @param name [String]
+    # @param variant [String, nil]
+    # @return [void]
+    def add_feature_flag(name, variant = nil)
+      @feature_flags.add(name, variant)
+    end
+
+    # Merge the given array of FeatureFlag instances into the stored feature
+    # flags
+    #
+    # New flags will be appended to the array. Flags with the same name will be
+    # overwritten, but their position in the array will not change
+    #
+    # @param feature_flags [Array<Bugsnag::FeatureFlag>]
+    # @return [void]
+    def add_feature_flags(feature_flags)
+      @feature_flags.merge(feature_flags)
+    end
+
+    # Remove the stored flag with the given name
+    #
+    # @param name [String]
+    # @return [void]
+    def clear_feature_flag(name)
+      @feature_flags.remove(name)
+    end
+
+    # Remove all the stored flags
+    #
+    # @return [void]
+    def clear_feature_flags
+      @feature_flags.clear
     end
 
     ##


### PR DESCRIPTION
## Goal

Feature flags can now be added and removed from events in callbacks, e.g.:

```ruby
Bugsnag.notify(exception) do |event|
  event.add_feature_flag("example")
  event.add_feature_flag("another example", "variant-1234")
end
```