### PR TITLE
Replace `Bundler.with_clean_env` with `Bundler.with_unbundled_env`

### DIFF
--- a/spec/integrations/logger_spec.rb
+++ b/spec/integrations/logger_spec.rb
@@ -19,7 +19,7 @@ describe 'Configuration.logger' do
     def run_app(name)
       out_reader, out_writer = IO.pipe
       Dir.chdir(File.join(File.dirname(__FILE__), "../fixtures/apps/#{name}")) do
-        Bundler.with_clean_env do
+        Bundler.with_unbundled_env do
           pid = Process.spawn('bundle install',
                               out: out_writer.fileno,
                               err: out_writer.fileno)
@@ -85,7 +85,7 @@ describe 'Configuration.logger' do
     def run_app(name)
       output = ''
       Dir.chdir(File.join(File.dirname(__FILE__), "../fixtures/apps/scripts")) do
-        Bundler.with_clean_env do
+        Bundler.with_unbundled_env do
           IO.popen([@env, 'bundle', 'exec', 'ruby', "#{name}.rb", err: [:child, :out]]) do |io|
             output << io.read
           end


### PR DESCRIPTION
Running spec outputs the following deprecation message:

```
[DEPRECATED] `Bundler.with_clean_env` has been deprecated in favor of `Bundler.with_unbundled_env`. If you instead want the environment before bundler was originally loaded, use `Bundler.with_original_env` (called at /[abridged]/spec/integrations/logger_spec.rb:88)
```

This commit switches them accordingly and make the test suite free of bundler warnings.

## Design
The message says we have another option, `Bundler.with_original_env`, which I did not opt for as simply replacing with `with_unbundled_env` seems alright for tests to pass.

## Testing
The CI workflow will let us know that bin/rake passes.