### PR TITLE
Add a warning message when notify payloads are subject to truncation

### DIFF
--- a/lib/bugsnag.rb
+++ b/lib/bugsnag.rb
@@ -535,6 +535,11 @@ module Bugsnag
     # @return [String]
     def report_to_json(report)
       cleaned = cleaner.clean_object(report.as_json)
+
+      if Bugsnag::Helpers.payload_too_long?(cleaned)
+        configuration.warn("The notify payload is too large and will be truncated.")
+      end
+
       trimmed = Bugsnag::Helpers.trim_if_needed(cleaned)
 
       ::JSON.dump(trimmed)

--- a/lib/bugsnag/helpers.rb
+++ b/lib/bugsnag/helpers.rb
@@ -71,6 +71,13 @@ module Bugsnag
       end
     end
 
+    ##
+    # Validate that the serialized JSON string value is below maximum payload
+    # length
+    def self.payload_too_long?(value)
+      get_payload_length(value) >= MAX_PAYLOAD_LENGTH
+    end
+
     private
 
     TRUNCATION_INFO = '[TRUNCATED]'
@@ -154,13 +161,6 @@ module Bugsnag
       else
         trim_as_string(value)
       end
-    end
-
-    ##
-    # Validate that the serialized JSON string value is below maximum payload
-    # length
-    def self.payload_too_long?(value)
-      get_payload_length(value) >= MAX_PAYLOAD_LENGTH
     end
 
     def self.get_payload_length(value)


### PR DESCRIPTION
## Goal

<!-- Why is this change necessary? -->
* Inform the devs when truncation can occur from large payloads

## Design

<!-- Why was this approach used? -->

## Changeset

<!-- What changed? -->

## Testing

<!-- How was it tested? What manual and automated tests were
     run/added? -->