### PR TITLE
Add `ignored_in_project_file_paths` configuration

### DIFF
--- a/lib/bugsnag/configuration.rb
+++ b/lib/bugsnag/configuration.rb
@@ -168,6 +168,15 @@ module Bugsnag
     # @return [Array<String>]
     attr_accessor :vendor_paths
 
+    # A set of file paths within the {project_root} that should not be considered
+    # as "in project"
+    #
+    # These paths should be relative to the {project_root} and will only match
+    # exact file paths
+    #
+    # @return [Array<String>]
+    attr_reader :ignored_in_project_file_paths
+
     # The default context for all future events
     # Setting this will disable automatic context setting
     # @return [String, nil]
@@ -269,6 +278,7 @@ module Bugsnag
       # will only appear in the full trace.
       self.vendor_path = DEFAULT_VENDOR_PATH
       @vendor_paths = []
+      @ignored_in_project_file_paths = Set.new
 
       # Set up logging
       self.logger = Logger.new(STDOUT)
@@ -719,6 +729,10 @@ module Bugsnag
     # @return [void]
     def auto_track_sessions=(track_sessions)
       @auto_capture_sessions = track_sessions
+    end
+
+    def ignored_in_project_file_paths=(ignored_file_paths)
+      @ignored_in_project_file_paths = ignored_file_paths.to_set
     end
 
     private

--- a/lib/bugsnag/stacktrace.rb
+++ b/lib/bugsnag/stacktrace.rb
@@ -43,7 +43,7 @@ module Bugsnag
         if defined?(configuration.project_root) && configuration.project_root.to_s != ''
           trace_hash[:inProject] = true if file.start_with?(configuration.project_root.to_s)
           file.sub!(/#{configuration.project_root}\//, "")
-          trace_hash.delete(:inProject) if vendor_path?(configuration, file)
+          trace_hash.delete(:inProject) if out_of_project?(configuration, file)
         end
 
         # Strip common gem path prefixes
@@ -71,12 +71,22 @@ module Bugsnag
     end
 
     # @api private
+    def self.out_of_project?(configuration, file_path)
+      vendor_path?(configuration, file_path) || ignored_in_project_file?(configuration, file_path)
+    end
+
+    # @api private
     def self.vendor_path?(configuration, file_path)
       return true if configuration.vendor_path && file_path.match(configuration.vendor_path)
 
       configuration.vendor_paths.any? do |vendor_path|
         file_path.start_with?("#{vendor_path.sub(/\/$/, '')}/")
       end
+    end
+
+    # @api private
+    def self.ignored_in_project_file?(configuration, file_path)
+      configuration.ignored_in_project_file_paths.include?(file_path)
     end
   end
 end

--- a/spec/stacktrace_spec.rb
+++ b/spec/stacktrace_spec.rb
@@ -480,6 +480,34 @@ describe Bugsnag::Stacktrace do
       expect(out_project_trace(stacktrace)).to eq(["abc_xyz/lib/dont.rb"])
     end
   end
+  context "with configurable ignored_in_project_file_paths" do
+    let(:configuration) do
+      configuration = Bugsnag::Configuration.new
+      configuration.project_root = "/foo/bar"
+      configuration
+    end
+
+    let(:backtrace) do
+      [
+        "/foo/bar/app/models/user.rb:1:in `something'",
+        "/foo/bar/abc_xyz/lib/dont.rb:1:in `to_s'",
+        "/foo/bar/abc/other_lib/ignore_me.rb:1:in `to_s'",
+        "/foo/bar/abc/lib/ignore_me.rb:1:in `to_s'",
+        "/foo/bar/xyz/lib/ignore_me.rb:1:in `to_s'",
+      ]
+    end
+
+    it "with ignored_in_project_file_paths set to ['abc/other_lib/ignore_me.rb', 'abc/lib/ignore_me.rb', 'xyz/lib/ignore_me.rb']" do
+      configuration.ignored_in_project_file_paths = ["abc/other_lib/ignore_me.rb", "abc/lib/ignore_me.rb", "xyz/lib/ignore_me.rb"]
+      stacktrace = Bugsnag::Stacktrace.process(backtrace, configuration)
+
+      expect(out_project_trace(stacktrace)).to eq([
+        "abc/other_lib/ignore_me.rb",
+        "abc/lib/ignore_me.rb",
+        "xyz/lib/ignore_me.rb",
+      ])
+    end
+  end
 
   private
 

--- a/spec/stacktrace_spec.rb
+++ b/spec/stacktrace_spec.rb
@@ -418,12 +418,6 @@ describe Bugsnag::Stacktrace do
       ]
     end
 
-    def out_project_trace(stacktrace)
-      stacktrace.map do |trace_line|
-        trace_line[:file] unless trace_line[:inProject]
-      end.compact
-    end
-
     it "marks vendor/ and .bundle/ as out-project by default" do
       stacktrace = Bugsnag::Stacktrace.process(backtrace, configuration)
 
@@ -458,12 +452,6 @@ describe Bugsnag::Stacktrace do
       ]
     end
 
-    def out_project_trace(stacktrace)
-      stacktrace.map do |trace_line|
-        trace_line[:file] unless trace_line[:inProject]
-      end.compact
-    end
-
     it "with vendor_paths set to ['abc', 'xyz']" do
       configuration.vendor_paths = ['abc', 'xyz']
       stacktrace = Bugsnag::Stacktrace.process(backtrace, configuration)
@@ -491,5 +479,13 @@ describe Bugsnag::Stacktrace do
 
       expect(out_project_trace(stacktrace)).to eq(["abc_xyz/lib/dont.rb"])
     end
+  end
+
+  private
+
+  def out_project_trace(stacktrace)
+    stacktrace.map do |trace_line|
+      trace_line[:file] unless trace_line[:inProject]
+    end.compact
   end
 end


### PR DESCRIPTION
## Goal

Allow single files to be ignored when grouping errors. This is useful when a single file appears in the stacktrace, and ignoring its parent folder through `vendor_paths` would cause other siblings that we do not want to ignore in the folder to be ignored.

[This gist](https://gist.github.com/pjambet/5aef5bcfa04d67d17db9aade23a827ed) shows an example where this can happen, when a module is used and wraps actions, in this case with an `around_create` block.

When needing this, the only option I found was to create a middleware that would inspect the content of the stacktraces in the report and flag lines as not in-project. It felt like a lot of work for a seemingly small task. It seemed like a built-in config would help here!

## Design

<!-- Why was this approach used? -->
A new config was added, and to optimize for the `include?` call when processing stacktraces, we make sure to always convert the input to a set, as to not require users to remember to create a set and simply pass an array.

## Changeset

<!-- What changed? -->
A new config is now available, `ignored_in_project_file_paths`, it can be used like this:

```ruby
Bugsnag.configure do |config|
  config.ignored_in_project_file_paths = ["abc/other_lib/ignore_me.rb", "abc/lib/ignore_me.rb", "xyz/lib/ignore_me.rb"]
end
```

## Testing

<!-- How was it tested? What manual and automated tests were
     run/added? -->
Automated tests were added