### PR TITLE
Fix typo in changelog version number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Changelog
 * Use `Exception#detailed_message` instead of `Exception#message` when available
   | [#761](https://github.com/bugsnag/bugsnag-ruby/pull/761)
 
-## v6.26.0 (1 December 2022)
+## v6.25.0 (1 December 2022)
 
 ### Enhancements
 


### PR DESCRIPTION
## Goal

I accidentally marked the last release as `6.26.0` instead of `6.25.0` in the changelog. The release used the correct .25 version, so only the changelog needs an update