### PR TITLE
Add Ruby 3.2 to CI

### DIFF
--- a/.github/workflows/maze-runner.yml
+++ b/.github/workflows/maze-runner.yml
@@ -141,7 +141,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ['1.9', '2.0', '2.1', '2.2', '2.3', '2.4', '2.5', '2.6', '2.7', '3.0', '3.1']
+        ruby-version: ['1.9', '2.0', '2.1', '2.2', '2.3', '2.4', '2.5', '2.6', '2.7', '3.0', '3.1', '3.2-rc']
 
     uses: ./.github/workflows/run-maze-runner.yml
     with:

--- a/.github/workflows/maze-runner.yml
+++ b/.github/workflows/maze-runner.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ['1.9', '3.1']
+        ruby-version: ['1.9', '3.2-rc']
 
     uses: ./.github/workflows/run-maze-runner.yml
     with:
@@ -36,11 +36,11 @@ jobs:
             rack-version: '1'
           - ruby-version: '2.2'
             rack-version: '2'
-          - ruby-version: '3.1'
+          - ruby-version: '3.2-rc'
             rack-version: '2'
           - ruby-version: '2.4'
             rack-version: '3'
-          - ruby-version: '3.1'
+          - ruby-version: '3.2-rc'
             rack-version: '3'
 
     uses: ./.github/workflows/run-maze-runner.yml
@@ -56,7 +56,7 @@ jobs:
         include:
           - ruby-version: '2.0'
             que-version: '0.14'
-          - ruby-version: '3.1'
+          - ruby-version: '3.2-rc'
             que-version: '0.14'
           - ruby-version: '2.5'
             que-version: '1'
@@ -120,7 +120,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ['2.7', '3.1']
+        ruby-version: ['2.7', '3.2-rc']
         rails-version: ['6', '7', '_integrations']
         include:
           - ruby-version: '2.5'
@@ -128,7 +128,7 @@ jobs:
         exclude:
           - ruby-version: '2.7'
             rails-version: '6'
-          - ruby-version: '3.1'
+          - ruby-version: '3.2-rc'
             rails-version: '_integrations'
 
     uses: ./.github/workflows/run-maze-runner.yml

--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ['2.2', '2.3', '2.4', '2.5', '2.6', '2.7', '3.0', '3.1']
+        ruby-version: ['2.2', '2.3', '2.4', '2.5', '2.6', '2.7', '3.0', '3.1', '3.2']
         optional-groups: ['test sidekiq']
         include:
           - ruby-version: '1.9'


### PR DESCRIPTION
## Goal

Update CI to use Ruby 3.2

## Changeset

- `maze-runner.yml`: use the docker tag `3.2-rc` where we're currently running 3.1 — there's no `3.2` tag yet so this will need updating when 3.2 is officially released
- `test-package.yml`: add 3.2 as a version to run specs with (setup-ruby understands that without a RC suffix)