### PR TITLE
Avoid to use bundle-install --with and --binstubs options on CI

### DIFF
--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -20,6 +20,8 @@ jobs:
             optional-groups: 'test'
           - ruby-version: 'jruby'
             optional-groups: 'test'
+    env:
+      BUNDLE_WITH: ${{ matrix.optional-groups }}
 
     steps:
       - uses: actions/checkout@v3
@@ -29,9 +31,9 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby-version }}
 
-      - run: bundle install --with "${{ matrix.optional-groups }}" --binstubs
+      - run: bundle install
 
-      - run: ./bin/rake spec
+      - run: bundle exec rake spec
 
   linting:
     runs-on: ubuntu-latest

--- a/dockerfiles/Dockerfile.jruby-unit-tests
+++ b/dockerfiles/Dockerfile.jruby-unit-tests
@@ -8,6 +8,7 @@ COPY . .
 ARG BUNDLE_VERSION
 ARG GEMSETS
 RUN gem install bundler -v $BUNDLE_VERSION
-RUN bundle _${BUNDLE_VERSION}_ install --with "$GEMSETS" --binstubs
+RUN bundle _${BUNDLE_VERSION}_ config set with "$GEMSETS"
+RUN bundle _${BUNDLE_VERSION}_ install
 
 CMD ["bundle", "exec", "./bin/rake", "spec"]

--- a/dockerfiles/Dockerfile.ruby-unit-tests
+++ b/dockerfiles/Dockerfile.ruby-unit-tests
@@ -7,6 +7,7 @@ COPY . .
 ARG BUNDLE_VERSION
 ARG GEMSETS
 RUN gem install bundler -v ${BUNDLE_VERSION}
-RUN bundle _${BUNDLE_VERSION}_ install --with "$GEMSETS" --binstubs
+RUN bundle _${BUNDLE_VERSION}_ config set with "$GEMSETS"
+RUN bundle _${BUNDLE_VERSION}_ install
 
 CMD ["bundle", "exec", "./bin/rake", "spec"]


### PR DESCRIPTION
Use either BUNDLE_WITH variable or bundle config set. --binstubs is not required on CI environment.

## Goal

Use the modern syntax around Bundler CLI.

## Design

- Suppose to use Bundler 2.2.0 (or higher).
- Use either `BUNDLE_WITH` environment variable or `bundle config set`.
- `--binstubs` is not required on CI environment at all.

## Changeset

- Avoid to use `binstubs`'ed command; use `bundle exec` for the only single time.
- Use `bundle config set with` instead of `install --with`.

## Testing

- [ ] on GitHub Actions