### PR TITLE
Add any successfully parsed non-nil JSON body to report, regardless of class

### DIFF
--- a/lib/bugsnag/middleware/rack_request.rb
+++ b/lib/bugsnag/middleware/rack_request.rb
@@ -109,7 +109,7 @@ module Bugsnag::Middleware
       body = parsed_request_body(request, env)
 
       # this request may not have a body
-      return unless body.is_a?(Hash) && !body.empty?
+      return if body.nil?
 
       report.add_metadata(:request, :body, body)
     end


### PR DESCRIPTION
## Goal

The purpose of this PR is to allow any successfully parsed JSON body to be displayed in the request tab of the event page. Previously, only Hashes were included in the event report, which meant that any errors that occurred during the processing of a request with content type `application/json-patch+json` (where the top level element is an array) did not have enough information to debug the issue.

## Design

N/A

## Changeset

Before this change, only JSON that was parsed to a non-empty Hash was added to the `$request.body` event metadata. After this change, any successfully parsed non-nil object will be added.

## Testing

I have not updated the tests, as 
* everything was passing
* the overall intent of the code has not changed
* there was no specific test case to assert that arrays should NOT be reported
* the tests in spec/integrations/rack_spec.rb are at such a high level that it would require an extra 64 lines of test code to test each code path of the `add_request_body`, and this did not seem like a good tradeoff in terms of test maintainability. 

Having said that, if it is requested, I will add a new test - it would probably be a unit test that did a naughty test of the private `add_request_body` method only.