### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -4,12 +4,12 @@ on: [push, pull_request]
 
 jobs:
   specs:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os || 'ubuntu-latest' }}
 
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ['2.2', '2.3', '2.4', '2.5', '2.6', '2.7', '3.0', '3.1', '3.2']
+        ruby-version: ['2.3', '2.4', '2.5', '2.6', '2.7', '3.0', '3.1', '3.2']
         optional-groups: ['test sidekiq']
         include:
           - ruby-version: '1.9'
@@ -18,6 +18,9 @@ jobs:
             optional-groups: 'test'
           - ruby-version: '2.1'
             optional-groups: 'test'
+          - ruby-version: '2.2'
+            optional-groups: 'test sidekiq'
+            os: 'ubuntu-20.04'
           - ruby-version: 'jruby'
             optional-groups: 'test'
 

--- a/features/fixtures/rails3/app/Gemfile
+++ b/features/fixtures/rails3/app/Gemfile
@@ -15,3 +15,6 @@ gem 'bugsnag', path: '/bugsnag'
 gem 'rack-cache', '~> 1.9.0'
 
 gem "warden"
+
+# Install a compatible Loofah version on Ruby <2.5
+gem 'loofah', '2.20.0' if RUBY_VERSION < '2.5'

--- a/features/fixtures/rails4/app/Gemfile
+++ b/features/fixtures/rails4/app/Gemfile
@@ -44,3 +44,6 @@ gem 'devise'
 gem "mongoid", '~> 5.4.0'
 
 gem "nokogiri", "1.6.8"
+
+# Install a compatible Loofah version
+gem 'loofah', '2.20.0'

--- a/features/fixtures/rails5/app/Gemfile
+++ b/features/fixtures/rails5/app/Gemfile
@@ -50,3 +50,6 @@ gem "clearance",  ruby_version < Gem::Version.new('2.3.0') ? '1.16.1' : '~> 1.16
 gem "mongoid"
 
 gem "nokogiri", "1.6.8"
+
+# Install a compatible Loofah version
+gem 'loofah', '2.20.0'


### PR DESCRIPTION
## Goal

We currently have two failures on CI:

- a transitive dependency (Loofah) in the Rails 3, 4 & 5 bumped their minimum Ruby & Nokogiri versions, which causes a crash on Ruby < 2.5 and older Nokogiris
- Ruby 2.2 no longer works on the `ubuntu-latest` GH runner