### PR TITLE
Scope feature flags to the current thread

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -4,6 +4,7 @@
 --no-private
 --protected
 --title "bugsnag-ruby API Documentation"
+--embed-mixins
 lib/**/*.rb
 -
 README.md

--- a/features/fixtures/rails3/app/app/controllers/feature_flags_controller.rb
+++ b/features/fixtures/rails3/app/app/controllers/feature_flags_controller.rb
@@ -4,10 +4,14 @@ class FeatureFlagsController < ActionController::Base
   before_bugsnag_notify :add_feature_flags
 
   def unhandled
+    Bugsnag.add_feature_flag('unhandled')
+
     raise 'oh no'
   end
 
   def handled
+    Bugsnag.add_feature_flag('handled')
+
     Bugsnag.notify(RuntimeError.new('ahhh'))
 
     render json: {}
@@ -21,7 +25,7 @@ class FeatureFlagsController < ActionController::Base
     end
 
     if params.key?('clear_all_flags')
-      event.clear_feature_flags
+      event.add_metadata(:clear_all_flags, :a, 1)
     else
       event.clear_feature_flag('should be removed!')
     end

--- a/features/fixtures/rails3/app/config/initializers/bugsnag.rb
+++ b/features/fixtures/rails3/app/config/initializers/bugsnag.rb
@@ -33,11 +33,14 @@ Bugsnag.configure do |config|
     end)
   end
 
-  config.add_feature_flags([
-    Bugsnag::FeatureFlag.new('from config 1'),
-    Bugsnag::FeatureFlag.new('from config 2', 'abc xyz'),
-    Bugsnag::FeatureFlag.new('should be removed!'),
-  ])
-end
+  config.add_on_error(proc do |event|
+    event.add_feature_flags([
+      Bugsnag::FeatureFlag.new('from config 1'),
+      Bugsnag::FeatureFlag.new('from config 2', 'abc xyz'),
+    ])
 
-Bugsnag.add_feature_flag('from global', '123')
+    if event.metadata.key?(:clear_all_flags)
+      event.clear_feature_flags
+    end
+  end)
+end

--- a/features/fixtures/rails4/app/app/controllers/feature_flags_controller.rb
+++ b/features/fixtures/rails4/app/app/controllers/feature_flags_controller.rb
@@ -4,10 +4,14 @@ class FeatureFlagsController < ActionController::Base
   before_bugsnag_notify :add_feature_flags
 
   def unhandled
+    Bugsnag.add_feature_flag('unhandled')
+
     raise 'oh no'
   end
 
   def handled
+    Bugsnag.add_feature_flag('handled')
+
     Bugsnag.notify(RuntimeError.new('ahhh'))
 
     render json: {}
@@ -21,7 +25,7 @@ class FeatureFlagsController < ActionController::Base
     end
 
     if params.key?('clear_all_flags')
-      event.clear_feature_flags
+      event.add_metadata(:clear_all_flags, :a, 1)
     else
       event.clear_feature_flag('should be removed!')
     end

--- a/features/fixtures/rails4/app/config/initializers/bugsnag.rb
+++ b/features/fixtures/rails4/app/config/initializers/bugsnag.rb
@@ -33,11 +33,14 @@ Bugsnag.configure do |config|
     end)
   end
 
-  config.add_feature_flags([
-    Bugsnag::FeatureFlag.new('from config 1'),
-    Bugsnag::FeatureFlag.new('from config 2', 'abc xyz'),
-    Bugsnag::FeatureFlag.new('should be removed!'),
-  ])
-end
+  config.add_on_error(proc do |event|
+    event.add_feature_flags([
+      Bugsnag::FeatureFlag.new('from config 1'),
+      Bugsnag::FeatureFlag.new('from config 2', 'abc xyz'),
+    ])
 
-Bugsnag.add_feature_flag('from global', '123')
+    if event.metadata.key?(:clear_all_flags)
+      event.clear_feature_flags
+    end
+  end)
+end

--- a/features/fixtures/rails5/app/app/controllers/feature_flags_controller.rb
+++ b/features/fixtures/rails5/app/app/controllers/feature_flags_controller.rb
@@ -4,10 +4,14 @@ class FeatureFlagsController < ActionController::Base
   before_bugsnag_notify :add_feature_flags
 
   def unhandled
+    Bugsnag.add_feature_flag('unhandled')
+
     raise 'oh no'
   end
 
   def handled
+    Bugsnag.add_feature_flag('handled')
+
     Bugsnag.notify(RuntimeError.new('ahhh'))
   end
 
@@ -19,7 +23,7 @@ class FeatureFlagsController < ActionController::Base
     end
 
     if params.key?('clear_all_flags')
-      event.clear_feature_flags
+      event.add_metadata(:clear_all_flags, :a, 1)
     else
       event.clear_feature_flag('should be removed!')
     end

