### PR TITLE
fix typo in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-## v6.26.0 (1 December 2022)
+## v6.25.0 (1 December 2022)
 
 ### Enhancements
 


### PR DESCRIPTION
## Goal

There was a typo in the CHANGELOG which lists the most recent release as v6.26.0 - when it was actually v6.25.0

