### PR TITLE
Add support for Sidekiq 7

### DIFF
--- a/.github/workflows/maze-runner.yml
+++ b/.github/workflows/maze-runner.yml
@@ -73,7 +73,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ['2.5']
+        ruby-version: ['2.5', '3.0', '3.1', '3.2']
         sidekiq-version: ['2', '3', '4', '5', '6', '7']
 
     uses: ./.github/workflows/run-maze-runner.yml

--- a/.github/workflows/maze-runner.yml
+++ b/.github/workflows/maze-runner.yml
@@ -74,7 +74,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version: ['2.5']
-        sidekiq-version: ['2', '3', '4', '5', '6']
+        sidekiq-version: ['2', '3', '4', '5', '6', '7']
 
     uses: ./.github/workflows/run-maze-runner.yml
     with:

--- a/.github/workflows/maze-runner.yml
+++ b/.github/workflows/maze-runner.yml
@@ -73,8 +73,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ['2.5', '3.0', '3.1', '3.2']
+        ruby-version: ['2.5', '2.7']
         sidekiq-version: ['2', '3', '4', '5', '6', '7']
+        include:
+          - ruby-version: '3.2'
+            sidekiq-version: '7'
+        exclude:
+          # 2.7 is the minimum ruby version that sidekiq 7 supports
+          - ruby-version: '2.5'
+            sidekiq-version: '7'
 
     uses: ./.github/workflows/run-maze-runner.yml
     with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+## TBD
+
+### Enhancements
+
+* Support Sidekiq v7
+  | [#785](https://github.com/bugsnag/bugsnag-ruby/pull/785)
+  | [stevenharman](https://github.com/stevenharman)
+
 ## v6.25.2 (7 February 2023)
 
 ### Enhancements

--- a/lib/bugsnag/integrations/sidekiq.rb
+++ b/lib/bugsnag/integrations/sidekiq.rb
@@ -4,6 +4,7 @@ module Bugsnag
   ##
   # Extracts and attaches Sidekiq job and queue information to an error report
   class Sidekiq
+    include ::Sidekiq::ServerMiddleware if defined?(::Sidekiq::ServerMiddleware)
 
     unless const_defined?(:FRAMEWORK_ATTRIBUTES)
       FRAMEWORK_ATTRIBUTES = {


### PR DESCRIPTION
Sidekiq 7 has a new internal structure and middleware is now expected to include a module, depending on client vs server middleware. See: https://github.com/sidekiq/sidekiq/blob/main/docs/middleware.md

## Goal

Support for Sidekiq 7, which has some new internals, including a slightly different middleware API. While we don't currently any of the things offered by the new API, this will make sure we don't break on accident.

## Design

Only include the new middleware module if it's been defined, which will only happen for Sidekiq 7+.