### PR TITLE
Fix mailman fixture

### DIFF
--- a/features/fixtures/mailman/app/Gemfile
+++ b/features/fixtures/mailman/app/Gemfile
@@ -6,6 +6,7 @@ gem 'hitimes', '~> 1.2.6'
 gem 'i18n', '~> 0.9.5'
 gem 'rb-inotify', '0.9.8'
 gem 'maildir', '~> 2.1.0'
+gem 'mail', '~> 2.7.1'
 gem 'activesupport', '~> 3.2'
 gem 'rack', '~> 1.6.11'
 


### PR DESCRIPTION
## Goal

A newly released version of the `mail` gem broke the fixture by requiring too new of a Ruby version (via one of its dependencies `date`)