### PR TITLE
Use docker compose exec to run queue commands in maze runner tests

### DIFF
--- a/Gemfile-maze-runner
+++ b/Gemfile-maze-runner
@@ -1,3 +1,3 @@
 source "https://rubygems.org"
 
-gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v7.6.0'
+gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v7.10.1'

--- a/features/fixtures/que/Dockerfile
+++ b/features/fixtures/que/Dockerfile
@@ -13,3 +13,5 @@ ENV QUE_VERSION $QUE_VERSION
 RUN bundle install
 
 COPY app/ /usr/src/app
+
+CMD bundle exec que ./app.rb

--- a/features/fixtures/rails_integrations/app/lib/tasks/fixture.rake
+++ b/features/fixtures/rails_integrations/app/lib/tasks/fixture.rake
@@ -1,0 +1,13 @@
+namespace :fixture do
+  task queue_unhandled_job: [:environment] do
+    UnhandledJob.perform_later(1, yes: true)
+  end
+
+  task queue_working_job: [:environment] do
+    WorkingJob.perform_later
+  end
+
+  task queue_resque_job: [:environment] do
+    Resque.enqueue(ResqueWorker, 123, "abc", [7, 8, 9], x: true, y: false)
+  end
+end

--- a/features/fixtures/sidekiq/Dockerfile
+++ b/features/fixtures/sidekiq/Dockerfile
@@ -15,3 +15,5 @@ ENV SIDEKIQ_VERSION $SIDEKIQ_VERSION
 RUN bundle install
 
 COPY app/ /app/
+
+CMD bundle exec sidekiq -r ./app.rb

--- a/features/que.feature
+++ b/features/que.feature
@@ -1,8 +1,8 @@
 Feature: Errors are delivered to Bugsnag from Que
 
 Scenario: Que will deliver unhandled errors
-  Given I run the service "que" with the command "bundle exec ruby app.rb unhandled"
-  And I run the service "que" with the command "timeout 5 bundle exec que ./app.rb"
+  Given I start the service "que"
+  When I execute the command "bundle exec ruby app.rb unhandled" in the service "que"
   And I wait to receive an error
   Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
   And the event "unhandled" is true
@@ -14,8 +14,8 @@ Scenario: Que will deliver unhandled errors
   And the exception "errorClass" equals "RuntimeError"
 
 Scenario: Que will deliver handled errors
-  Given I run the service "que" with the command "bundle exec ruby app.rb handled"
-  And I run the service "que" with the command "timeout 5 bundle exec que ./app.rb"
+  Given I start the service "que"
+  When I execute the command "bundle exec ruby app.rb handled" in the service "que"
   And I wait to receive an error
   Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
   And the event "unhandled" is false

--- a/features/sidekiq.feature
+++ b/features/sidekiq.feature
@@ -1,7 +1,8 @@
 Feature: Bugsnag raises errors in Sidekiq workers
 
 Scenario: An unhandled RuntimeError sends a report
-  Given I run the service "sidekiq" with the command "timeout 5 bundle exec rake sidekiq_tests:unhandled_error"
+  Given I start the service "sidekiq"
+  And I execute the command "bundle exec ruby initializers/UnhandledError.rb" in the service "sidekiq"
   And I wait to receive an error
   Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
   And the event "unhandled" is true
@@ -19,7 +20,8 @@ Scenario: An unhandled RuntimeError sends a report
   And the event "metaData.config.delivery_method" equals "thread_queue"
 
 Scenario: A handled RuntimeError can be notified
-  Given I run the service "sidekiq" with the command "timeout 5 bundle exec rake sidekiq_tests:handled_error"
+  Given I start the service "sidekiq"
+  And I execute the command "bundle exec ruby initializers/HandledError.rb" in the service "sidekiq"
   And I wait to receive an error
   Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
   And the event "unhandled" is false
@@ -35,7 +37,8 @@ Scenario: A handled RuntimeError can be notified
 
 Scenario: Synchronous delivery can be used
   Given I set environment variable "BUGSNAG_DELIVERY_METHOD" to "synchronous"
-  And I run the service "sidekiq" with the command "timeout 5 bundle exec rake sidekiq_tests:handled_error"
+  And I start the service "sidekiq"
+  And I execute the command "bundle exec ruby initializers/HandledError.rb" in the service "sidekiq"
   And I wait to receive an error
   Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
   And the event "unhandled" is false

--- a/features/steps/ruby_notifier_steps.rb
+++ b/features/steps/ruby_notifier_steps.rb
@@ -27,13 +27,27 @@ Given("I start the rails service") do
   }
 end
 
+Given("I start the rails service with the database") do
+  steps %Q{
+    Given I start the rails service
+    And I run the "db:prepare" rake task in the rails app
+    And I run the "db:migrate" rake task in the rails app
+  }
+end
+
 When("I navigate to the route {string} on the rails app") do |route|
   RAILS_FIXTURE.navigate_to(route)
 end
 
 When("I run {string} in the rails app") do |command|
   steps %Q{
-    When I run the service "rails#{ENV['RAILS_VERSION']}" with the command "#{command}"
+    When I execute the command "#{command}" in the service "rails#{ENV['RAILS_VERSION']}"
+  }
+end
+
+When("I run {string} in the rails app in the background") do |command|
+  steps %Q{
+    When I execute the command "#{command}" in the service "rails#{ENV['RAILS_VERSION']}" in the background
   }
 end
 
@@ -43,9 +57,15 @@ When("I run the {string} rake task in the rails app") do |task|
   }
 end
 
+When("I run the {string} rake task in the rails app in the background") do |task|
+  steps %Q{
+    When I run "bundle exec rake #{task}" in the rails app in the background
+  }
+end
+
 When("I run {string} with the rails runner") do |code|
   steps %Q{
-    When I run "bundle exec rails runner '#{code}'" in the rails app
+    When I execute the command "bundle exec rails runner #{code}" in the service "rails#{ENV['RAILS_VERSION']}"
   }
 end
 


### PR DESCRIPTION
## Goal

Switch to using `docker compose exec` to run queue commands in the Maze Runner tests

This is faster and more reliable than the `timeout` based approach we're currently using