### PR TITLE
Fix mailman dependency breaking CI

### DIFF
--- a/features/fixtures/mailman/app/Gemfile
+++ b/features/fixtures/mailman/app/Gemfile
@@ -12,3 +12,6 @@ gem 'rack', '~> 1.6.11'
 
 # Install a compatible FFI version on Ruby <2.3
 gem 'ffi', '< 1.13.0' if RUBY_VERSION < '2.3.0'
+
+# Install a compatible mini_mime version on Ruby <2.6
+gem 'mini_mime', '< 1.1.4' if RUBY_VERSION < '2.6.0'


### PR DESCRIPTION
## Goal

mini_mime 1.1.4 requires Ruby 2.5 & 1.1.5 requires Ruby 2.6, so we need to install an older version on Ruby 2.0

https://github.com/bugsnag/bugsnag-ruby/actions/runs/5831025631/job/15813593650