### PR TITLE
Use the released Ruby 3.2 version on CI

### DIFF
--- a/.github/workflows/maze-runner.yml
+++ b/.github/workflows/maze-runner.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ['1.9', '3.2-rc']
+        ruby-version: ['1.9', '3.2']
 
     uses: ./.github/workflows/run-maze-runner.yml
     with:
@@ -36,11 +36,11 @@ jobs:
             rack-version: '1'
           - ruby-version: '2.2'
             rack-version: '2'
-          - ruby-version: '3.2-rc'
+          - ruby-version: '3.2'
             rack-version: '2'
           - ruby-version: '2.4'
             rack-version: '3'
-          - ruby-version: '3.2-rc'
+          - ruby-version: '3.2'
             rack-version: '3'
 
     uses: ./.github/workflows/run-maze-runner.yml
@@ -56,7 +56,7 @@ jobs:
         include:
           - ruby-version: '2.0'
             que-version: '0.14'
-          - ruby-version: '3.2-rc'
+          - ruby-version: '3.2'
             que-version: '0.14'
           - ruby-version: '2.5'
             que-version: '1'
@@ -120,7 +120,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ['2.7', '3.2-rc']
+        ruby-version: ['2.7', '3.2']
         rails-version: ['6', '7', '_integrations']
         include:
           - ruby-version: '2.5'
@@ -128,7 +128,7 @@ jobs:
         exclude:
           - ruby-version: '2.7'
             rails-version: '6'
-          - ruby-version: '3.2-rc'
+          - ruby-version: '3.2'
             rails-version: '_integrations'
 
     uses: ./.github/workflows/run-maze-runner.yml
@@ -141,7 +141,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ['1.9', '2.0', '2.1', '2.2', '2.3', '2.4', '2.5', '2.6', '2.7', '3.0', '3.1', '3.2-rc']
+        ruby-version: ['1.9', '2.0', '2.1', '2.2', '2.3', '2.4', '2.5', '2.6', '2.7', '3.0', '3.1', '3.2']
 
     uses: ./.github/workflows/run-maze-runner.yml
     with:


### PR DESCRIPTION
## Goal

Switch CI to run against the released 3.2 version instead of the release candidate