### PR TITLE
Allow partial strings on Rails `filter_parameters` for `meta_data_filters`

### DIFF
--- a/example/rails-42/config/initializers/filter_parameter_logging.rb
+++ b/example/rails-42/config/initializers/filter_parameter_logging.rb
@@ -1,4 +1,4 @@
 # Be sure to restart your server when you modify this file.
 
 # Configure sensitive parameters which will be filtered from the log file.
-Rails.application.config.filter_parameters += [:password]
+Rails.application.config.filter_parameters += [:passw]

--- a/example/rails-51/config/initializers/filter_parameter_logging.rb
+++ b/example/rails-51/config/initializers/filter_parameter_logging.rb
@@ -1,4 +1,4 @@
 # Be sure to restart your server when you modify this file.
 
 # Configure sensitive parameters which will be filtered from the log file.
-Rails.application.config.filter_parameters += [:password]
+Rails.application.config.filter_parameters += [:passw]

--- a/example/rails-60/config/initializers/filter_parameter_logging.rb
+++ b/example/rails-60/config/initializers/filter_parameter_logging.rb
@@ -1,4 +1,4 @@
 # Be sure to restart your server when you modify this file.
 
 # Configure sensitive parameters which will be filtered from the log file.
-Rails.application.config.filter_parameters += [:password]
+Rails.application.config.filter_parameters += [:passw]

--- a/features/fixtures/delayed_job/app/config/initializers/filter_parameter_logging.rb
+++ b/features/fixtures/delayed_job/app/config/initializers/filter_parameter_logging.rb
@@ -1,4 +1,4 @@
 # Be sure to restart your server when you modify this file.
 
 # Configure sensitive parameters which will be filtered from the log file.
-Rails.application.config.filter_parameters += [:password]
+Rails.application.config.filter_parameters += [:passw]

--- a/features/fixtures/rails4/app/config/initializers/filter_parameter_logging.rb
+++ b/features/fixtures/rails4/app/config/initializers/filter_parameter_logging.rb
@@ -1,5 +1,5 @@
 # Be sure to restart your server when you modify this file.
 
 # Configure sensitive parameters which will be filtered from the log file.
-Rails.application.config.filter_parameters += [:password]
+Rails.application.config.filter_parameters += [:passw]
 Rails.application.config.filter_parameters += [:my_specific_filter]

--- a/features/fixtures/rails5/app/config/initializers/filter_parameter_logging.rb
+++ b/features/fixtures/rails5/app/config/initializers/filter_parameter_logging.rb
@@ -1,5 +1,5 @@
 # Be sure to restart your server when you modify this file.
 
 # Configure sensitive parameters which will be filtered from the log file.
-Rails.application.config.filter_parameters += [:password]
+Rails.application.config.filter_parameters += [:passw]
 Rails.application.config.filter_parameters += [:my_specific_filter]

--- a/features/fixtures/rails6/app/config/initializers/filter_parameter_logging.rb
+++ b/features/fixtures/rails6/app/config/initializers/filter_parameter_logging.rb
@@ -1,5 +1,5 @@
 # Be sure to restart your server when you modify this file.
 
 # Configure sensitive parameters which will be filtered from the log file.
-Rails.application.config.filter_parameters += [:password]
+Rails.application.config.filter_parameters += [:passw]
 Rails.application.config.filter_parameters += [:my_specific_filter]

--- a/features/fixtures/rails7/app/config/initializers/filter_parameter_logging.rb
+++ b/features/fixtures/rails7/app/config/initializers/filter_parameter_logging.rb
@@ -1,5 +1,5 @@
 # Be sure to restart your server when you modify this file.
 
 # Configure sensitive parameters which will be filtered from the log file.
-Rails.application.config.filter_parameters += [:password]
+Rails.application.config.filter_parameters += [:passw]
 Rails.application.config.filter_parameters += [:my_specific_filter]

--- a/features/fixtures/rails_integrations/app/config/initializers/filter_parameter_logging.rb
+++ b/features/fixtures/rails_integrations/app/config/initializers/filter_parameter_logging.rb
@@ -1,4 +1,4 @@
 # Be sure to restart your server when you modify this file.
 
 # Configure sensitive parameters which will be filtered from the log file.
-Rails.application.config.filter_parameters += [:password]
+Rails.application.config.filter_parameters += [:passw]

--- a/lib/bugsnag/integrations/railtie.rb
+++ b/lib/bugsnag/integrations/railtie.rb
@@ -121,7 +121,7 @@ module Bugsnag
         config.meta_data_filters += ::Rails.configuration.filter_parameters.map do |filter|
           case filter
           when String, Symbol
-            /\A#{filter}\z/
+            /#{filter}/i
           else
             filter
           end


### PR DESCRIPTION
## Goal

The Recent Rails template will generate `filter_parameters` with *partial* strings, such as `:passw` and `:_key`. I think this library should also allow such keywords to filter out, following the Rails template.

https://github.com/rails/rails/blob/f838a7421228204bbc1e012ff9a3801ed598da80/railties/lib/rails/generators/rails/app/templates/config/initializers/filter_parameter_logging.rb.tt#L6-L8

This patch might be a breaking change because it will filter more parameters than before, but to exclude them would be better than sending probably sensitive parameters as they are.

## Design

I just removed `\A` and `\z` from the `Regexp` construction on a railtie as well as adding `i` to allow any cases to be matched.

## Changeset

* Remove `\A` and `\z`, and add `i` to `Regexp` initialization on railtie

## Testing

I updated `Rails.application.config.filter_parameters` inside `features` to be `:passw` from `:password`. It would be good if the End to end tests pass.