### PR TITLE
Add support for adding global feature flags

### DIFF
--- a/lib/bugsnag.rb
+++ b/lib/bugsnag.rb
@@ -429,6 +429,42 @@ module Bugsnag
       configuration.clear_metadata(section, *args)
     end
 
+    # Add a feature flag with the given name & variant
+    #
+    # @param name [String]
+    # @param variant [String, nil]
+    # @return [void]
+    def add_feature_flag(name, variant = nil)
+      configuration.add_feature_flag(name, variant)
+    end
+
+    # Merge the given array of FeatureFlag instances into the stored feature
+    # flags
+    #
+    # New flags will be appended to the array. Flags with the same name will be
+    # overwritten, but their position in the array will not change
+    #
+    # @param feature_flags [Array<Bugsnag::FeatureFlag>]
+    # @return [void]
+    def add_feature_flags(feature_flags)
+      configuration.add_feature_flags(feature_flags)
+    end
+
+    # Remove the stored flag with the given name
+    #
+    # @param name [String]
+    # @return [void]
+    def clear_feature_flag(name)
+      configuration.clear_feature_flag(name)
+    end
+
+    # Remove all the stored flags
+    #
+    # @return [void]
+    def clear_feature_flags
+      configuration.clear_feature_flags
+    end
+
     private
 
     def should_deliver_notification?(exception, auto_notify)

--- a/lib/bugsnag/report.rb
+++ b/lib/bugsnag/report.rb
@@ -143,7 +143,7 @@ module Bugsnag
       self.user = {}
 
       @metadata_delegate = Utility::MetadataDelegate.new
-      @feature_flags = Utility::FeatureFlagDelegate.new
+      @feature_flags = configuration.feature_flag_delegate.dup
     end
 
     ##

--- a/lib/bugsnag/utility/feature_flag_delegate.rb
+++ b/lib/bugsnag/utility/feature_flag_delegate.rb
@@ -8,6 +8,13 @@ module Bugsnag::Utility
       @storage = {}
     end
 
+    def initialize_dup(original)
+      super
+
+      # copy the internal storage when 'dup' is called
+      @storage = @storage.dup
+    end
+
     # Add a feature flag with the given name & variant
     #
     # @param name [String]

--- a/spec/bugsnag_spec.rb
+++ b/spec/bugsnag_spec.rb
@@ -1127,4 +1127,84 @@ describe Bugsnag do
       })
     end
   end
+
+  describe "feature flags" do
+    it "is added to the payload" do
+      Bugsnag.add_feature_flag('abc')
+      Bugsnag.add_feature_flag('xyz', '123')
+
+      Bugsnag.notify(BugsnagTestException.new("It crashed"))
+
+      expect(Bugsnag).to have_sent_notification { |payload, headers|
+        event = get_event_from_payload(payload)
+        expect(event["featureFlags"]).to eq([
+          { "featureFlag" => "abc" },
+          { "featureFlag" => "xyz", "variant" => "123" },
+        ])
+      }
+    end
+
+    it "does not mutate the global feature flags if more flags are added" do
+      Bugsnag.add_feature_flag('abc')
+      Bugsnag.add_feature_flag('xyz', '123')
+
+      Bugsnag.notify(BugsnagTestException.new("It crashed")) do |event|
+        event.add_feature_flag('another one')
+      end
+
+      expect(Bugsnag).to have_sent_notification { |payload, headers|
+        event = get_event_from_payload(payload)
+        expect(event["featureFlags"]).to eq([
+          { "featureFlag" => "abc" },
+          { "featureFlag" => "xyz", "variant" => "123" },
+          { "featureFlag" => "another one" },
+        ])
+
+        expect(Bugsnag.configuration.feature_flag_delegate.as_json).to eq([
+          { "featureFlag" => "abc" },
+          { "featureFlag" => "xyz", "variant" => "123" },
+        ])
+      }
+    end
+
+    it "does not mutate the global feature flags if flags are removed" do
+      Bugsnag.add_feature_flag('abc')
+      Bugsnag.add_feature_flag('xyz', '123')
+
+      Bugsnag.notify(BugsnagTestException.new("It crashed")) do |event|
+        event.clear_feature_flags
+      end
+
+      expect(Bugsnag).to have_sent_notification { |payload, headers|
+        event = get_event_from_payload(payload)
+        expect(event["featureFlags"]).to be_empty
+
+        expect(Bugsnag.configuration.feature_flag_delegate.as_json).to eq([
+          { "featureFlag" => "abc" },
+          { "featureFlag" => "xyz", "variant" => "123" },
+        ])
+      }
+    end
+
+    it "does not mutate the event's feature flags if global flags are removed" do
+      Bugsnag.add_feature_flags([
+        Bugsnag::FeatureFlag.new('abc'),
+        Bugsnag::FeatureFlag.new('xyz', 123),
+      ])
+
+      Bugsnag.notify(BugsnagTestException.new("It crashed")) do |event|
+        Bugsnag.clear_feature_flags
+      end
+
+      expect(Bugsnag).to have_sent_notification { |payload, headers|
+        event = get_event_from_payload(payload)
+        expect(event["featureFlags"]).to eq([
+          { "featureFlag" => "abc" },
+          { "featureFlag" => "xyz", "variant" => "123" },
+        ])
+
+        expect(Bugsnag.configuration.feature_flag_delegate.as_json).to be_empty
+      }
+    end
+  end
 end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -712,4 +712,107 @@ describe Bugsnag::Configuration do
       end
     end
   end
