### PR TITLE
Fix when resque failure backend is already multiple

### DIFF
--- a/lib/bugsnag/integrations/resque.rb
+++ b/lib/bugsnag/integrations/resque.rb
@@ -21,7 +21,7 @@ module Bugsnag
       return if ::Resque::Failure.backend == self
 
       # Ensure resque is using a "Multiple" failure backend
-      unless ::Resque::Failure.backend < ::Resque::Failure::Multiple
+      unless ::Resque::Failure.backend <= ::Resque::Failure::Multiple
         original_backend = ::Resque::Failure.backend
         ::Resque::Failure.backend = ::Resque::Failure::Multiple
         ::Resque::Failure.backend.classes ||= []

--- a/spec/integrations/resque_spec.rb
+++ b/spec/integrations/resque_spec.rb
@@ -31,7 +31,7 @@ describe 'Bugsnag::Resque', :order => :defined do
     #Auto-load failure backend
     backend = double('backend')
     allow(::Resque::Failure).to receive(:backend).and_return(backend)
-    expect(backend).to receive(:<).and_return(nil)
+    expect(backend).to receive(:<=).and_return(nil)
     expect(::Resque::Failure).to receive(:backend=).with(::Resque::Failure::Multiple)
     classes = double('classes')
     allow(backend).to receive(:classes).and_return(classes)


### PR DESCRIPTION
## Goal

We had an outage today after recently introducing Bugsnag into our codebase because our Resque failure backend was already `Resque::Failure::Multiple`, which this code looks like it handles, except the wrong operator was used:

```irb
Resque::Failure::Multiple < Resque::Failure::Multiple
# => false

Resque::Failure::Multiple <= Resque::Failure::Multiple
# => true
```

The backend is likely to be the `Resque::Failure::Multiple` class, not a sub-class.

This meant that when the bugsnag instrumentation code ran and we ended up with:

```
Resque::Failure.backend
# => Resque::Failure::Multiple
Resque::Failure::Multiple.classes
# => [Resque::Failure::Redis, Bugsnag::Resque, Resque::Failure::Multiple]
```

So a failure was reported to Redis, then Bugsnag, then Redis, then Bugsnag, then Redis, then Bugsnag, and so on, until we got a "stack overflow" error.

For us, we had a worker which needed cleanup during resque boot, which involves reporting a failure, so none of our resque workers would boot or process work, resulting in an outage of all background queue processing.

# Testing

The tests here are pretty literal and testing the implementation more than the outcome. It might be possible to refactor them to test the Resque side of things a little more, but that's a little more than I'd like to chew off in this PR.

We are currently using `BUGSNAG_DISABLE_AUTOCONFIGURE` to work around, and would love to get this change merged and released quickly so we can use Bugsnag error reporting for Resque :pray: