### PR TITLE
Allow Gem paths to be stripped from file names in stacktraces when they contain a Regexp special character

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ Changelog
 
 ## TBD
 
+### Fixes
+
+* Allow Gem paths to be stripped from file names in stacktraces when they contain a Regexp special character
+  | [#764](https://github.com/bugsnag/bugsnag-ruby/pull/764)
+
 ### Enhancements
 
 * Use `Exception#detailed_message` instead of `Exception#message` when available

--- a/lib/bugsnag/stacktrace.rb
+++ b/lib/bugsnag/stacktrace.rb
@@ -48,7 +48,9 @@ module Bugsnag
 
         # Strip common gem path prefixes
         if defined?(Gem)
-          file = Gem.path.inject(file) {|line, path| line.sub(/#{path}\//, "") }
+          Gem.path.each do |path|
+            file.sub!("#{path}/", "")
+          end
         end
 
         trace_hash[:file] = file


### PR DESCRIPTION
## Goal

We strip the Gem paths from file names in stack traces, but this doesn't work if there's a regexp special character

For example, the Ruby 3.2 RC contains a '+' in the gem path (at least locally and on CI): `/.../.gem/ruby/3.2.0+3`

This won't match any paths when used in a Regexp, because it is expecting one or more `0` characters, rather than the literal characters `0+`. I've changed this matching logic to use a string instead of a Regexp to sidestep this problem and save having to escape the path

I spent a bit of time looking at adding unit tests for this but decided not to in the end because it involves reaching into `Gem` internals and, with the wide range of Ruby versions we support, that didn't seem like a good idea. We already have tests for this stripping that use the real Gem path to prove this doesn't break anything

## Testing

This [caused a test to fail](https://github.com/bugsnag/bugsnag-ruby/blob/eefe5a0aff52d878c54c6ac2d43fd943ffefdaaa/spec/stacktrace_spec.rb#L380-L403) on the Ruby 3.2 RC, which now passes with this change