+
+  describe "feature flags" do
+    describe "#feature_flag_delegate" do
+      it "is initially empty" do
+        expect(subject.feature_flag_delegate.to_a).to be_empty
+      end
+
+      it "cannot be reassigned" do
+        expect(subject).not_to respond_to(:feature_flag_delegate=)
+      end
+
+      it "reflects changes in add/clear feature flags" do
+        subject.add_feature_flag('abc')
+        subject.add_feature_flags([
+          Bugsnag::FeatureFlag.new('1'),
+          Bugsnag::FeatureFlag.new('2', 'z'),
+          Bugsnag::FeatureFlag.new('3'),
+        ])
+        subject.add_feature_flag('xyz', '1234')
+
+        subject.clear_feature_flag('3')
+
+        expect(subject.feature_flag_delegate.to_a).to eq([
+          Bugsnag::FeatureFlag.new('abc'),
+          Bugsnag::FeatureFlag.new('1'),
+          Bugsnag::FeatureFlag.new('2', 'z'),
+          Bugsnag::FeatureFlag.new('xyz', '1234'),
+        ])
+
+        subject.clear_feature_flags
+
+        expect(subject.feature_flag_delegate.to_a).to be_empty
+      end
+    end
+
+    describe "concurrent access" do
+      it "can handle multiple threads adding feature flags" do
+        configuration = Bugsnag::Configuration.new
+
+        threads = 5.times.map do |i|
+          Thread.new do
+            configuration.add_feature_flag("thread_#{i} flag 1", i)
+          end
+        end
+
+        threads += 5.times.map do |i|
+          Thread.new do
+            configuration.add_feature_flags([
+              Bugsnag::FeatureFlag.new("thread_#{i} flag 2", i * 100),
+              Bugsnag::FeatureFlag.new("thread_#{i} flag 3", i * 100 + 1),
+            ])
+          end
+        end
+
+        threads.shuffle.map(&:join)
+
+        flags = configuration.feature_flag_delegate.to_a.sort do |a, b|
+          a.name <=> b.name
+        end
+
+        expect(flags).to eq([
+          Bugsnag::FeatureFlag.new('thread_0 flag 1', 0),
+          Bugsnag::FeatureFlag.new('thread_0 flag 2', 0),
+          Bugsnag::FeatureFlag.new('thread_0 flag 3', 1),
+          Bugsnag::FeatureFlag.new('thread_1 flag 1', 1),
+          Bugsnag::FeatureFlag.new('thread_1 flag 2', 100),
+          Bugsnag::FeatureFlag.new('thread_1 flag 3', 101),
+          Bugsnag::FeatureFlag.new('thread_2 flag 1', 2),
+          Bugsnag::FeatureFlag.new('thread_2 flag 2', 200),
+          Bugsnag::FeatureFlag.new('thread_2 flag 3', 201),
+          Bugsnag::FeatureFlag.new('thread_3 flag 1', 3),
+          Bugsnag::FeatureFlag.new('thread_3 flag 2', 300),
+          Bugsnag::FeatureFlag.new('thread_3 flag 3', 301),
+          Bugsnag::FeatureFlag.new('thread_4 flag 1', 4),
+          Bugsnag::FeatureFlag.new('thread_4 flag 2', 400),
+          Bugsnag::FeatureFlag.new('thread_4 flag 3', 401),
+        ])
+      end
+
+      it "can handle multiple threads clearing feature flags" do
+        configuration = Bugsnag::Configuration.new
+
+        configuration.add_feature_flag('abc')
+        configuration.add_feature_flag('xyz')
+
+        5.times do |i|
+          configuration.add_feature_flag("thread_#{i}", i)
+        end
+
+        threads = 5.times.map do |i|
+          Thread.new do
+            configuration.clear_feature_flag("thread_#{i}")
+            configuration.clear_feature_flag('abc')
+            configuration.clear_feature_flag('xyz')
+          end
+        end
+
+        threads.shuffle.map(&:join)
+
+        expect(configuration.feature_flag_delegate.to_a).to be_empty
+      end
+    end
+  end
 end

