### PR TITLE
docs: remove bugsnag-em from the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ The Bugsnag exception reporter for Ruby gives you instant notification of except
     * [Rake](https://docs.bugsnag.com/platforms/ruby/rake)
     * [Sidekiq](https://docs.bugsnag.com/platforms/ruby/sidekiq)
     * [Other Ruby apps](https://docs.bugsnag.com/platforms/ruby/other)
-    * For [EventMachine](https://rubyeventmachine.com) integration, see [`bugsnag-em`](https://github.com/bugsnag/bugsnag-em)
 3. Relax!
 
 ## Support


### PR DESCRIPTION
## Goal

`bugsnag` gem 5.x is no more used and so `bugsnag-em` should be unreferenced.

## Design

As per https://github.com/bugsnag/bugsnag-em/pull/5, we should remove references for `bugsnag-em` gem.

## Changeset

- Remove an entry about bugsnag-em from the docs.

## Testing

n/a