--- a/features/fixtures/rails5/app/config/initializers/bugsnag.rb
+++ b/features/fixtures/rails5/app/config/initializers/bugsnag.rb
@@ -33,11 +33,14 @@ Bugsnag.configure do |config|
     end)
   end
 
-  config.add_feature_flags([
-    Bugsnag::FeatureFlag.new('from config 1'),
-    Bugsnag::FeatureFlag.new('from config 2', 'abc xyz'),
-    Bugsnag::FeatureFlag.new('should be removed!'),
-  ])
-end
+  config.add_on_error(proc do |event|
+    event.add_feature_flags([
+      Bugsnag::FeatureFlag.new('from config 1'),
+      Bugsnag::FeatureFlag.new('from config 2', 'abc xyz'),
+    ])
 
-Bugsnag.add_feature_flag('from global', '123')
+    if event.metadata.key?(:clear_all_flags)
+      event.clear_feature_flags
+    end
+  end)
+end

--- a/features/fixtures/rails6/app/app/controllers/feature_flags_controller.rb
+++ b/features/fixtures/rails6/app/app/controllers/feature_flags_controller.rb
@@ -4,10 +4,14 @@ class FeatureFlagsController < ActionController::Base
   before_bugsnag_notify :add_feature_flags
 
   def unhandled
+    Bugsnag.add_feature_flag('unhandled')
+
     raise 'oh no'
   end
 
   def handled
+    Bugsnag.add_feature_flag('handled')
+
     Bugsnag.notify(RuntimeError.new('ahhh'))
   end
 
@@ -19,7 +23,7 @@ class FeatureFlagsController < ActionController::Base
     end
 
     if params.key?('clear_all_flags')
-      event.clear_feature_flags
+      event.add_metadata(:clear_all_flags, :a, 1)
     else
       event.clear_feature_flag('should be removed!')
     end

--- a/features/fixtures/rails6/app/config/initializers/bugsnag.rb
+++ b/features/fixtures/rails6/app/config/initializers/bugsnag.rb
@@ -33,11 +33,14 @@ Bugsnag.configure do |config|
     end)
   end
 
-  config.add_feature_flags([
-    Bugsnag::FeatureFlag.new('from config 1'),
-    Bugsnag::FeatureFlag.new('from config 2', 'abc xyz'),
-    Bugsnag::FeatureFlag.new('should be removed!'),
-  ])
-end
+  config.add_on_error(proc do |event|
+    event.add_feature_flags([
+      Bugsnag::FeatureFlag.new('from config 1'),
+      Bugsnag::FeatureFlag.new('from config 2', 'abc xyz'),
+    ])
 
-Bugsnag.add_feature_flag('from global', '123')
+    if event.metadata.key?(:clear_all_flags)
+      event.clear_feature_flags
+    end
+  end)
+end

--- a/features/fixtures/rails7/app/app/controllers/feature_flags_controller.rb
+++ b/features/fixtures/rails7/app/app/controllers/feature_flags_controller.rb
@@ -4,10 +4,14 @@ class FeatureFlagsController < ActionController::Base
   before_bugsnag_notify :add_feature_flags
 
   def unhandled
+    Bugsnag.add_feature_flag('unhandled')
+
     raise 'oh no'
   end
 
   def handled
+    Bugsnag.add_feature_flag('handled')
+
     Bugsnag.notify(RuntimeError.new('ahhh'))
   end
 
@@ -19,7 +23,7 @@ class FeatureFlagsController < ActionController::Base
     end
 
     if params.key?('clear_all_flags')
-      event.clear_feature_flags
+      event.add_metadata(:clear_all_flags, :a, 1)
     else
       event.clear_feature_flag('should be removed!')
     end

--- a/features/fixtures/rails7/app/config/initializers/bugsnag.rb
+++ b/features/fixtures/rails7/app/config/initializers/bugsnag.rb
@@ -33,11 +33,14 @@ Bugsnag.configure do |config|
     end)
   end
 
-  config.add_feature_flags([
-    Bugsnag::FeatureFlag.new('from config 1'),
-    Bugsnag::FeatureFlag.new('from config 2', 'abc xyz'),
-    Bugsnag::FeatureFlag.new('should be removed!'),
-  ])
-end
+  config.add_on_error(proc do |event|
+    event.add_feature_flags([
+      Bugsnag::FeatureFlag.new('from config 1'),
+      Bugsnag::FeatureFlag.new('from config 2', 'abc xyz'),
+    ])
 
-Bugsnag.add_feature_flag('from global', '123')
+    if event.metadata.key?(:clear_all_flags)
+      event.clear_feature_flags
+    end
+  end)
+end