--- a/spec/utility/feature_flag_delegate_spec.rb
+++ b/spec/utility/feature_flag_delegate_spec.rb
@@ -17,6 +17,37 @@ describe Bugsnag::Utility::FeatureFlagDelegate do
     expect(delegate.as_json).to eq([])
   end
 
+  it "does not get mutated after being duplicated" do
+    delegate1 = Bugsnag::Utility::FeatureFlagDelegate.new
+    delegate1.add('abc', '123')
+
+    delegate2 = delegate1.dup
+    delegate2.add('xyz', '987')
+
+    expect(delegate1.to_a).to eq([
+      Bugsnag::FeatureFlag.new('abc', '123'),
+    ])
+
+    expect(delegate2.to_a).to eq([
+      Bugsnag::FeatureFlag.new('abc', '123'),
+      Bugsnag::FeatureFlag.new('xyz', '987'),
+    ])
+
+    delegate3 = delegate2.dup
+    delegate3.clear
+
+    expect(delegate1.to_a).to eq([
+      Bugsnag::FeatureFlag.new('abc', '123'),
+    ])
+
+    expect(delegate2.to_a).to eq([
+      Bugsnag::FeatureFlag.new('abc', '123'),
+      Bugsnag::FeatureFlag.new('xyz', '987'),
+    ])
+
+    expect(delegate3.to_a).to be_empty
+  end
+
   describe "#add" do
     it "can add flags individually" do
       delegate = Bugsnag::Utility::FeatureFlagDelegate.new


### PR DESCRIPTION
## Goal

This PR adds support for global feature flags via `Bugsnag.add_feature_flag` & `config.add_feature_flag`. These flags are added to every future event automatically, in much the same way as [global metadata works](https://docs.bugsnag.com/platforms/ruby/other/customizing-error-reports/#global-metadata) vs [event-specific metadata](https://docs.bugsnag.com/platforms/ruby/other/customizing-error-reports/#updating-events-using-callbacks)

This is useful for flags that are not per-user but toggle features on/off for everyone at once

The APIs added are:

```ruby
Bugsnag.add_feature_flag(name, variant)
Bugsnag.add_feature_flags(feature_flags)
Bugsnag.clear_feature_flag(name)
Bugsnag.clear_feature_flags

Bugsnag.configure do |config|
  config.add_feature_flag(name, variant)
  config.add_feature_flags(feature_flags)
  config.clear_feature_flag(name)
  config.clear_feature_flags
end
```