### PR TITLE
Bump Nokogiri version used in fixtures to fix CI

### DIFF
--- a/spec/fixtures/apps/rails-initializer-config/Gemfile
+++ b/spec/fixtures/apps/rails-initializer-config/Gemfile
@@ -5,5 +5,5 @@ ruby_version = Gem::Version.new(RUBY_VERSION.dup)
 gem 'railties', ruby_version <= Gem::Version.new('2.6') ? '4.2.10' : '~> 6.0.2', require: %w(action_controller rails)
 gem 'rake', ruby_version <= Gem::Version.new('1.9.3') ? '~> 11.3.0' : '~> 12.3.0'
 gem 'minitest', ruby_version <= Gem::Version.new('2.2') ? '5.11.3' : '~> 5.14.0'
-gem 'nokogiri', '1.6.8'
+gem 'nokogiri', ruby_version < Gem::Version.new('2.6') ?  '1.6.8' : '~> 1.13.9'
 gem 'bugsnag', path: '../../../..'

--- a/spec/fixtures/apps/rails-invalid-initializer-config/Gemfile
+++ b/spec/fixtures/apps/rails-invalid-initializer-config/Gemfile
@@ -5,5 +5,5 @@ ruby_version = Gem::Version.new(RUBY_VERSION.dup)
 gem 'railties', ruby_version <= Gem::Version.new('2.6') ? '4.2.10' : '~> 6.0.2', require: %w(action_controller rails)
 gem 'rake', ruby_version <= Gem::Version.new('1.9.3') ? '~> 11.3.0' : '~> 12.3.0'
 gem 'minitest', ruby_version <= Gem::Version.new('2.2') ? '5.11.3' : '~> 5.14.0'
-gem 'nokogiri', '1.6.8'
+gem 'nokogiri', ruby_version < Gem::Version.new('2.6') ?  '1.6.8' : '~> 1.13.9'
 gem 'bugsnag', path: '../../../..'

--- a/spec/fixtures/apps/rails-no-config/Gemfile
+++ b/spec/fixtures/apps/rails-no-config/Gemfile
@@ -5,5 +5,5 @@ ruby_version = Gem::Version.new(RUBY_VERSION.dup)
 gem 'railties', ruby_version <= Gem::Version.new('2.6') ? '4.2.10' : '~> 6.0.2', require: %w(action_controller rails)
 gem 'rake', ruby_version <= Gem::Version.new('1.9.3') ? '~> 11.3.0' : '~> 12.3.0'
 gem 'minitest', ruby_version <= Gem::Version.new('2.2') ? '5.11.3' : '~> 5.14.0'
-gem 'nokogiri', '1.6.8'
+gem 'nokogiri', ruby_version < Gem::Version.new('2.6') ?  '1.6.8' : '~> 1.13.9'
 gem 'bugsnag', path: '../../../..'


### PR DESCRIPTION
## Goal

I'm not sure why this suddenly broke, but the super old Nokogiri version used in our fixtures no longer installs on Ruby 2.7, 3.0 & 3.1

This PR updates the version to fix CI