### PR TITLE
Drop feature flags with invalid names

### DIFF
--- a/lib/bugsnag/feature_flag.rb
+++ b/lib/bugsnag/feature_flag.rb
@@ -42,6 +42,16 @@ module Bugsnag
       end
     end
 
+    # Check if this flag is valid, i.e. has a name that's a String and a variant
+    # that's either nil or a String
+    #
+    # @return [Boolean]
+    def valid?
+      @name.is_a?(String) &&
+        !@name.empty? &&
+        (@variant.nil? || @variant.is_a?(String))
+    end
+
     private
 
     # Coerce this variant into a valid value (String or nil)

--- a/lib/bugsnag/utility/feature_flag_delegate.rb
+++ b/lib/bugsnag/utility/feature_flag_delegate.rb
@@ -14,7 +14,11 @@ module Bugsnag::Utility
     # @param variant [String, nil]
     # @return [void]
     def add(name, variant)
-      @storage[name] = Bugsnag::FeatureFlag.new(name, variant)
+      flag = Bugsnag::FeatureFlag.new(name, variant)
+
+      return unless flag.valid?
+
+      @storage[flag.name] = flag
     end
 
     # Merge the given array of FeatureFlag instances into the stored feature
@@ -28,6 +32,7 @@ module Bugsnag::Utility
     def merge(feature_flags)
       feature_flags.each do |flag|
         next unless flag.is_a?(Bugsnag::FeatureFlag)
+        next unless flag.valid?
 
         @storage[flag.name] = flag
       end

--- a/spec/feature_flag_spec.rb
+++ b/spec/feature_flag_spec.rb
@@ -118,4 +118,47 @@ describe Bugsnag::FeatureFlag do
       expect(flag2).not_to eq(flag1)
     end
   end
+
+  describe "#valid?" do
+    [
+      nil,
+      true,
+      false,
+      1234,
+      [1, 2, 3],
+      { a: 1, b: 2 },
+      :abc,
+      "",
+    ].each do |name|
+      it "returns false when name is '#{name.inspect}' with no variant" do
+        flag = Bugsnag::FeatureFlag.new(name)
+
+        expect(flag.valid?).to be(false)
+      end
+
+      it "returns false when name is '#{name.inspect}' and variant is present" do
+        flag = Bugsnag::FeatureFlag.new(name, name)
+
+        expect(flag.valid?).to be(false)
+      end
+
+      it "returns true when name is a string and variant is '#{name.inspect}'" do
+        flag = Bugsnag::FeatureFlag.new("a name", name)
+
+        expect(flag.valid?).to be(true)
+      end
+    end
+
+    it "returns true when name is a string with no variant" do
+      flag = Bugsnag::FeatureFlag.new("a name")
+
+      expect(flag.valid?).to be(true)
+    end
+
+    it "returns true when name and variant are strings" do
+      flag = Bugsnag::FeatureFlag.new("a name", "a variant")
+
+      expect(flag.valid?).to be(true)
+    end
+  end
 end

--- a/spec/utility/feature_flag_delegate_spec.rb
+++ b/spec/utility/feature_flag_delegate_spec.rb
@@ -1,6 +1,16 @@
 require 'spec_helper'
 
 describe Bugsnag::Utility::FeatureFlagDelegate do
+  invalid_names = [
+    nil,
+    true,
+    false,
+    1234,
+    [1, 2, 3],
+    { a: 1, b: 2 },
+    "",
+  ]
+
   it "contains no flags by default" do
     delegate = Bugsnag::Utility::FeatureFlagDelegate.new
 
@@ -59,6 +69,21 @@ describe Bugsnag::Utility::FeatureFlagDelegate do
         { "featureFlag" => "abc", "variant" => "987" },
         { "featureFlag" => "another" },
       ])
+    end
+
+    invalid_names.each do |name|
+      it "drops flags when name is '#{name.inspect}'" do
+        delegate = Bugsnag::Utility::FeatureFlagDelegate.new
+
+        delegate.add("abc", "123")
+        delegate.add(name, nil)
+        delegate.add("xyz", "987")
+
+        expect(delegate.as_json).to eq([
+          { "featureFlag" => "abc", "variant" => "123" },
+          { "featureFlag" => "xyz", "variant" => "987" },
+        ])
+      end
     end
   end
 
@@ -149,6 +174,23 @@ describe Bugsnag::Utility::FeatureFlagDelegate do
         { "featureFlag" => "c", "variant" => "111" },
         { "featureFlag" => "d" },
       ])
+    end
+
+    invalid_names.each do |name|
+      it "drops flag when name is '#{name.inspect}'" do
+        delegate = Bugsnag::Utility::FeatureFlagDelegate.new
+
+        delegate.merge([
+          Bugsnag::FeatureFlag.new("abc", "123"),
+          Bugsnag::FeatureFlag.new(name, "456"),
+          Bugsnag::FeatureFlag.new("xyz", "789"),
+        ])
+
+        expect(delegate.as_json).to eq([
+          { "featureFlag" => "abc", "variant" => "123" },
+          { "featureFlag" => "xyz", "variant" => "789" },
+        ])
+      end
     end
   end
 


### PR DESCRIPTION
## Goal

As discussed in [#745](https://github.com/bugsnag/bugsnag-ruby/pull/745/files/14b7514f74c1f9b2c58df2959a42ba529b77a406#r1022695422), we should not be sending feature flags that have invalid names to the Event API

This PR prevents feature flags from being added to the `FeatureFlagDelegate` using a new `FeatureFlag#valid?` method

A feature flag is valid only if:

- name is a string with at least 1 character
- variant is nil OR variant is a string