### PR TITLE
Add Maze Runner tests for feature flags in Rack apps

### DIFF
--- a/features/rack.feature
+++ b/features/rack.feature
@@ -137,3 +137,40 @@ Scenario: A request with cookies and no matching filter will set cookies in meta
   And the event "metaData.request.params.b" equals "456"
   And the event "metaData.request.referer" is null
   And the event "metaData.request.url" ends with "/unhandled?a=123&b=456"
+
+Scenario: adding feature flags for an unhandled error
+  Given I start the rack service
+  When I navigate to the route "/feature-flags/unhandled" on the rack app
+  And I wait to receive an error
+  Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
+  And the event contains the following feature flags:
+     | featureFlag   | variant |
+     | a             | 1       |
+     | b             |         |
+     | c             | 3       |
+     | d             |         |
+
+ Scenario: adding feature flags for a handled error
+  Given I start the rack service
+  When I navigate to the route "/feature-flags/handled" on the rack app
+  And I wait to receive an error
+  Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
+  And the event contains the following feature flags:
+     | featureFlag   | variant |
+     | x             |         |
+     | y             | 1234    |
+     | z             |         |
+
+Scenario: clearing feature flags for an unhandled error
+  Given I start the rack service
+  When I navigate to the route "/feature-flags/unhandled?clear_all_flags=1" on the rack app
+  And I wait to receive an error
+  Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
+  And the event has no feature flags
+
+ Scenario: clearing feature flags for a handled error
+  Given I start the rack service
+  When I navigate to the route "/feature-flags/handled?clear_all_flags=1" on the rack app
+  And I wait to receive an error
+  Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
+  And the event has no feature flags


### PR DESCRIPTION
## Goal

Adds some Maze Runner tests for feature flags in our Rack fixture apps

I noticed we have a separate Rack fixture for v1 & v2, but they are identical code-wise. I'll merge them into a single fixture in a separate PR