--- a/features/rack.feature
+++ b/features/rack.feature
@@ -139,7 +139,6 @@ Scenario: adding feature flags for an unhandled error
   Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
   And the event contains the following feature flags:
      | featureFlag   | variant |
-     | from global   | 123     |
      | from config 1 |         |
      | from config 2 | abc xyz |
      | a             | 1       |
@@ -154,7 +153,6 @@ Scenario: adding feature flags for an unhandled error
   Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
   And the event contains the following feature flags:
      | featureFlag   | variant |
-     | from global   | 123     |
      | from config 1 |         |
      | from config 2 | abc xyz |
      | x             |         |

--- a/features/rails_features/feature_flags.feature
+++ b/features/rails_features/feature_flags.feature
@@ -12,7 +12,7 @@ Scenario: adding feature flags for an unhandled error
   And the exception "message" equals "oh no"
   And the event contains the following feature flags:
      | featureFlag   | variant |
-     | from global   | 123     |
+     | unhandled     |         |
      | from config 1 |         |
      | from config 2 | abc xyz |
      | a             | 1       |
@@ -23,9 +23,9 @@ Scenario: adding feature flags for an unhandled error
   When I discard the oldest error
   And I navigate to the route "/features/unhandled?flags[x]=9&flags[y]&flags[z]=7" on the rails app
   And I wait to receive an error
-  And the event contains the following feature flags:
+  Then the event contains the following feature flags:
      | featureFlag   | variant |
-     | from global   | 123     |
+     | unhandled     |         |
      | from config 1 |         |
      | from config 2 | abc xyz |
      | x             | 9       |
@@ -44,18 +44,18 @@ Scenario: adding feature flags for a handled error
   And the exception "message" equals "ahhh"
   And the event contains the following feature flags:
      | featureFlag   | variant |
-     | from global   | 123     |
+     | handled       |         |
      | from config 1 |         |
      | from config 2 | abc xyz |
      | ab            | 12      |
      | cd            | 34      |
   # ensure each request can have its own set of feature flags
   When I discard the oldest error
-  And I navigate to the route "/features/unhandled?flags[e]=h&flags[f]=i&flags[g]" on the rails app
+  And I navigate to the route "/features/handled?flags[e]=h&flags[f]=i&flags[g]" on the rails app
   And I wait to receive an error
-  And the event contains the following feature flags:
+  Then the event contains the following feature flags:
      | featureFlag   | variant |
-     | from global   | 123     |
+     | handled       |         |
      | from config 1 |         |
      | from config 2 | abc xyz |
      | e             | h       |
@@ -76,9 +76,9 @@ Scenario: clearing all feature flags doesn't affect subsequent requests
   When I discard the oldest error
   And I navigate to the route "/features/unhandled?flags[x]=9&flags[y]&flags[z]=7" on the rails app
   And I wait to receive an error
-  And the event contains the following feature flags:
+  Then the event contains the following feature flags:
      | featureFlag   | variant |
-     | from global   | 123     |
+     | unhandled     |         |
      | from config 1 |         |
      | from config 2 | abc xyz |
      | x             | 9       |

--- a/lib/bugsnag.rb
+++ b/lib/bugsnag.rb
@@ -2,6 +2,7 @@ require "rubygems"
 require "thread"
 
 require "bugsnag/version"
+require "bugsnag/utility/feature_data_store"
 require "bugsnag/configuration"
 require "bugsnag/meta_data"
 require "bugsnag/report"
@@ -48,6 +49,8 @@ module Bugsnag
   NIL_EXCEPTION_DESCRIPTION = "'nil' was notified as an exception"
 
   class << self
+    include Utility::FeatureDataStore
+
     ##
     # Configure the Bugsnag notifier application-wide settings.
     #
@@ -429,42 +432,6 @@ module Bugsnag
       configuration.clear_metadata(section, *args)
     end
 
-    # Add a feature flag with the given name & variant
-    #
-    # @param name [String]
-    # @param variant [String, nil]
-    # @return [void]
-    def add_feature_flag(name, variant = nil)
-      configuration.add_feature_flag(name, variant)
-    end
-
-    # Merge the given array of FeatureFlag instances into the stored feature
-    # flags
-    #
-    # New flags will be appended to the array. Flags with the same name will be
-    # overwritten, but their position in the array will not change
-    #
-    # @param feature_flags [Array<Bugsnag::FeatureFlag>]
-    # @return [void]
-    def add_feature_flags(feature_flags)
-      configuration.add_feature_flags(feature_flags)
-    end
-
-    # Remove the stored flag with the given name
-    #
-    # @param name [String]
-    # @return [void]
-    def clear_feature_flag(name)
-      configuration.clear_feature_flag(name)
-    end
-
-    # Remove all the stored flags
-    #
-    # @return [void]
-    def clear_feature_flags
-      configuration.clear_feature_flags
-    end
-
     private
 
     def should_deliver_notification?(exception, auto_notify)
