### PR TITLE
chore: remove extra query paramter from the links for GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The Bugsnag exception reporter for Ruby gives you instant notification of except
     * [Sidekiq](https://docs.bugsnag.com/platforms/ruby/sidekiq/configuration-options)
     * [Other Ruby apps](https://docs.bugsnag.com/platforms/ruby/other/configuration-options)
 * Check out some [example apps integrated with Bugsnag](https://github.com/bugsnag/bugsnag-ruby/tree/master/example) using Rails, Sinatra, Padrino, and more.
-* [Search open and closed issues](https://github.com/bugsnag/bugsnag-ruby/issues?utf8=✓&q=is%3Aissue) for similar problems
+* [Search open and closed issues](https://github.com/bugsnag/bugsnag-ruby/issues?q=is%3Aissue) for similar problems
 * [Report a bug or request a feature](https://github.com/bugsnag/bugsnag-ruby/issues/new)
 
 ## Contributing


### PR DESCRIPTION
## Goal

We do not need snowman `utf8=XX` as IE5-8 has been completely deprecated in [2020-10](https://learn.microsoft.com/en-us/lifecycle/products/internet-explorer-8).

See also https://discuss.rubyonrails.org/t/whats-with-the-snowman/53566

## Design

Remove `utf8=✓` from the links.

## Changeset

- Remove `utf8=✓` from the links

## Testing

- [ ] Check if https://github.com/bugsnag/bugsnag-ruby/issues?q=is%3Aissue is available