### PR TITLE
Support `Exception#detailed_message`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## TBD
+
+### Enhancements
+
+* Use `Exception#detailed_message` instead of `Exception#message` when available
+  | [#761](https://github.com/bugsnag/bugsnag-ruby/pull/761)
+
 ## v6.26.0 (1 December 2022)
 
 ### Enhancements

--- a/spec/report_spec.rb
+++ b/spec/report_spec.rb
@@ -34,6 +34,12 @@ else
   require_relative './support/exception_with_detailed_message_ruby_1'
 end
 
+class ExceptionWithDetailedMessageButNoHighlight < Exception
+  def detailed_message
+    "detail about '#{self}'"
+  end
+end
+
 shared_examples "Report or Event tests" do |class_to_test|
   context "metadata" do
     include_examples(
@@ -1466,6 +1472,16 @@ describe Bugsnag::Report do
       exception = get_exception_from_payload(payload)
       expect(exception["errorClass"]).to eq("ExceptionWithDetailedMessage")
       expect(exception["message"]).to eq("some message with some extra detail")
+    }
+  end
+
+  it "handles implementations of Exception#detailed_message with no 'highlight' parameter" do
+    Bugsnag.notify(ExceptionWithDetailedMessageButNoHighlight.new("some message"))
+
+    expect(Bugsnag).to have_sent_notification{ |payload, headers|
+      exception = get_exception_from_payload(payload)
+      expect(exception["errorClass"]).to eq("ExceptionWithDetailedMessageButNoHighlight")
+      expect(exception["message"]).to eq("detail about 'some message'")
     }
   end
 

--- a/spec/report_spec.rb
+++ b/spec/report_spec.rb
@@ -28,6 +28,12 @@ class JRubyException
   end
 end
 
+if RUBY_VERSION >= '2.0.0'
+  require_relative './support/exception_with_detailed_message'
+else
+  require_relative './support/exception_with_detailed_message_ruby_1'
+end
+
 shared_examples "Report or Event tests" do |class_to_test|
   context "metadata" do
     include_examples(
@@ -96,6 +102,17 @@ shared_examples "Report or Event tests" do |class_to_test|
         :error_class => "Timeout::Error",
         :message => "Timeout::Error",
         :severity => "warning"
+      })
+    end
+
+    it "uses Exception#detailed_message if available" do
+      exception = ExceptionWithDetailedMessage.new("some message")
+      report_or_event = class_to_test.new(exception, Bugsnag.configuration)
+
+      expect(report_or_event.summary).to eq({
+        error_class: "ExceptionWithDetailedMessage",
+        message: "some message with some extra detail",
+        severity: "warning"
       })
     end
 
@@ -287,6 +304,17 @@ shared_examples "Report or Event tests" do |class_to_test|
           ]
         )
       })
+    end
+
+    it "uses Exception#detailed_message if available" do
+      exception = ExceptionWithDetailedMessage.new("some message")
+      report_or_event = class_to_test.new(exception, Bugsnag.configuration)
+
+      expect(report_or_event.errors.length).to eq(1)
+
+      message = report_or_event.errors.first.error_message
+
+      expect(message).to eq("some message with some extra detail")
     end
   end
 
@@ -1399,7 +1427,6 @@ describe Bugsnag::Report do
   end
 
   it "does not unwrap more than 5 exceptions" do
-
     first_ex = ex = NestedException.new("Deep exception")
     10.times do |idx|
       ex = ex.original_exception = NestedException.new("Deep exception #{idx}")
@@ -1429,6 +1456,16 @@ describe Bugsnag::Report do
       exception = get_exception_from_payload(payload)
       expect(exception["errorClass"]).to eq("RuntimeError")
       expect(exception["message"]).to eq("test message")
+    }
+  end
+
+  it "uses Exception#detailed_message if available" do
+    Bugsnag.notify(ExceptionWithDetailedMessage.new("some message"))
+
+    expect(Bugsnag).to have_sent_notification{ |payload, headers|
+      exception = get_exception_from_payload(payload)
+      expect(exception["errorClass"]).to eq("ExceptionWithDetailedMessage")
+      expect(exception["message"]).to eq("some message with some extra detail")
     }
   end
 

--- a/spec/support/exception_with_detailed_message.rb
+++ b/spec/support/exception_with_detailed_message.rb
@@ -1,0 +1,10 @@
+class ExceptionWithDetailedMessage < Exception
+  def detailed_message(highlight: true)
+    # change the output to ensure we pass the right value for "highlight"
+    if highlight
+      "\e[1m!!! #{self} !!!\e[0m"
+    else
+      "#{self} with some extra detail"
+    end
+  end
+end

--- a/spec/support/exception_with_detailed_message_ruby_1.rb
+++ b/spec/support/exception_with_detailed_message_ruby_1.rb
@@ -1,0 +1,11 @@
+# ExceptionWithDetailedMessage for Ruby 1.9 (no keyword argument)
+class ExceptionWithDetailedMessage < Exception
+  def detailed_message(params)
+    # change the output to ensure we pass the right value for "highlight"
+    if params[:highlight]
+      "\e[1m!!! #{self} !!!\e[0m"
+    else
+      "#{self} with some extra detail"
+    end
+  end
+end


### PR DESCRIPTION
## Goal

This was added in Ruby 3.2 for things like 'did_you_mean' that annotate existing exception messages

Currently the annotations are included in `Exception#message`, but when Ruby 3.2 releases they will move to `Exception#detailed_message` so we need to use the new method to keep the existing behaviour