### PR TITLE
`bundle install` with `--with` and `--binstubs` flags has been deprecated

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,12 +17,14 @@ Thank you!
 
 * Install the test dependencies
     ```
-    bundle install --with test sidekiq --binstubs
+    bundle config set --local with 'test sidekiq'
+    bundle install
+    bundle binstubs --all
     ```
 
 * Run the tests with and make sure they all pass
     ```
-    bundle exec rake
+    bin/rake
     ```
     
 * Further information on installing and running the tests can be found in [the testing guide](TESTING.md)
@@ -32,7 +34,7 @@ Thank you!
 * Write API docs for your contributions using [YARD](https://yardoc.org/)
 * Generate the API documentation locally
     ```
-    bundle exec rake yard
+    bin/rake yard
     ```
 * Review your changes by opening `doc/index.html`
 


### PR DESCRIPTION
Following the getting started in CONTRIBUTING.md outputs deprecation messages:

```
[DEPRECATED] The `--with` flag is deprecated because it relies on being remembered across bundler invocations, which bundler will no longer do in future versions. Instead please use `bundle config set --local with 'test sidekiq'`, and stop using this flag
[DEPRECATED] The --binstubs option will be removed in favor of `bundle binstubs --all`
```

This commit updates the section accordingly.

Also, since it encourages to generate binstubs, incentivize using bin/* over bundle exec in development.

## Goal
- keep development onboarding free of warnings
- comply with bundler instructions

## Changeset
Documentation only.
