### PR TITLE
docs: use bundle config set instead of install --with

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -5,7 +5,8 @@
 To run locally:
 
 ```
-bundle install --with test sidekiq --binstubs
+bundle config set with "test sidekiq"
+bundle install
 bundle exec rake
 ```
 


### PR DESCRIPTION
## Goal

Force developers not to use `bundle install --with` and `bundle install --binstubs`, which were already deprecated.

## Design

- Replace `bundle install --with` with `bundle config set with`.
- `bundle binstubs --all`, which is the replacement of `bundle install --binstubs`, is not mandatory at all in this case.

## Changeset

- Replace `bundle install --with` with `bundle config set with`.
- Remove `bundle install --binstubs`.

## Testing

- [ ] Tested this on my local