@@ -594,6 +561,13 @@ module Bugsnag
       return unwrapped if unwrapped.cause.nil?
 
       unwrapped.cause
+    end
+
+    # Expose the feature flag delegate for {Bugsnag::Utility::FeatureDataStore}
+    #
+    # @return [Bugsnag::Utility::FeatureFlagDelegate]
+    def feature_flag_delegate
+      configuration.feature_flag_delegate
     end
   end
 end

--- a/lib/bugsnag/configuration.rb
+++ b/lib/bugsnag/configuration.rb
@@ -18,6 +18,8 @@ require "bugsnag/endpoint_validator"
 
 module Bugsnag
   class Configuration
+    include Utility::FeatureDataStore
+
     # Your Integration API Key
     # @return [String, nil]
     attr_accessor :api_key
@@ -670,42 +672,6 @@ module Bugsnag
     # @api private
     def feature_flag_delegate
       request_data[:feature_flag_delegate] ||= Bugsnag::Utility::FeatureFlagDelegate.new
-    end
-
-    # Add a feature flag with the given name & variant
-    #
-    # @param name [String]
-    # @param variant [String, nil]
-    # @return [void]
-    def add_feature_flag(name, variant = nil)
-      feature_flag_delegate.add(name, variant)
-    end
-
-    # Merge the given array of FeatureFlag instances into the stored feature
-    # flags
-    #
-    # New flags will be appended to the array. Flags with the same name will be
-    # overwritten, but their position in the array will not change
-    #
-    # @param feature_flags [Array<Bugsnag::FeatureFlag>]
-    # @return [void]
-    def add_feature_flags(feature_flags)
-      feature_flag_delegate.merge(feature_flags)
-    end
-
-    # Remove the stored flag with the given name
-    #
-    # @param name [String]
-    # @return [void]
-    def clear_feature_flag(name)
-      feature_flag_delegate.remove(name)
-    end
-
-    # Remove all the stored flags
-    #
-    # @return [void]
-    def clear_feature_flags
-      feature_flag_delegate.clear
     end
 
     ##

--- a/lib/bugsnag/utility/feature_data_store.rb
+++ b/lib/bugsnag/utility/feature_data_store.rb
@@ -1,0 +1,41 @@
+module Bugsnag::Utility
+  # @abstract Requires a #feature_flag_delegate method returning a
+  #   {Bugsnag::Utility::FeatureFlagDelegate}
+  module FeatureDataStore
+    # Add a feature flag with the given name & variant
+    #
+    # @param name [String]
+    # @param variant [String, nil]
+    # @return [void]
+    def add_feature_flag(name, variant = nil)
+      feature_flag_delegate.add(name, variant)
+    end
+
+    # Merge the given array of FeatureFlag instances into the stored feature
+    # flags
+    #
+    # New flags will be appended to the array. Flags with the same name will be
+    # overwritten, but their position in the array will not change
+    #
+    # @param feature_flags [Array<Bugsnag::FeatureFlag>]
+    # @return [void]
+    def add_feature_flags(feature_flags)
+      feature_flag_delegate.merge(feature_flags)
+    end
+
+    # Remove the stored flag with the given name
+    #
+    # @param name [String]
+    # @return [void]
+    def clear_feature_flag(name)
+      feature_flag_delegate.remove(name)
+    end
+
+    # Remove all the stored flags
+    #
+    # @return [void]
+    def clear_feature_flags
+      feature_flag_delegate.clear
+    end
+  end
+end


### PR DESCRIPTION
## Goal

This allows users to add feature flags to Bugsnag whenever they interact with their feature flag service, e.g.

```ruby
flag = get_flag_from_service('new-login-page')

if flag.enabled?
  Bugsnag.add_feature_flag('new-login-page')
  # render new login page
else
  Bugsnag.clear_feature_flag('new-login-page')
  # render old login page
end
```

Before this PR, the above snippet would affect all web requests/queued jobs because `Bugsnag.add_feature_flag` would write to a global set of flags (similar to `Bugsnag.add_metadata` vs `event.add_metadata`)

With this PR, feature flags are stored in a thread local (just like breadcrumbs), meaning each web request or queued job will have a separate set of flags

This is important because feature flags will usually be user-specific, e.g. to allow rolling out features to small groups of users at a time. With the previous implementation this was still possible but meant relying on adding all flags for the user at once in an `on_error` callback, whereas the new implementation allows for adding flags individually when they are used

## Changeset

- Store the `Configuration`'s `FeatureFlagDelegate` in a thread local
- Moved feature flag API into a `FeatureDataStore` module to allow all 3 places that implement the API to share the same code & docs (`Bugsnag`, `Configuration` & `Event`/`Report`)
- Updated Maze Runner tests to reflect the new changes — these previously relied on some flags being global