### PR TITLE
Add Ruby 3.3 to CI

### DIFF
--- a/.github/workflows/maze-runner.yml
+++ b/.github/workflows/maze-runner.yml
@@ -148,7 +148,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ['1.9', '2.0', '2.1', '2.2', '2.3', '2.4', '2.5', '2.6', '2.7', '3.0', '3.1', '3.2']
+        ruby-version: ['1.9', '2.0', '2.1', '2.2', '2.3', '2.4', '2.5', '2.6', '2.7', '3.0', '3.1', '3.2', '3.3']
 
     uses: ./.github/workflows/run-maze-runner.yml
     with:

--- a/.github/workflows/maze-runner.yml
+++ b/.github/workflows/maze-runner.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ['1.9', '3.2']
+        ruby-version: ['1.9', '3.3']
 
     uses: ./.github/workflows/run-maze-runner.yml
     with:
@@ -36,11 +36,11 @@ jobs:
             rack-version: '1'
           - ruby-version: '2.2'
             rack-version: '2'
-          - ruby-version: '3.2'
+          - ruby-version: '3.3'
             rack-version: '2'
           - ruby-version: '2.4'
             rack-version: '3'
-          - ruby-version: '3.2'
+          - ruby-version: '3.3'
             rack-version: '3'
 
     uses: ./.github/workflows/run-maze-runner.yml
@@ -76,7 +76,7 @@ jobs:
         ruby-version: ['2.5', '2.7']
         sidekiq-version: ['2', '3', '4', '5', '6', '7']
         include:
-          - ruby-version: '3.2'
+          - ruby-version: '3.3'
             sidekiq-version: '7'
         exclude:
           # 2.7 is the minimum ruby version that sidekiq 7 supports
@@ -127,7 +127,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ['2.7', '3.2']
+        ruby-version: ['2.7', '3.3']
         rails-version: ['6', '7', '_integrations']
         include:
           - ruby-version: '2.5'
@@ -135,7 +135,7 @@ jobs:
         exclude:
           - ruby-version: '2.7'
             rails-version: '6'
-          - ruby-version: '3.2'
+          - ruby-version: '3.3'
             rails-version: '_integrations'
 
     uses: ./.github/workflows/run-maze-runner.yml

--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ['2.3', '2.4', '2.5', '2.6', '2.7', '3.0', '3.1', '3.2']
+        ruby-version: ['2.3', '2.4', '2.5', '2.6', '2.7', '3.0', '3.1', '3.2', '3.3']
         optional-groups: ['test sidekiq']
         include:
           - ruby-version: '1.9'

--- a/features/fixtures/plain/app/app.rb
+++ b/features/fixtures/plain/app/app.rb
@@ -5,6 +5,7 @@ def configure_basics
   Bugsnag.configure do |conf|
     conf.api_key = ENV['BUGSNAG_API_KEY']
     conf.set_endpoints(ENV['BUGSNAG_ENDPOINT'], ENV["BUGSNAG_ENDPOINT"])
+    conf.project_root = File.dirname(File.realpath(__FILE__))
   end
 end
 
@@ -17,7 +18,7 @@ def configure_using_environment
     conf.ignore_classes << lambda { |ex| ex.class.to_s == ENV["BUGSNAG_IGNORE_CLASS"] } if ENV.include? "BUGSNAG_IGNORE_CLASS"
     conf.meta_data_filters << ENV["BUGSNAG_META_DATA_FILTERS"] if ENV.include? "BUGSNAG_META_DATA_FILTERS"
     conf.enabled_release_stages = [ENV["BUGSNAG_NOTIFY_RELEASE_STAGE"]] if ENV.include? "BUGSNAG_NOTIFY_RELEASE_STAGE"
-    conf.project_root = ENV["BUGSNAG_PROJECT_ROOT"] if ENV.include? "BUGSNAG_PROJECT_ROOT"
+    conf.project_root = File.dirname(File.realpath(__FILE__))
     conf.proxy_host = ENV["BUGSNAG_PROXY_HOST"] if ENV.include? "BUGSNAG_PROXY_HOST"
     conf.proxy_password = ENV["BUGSNAG_PROXY_PASSWORD"] if ENV.include? "BUGSNAG_PROXY_PASSWORD"
     conf.proxy_port = ENV["BUGSNAG_PROXY_PORT"] if ENV.include? "BUGSNAG_PROXY_PORT"

--- a/features/fixtures/plain/app/stack_frame_modification/mark_frames_in_project.rb
+++ b/features/fixtures/plain/app/stack_frame_modification/mark_frames_in_project.rb
@@ -4,7 +4,9 @@ require "./stack_frame_modification/initiators/#{initiator}"
 
 callback = Proc.new do |report|
   report.exceptions[0][:stacktrace].each_with_index do |frame, index|
-    if index > 0
+    if index == 0
+      frame[:inProject] = nil
+    else
       frame[:inProject] = true
     end
   end

--- a/features/fixtures/rails7/app/Gemfile
+++ b/features/fixtures/rails7/app/Gemfile
@@ -8,7 +8,8 @@ gem "rails", "~> 7.0.1"
 gem "sprockets-rails"
 
 # Use sqlite3 as the database for Active Record
-gem "sqlite3", "~> 1.4"
+# Install a compatible sqlite version on Ruby <3.0
+gem "sqlite3", RUBY_VERSION >= '3.0' ? "~> 1.7" : "< 1.7"
 
 # Use the Puma web server [https://github.com/puma/puma]
 gem "puma", "~> 5.0"

--- a/features/plain_features/handled_errors.feature
+++ b/features/plain_features/handled_errors.feature
@@ -9,7 +9,7 @@ Scenario: A rescued exception sends a report
   And the event "severityReason.type" equals "handledException"
   And the event "device.time" is a timestamp
   And the exception "errorClass" equals "RuntimeError"
-  And the "file" of stack frame 0 equals "/usr/src/app/handled/notify_exception.rb"
+  And the "file" of stack frame 0 equals "handled/notify_exception.rb"
   And the "lineNumber" of stack frame 0 equals 6
 
 Scenario: A notified string sends a report
@@ -21,7 +21,7 @@ Scenario: A notified string sends a report
   And the event "severityReason.type" equals "handledException"
   And the event "device.time" is a timestamp
   And the exception "errorClass" equals "RuntimeError"
-  And the "file" of the top non-bugsnag stackframe equals "/usr/src/app/handled/notify_string.rb"
+  And the "file" of the top non-bugsnag stackframe equals "handled/notify_string.rb"
   And the "lineNumber" of the top non-bugsnag stackframe equals 8
 
 Scenario: A handled error doesn't send a report when the :skip_bugsnag flag is set
@@ -36,7 +36,7 @@ Scenario: A handled error can attach metadata in a block
   And the event "severity" equals "warning"
   And the event "severityReason.type" equals "handledException"
   And the exception "errorClass" equals "RuntimeError"
-  And the "file" of stack frame 0 equals "/usr/src/app/handled/block_metadata.rb"
+  And the "file" of stack frame 0 equals "handled/block_metadata.rb"
   And the "lineNumber" of stack frame 0 equals 6
   And the event "metaData.account.id" equals "1234abcd"
   And the event "metaData.account.name" equals "Acme Co"

--- a/features/plain_features/release_stages.feature
+++ b/features/plain_features/release_stages.feature
@@ -16,4 +16,4 @@ Scenario: Does notify in the correct release stage
   And the event "severity" equals "error"
   And the event "severityReason.type" equals "unhandledException"
   And the exception "errorClass" equals "RuntimeError"
-  And the "file" of stack frame 0 equals "/usr/src/app/configuration/send_unhandled.rb"
+  And the "file" of stack frame 0 equals "configuration/send_unhandled.rb"

--- a/features/plain_features/report_stack_frames.feature
+++ b/features/plain_features/report_stack_frames.feature
@@ -5,7 +5,7 @@ Scenario Outline: Stack frames can be removed
   When I run the service "plain-ruby" with the command "bundle exec ruby stack_frame_modification/remove_stack_frame.rb"
   And I wait to receive an error
   Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
-  And the "file" of the top non-bugsnag stackframe equals "/usr/src/app/stack_frame_modification/initiators/<initiator>.rb"
+  And the "file" of the top non-bugsnag stackframe equals "stack_frame_modification/initiators/<initiator>.rb"
   And the "lineNumber" of stack frame 0 equals <lineNumber>
 
   Examples:
@@ -20,7 +20,7 @@ Scenario: Stack frames can be removed from a notified string
   When I run the service "plain-ruby" with the command "bundle exec ruby stack_frame_modification/remove_stack_frame.rb"
   And I wait to receive an error
   Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
-  And the "file" of the top non-bugsnag stackframe equals "/usr/src/app/stack_frame_modification/initiators/handled_block.rb"
+  And the "file" of the top non-bugsnag stackframe equals "stack_frame_modification/initiators/handled_block.rb"
   And the "lineNumber" of the top non-bugsnag stackframe equals 19
 
 Scenario Outline: Stack frames can be marked as in project
@@ -28,7 +28,7 @@ Scenario Outline: Stack frames can be marked as in project
   When I run the service "plain-ruby" with the command "bundle exec ruby stack_frame_modification/mark_frames_in_project.rb"
   And I wait to receive an error
   Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
-  And the "file" of stack frame 0 equals "/usr/src/app/stack_frame_modification/initiators/<initiator>.rb"
+  And the "file" of stack frame 0 equals "stack_frame_modification/initiators/<initiator>.rb"
   And the event "exceptions.0.stacktrace.0.inProject" is null
   And the event "exceptions.0.stacktrace.1.inProject" is true
   And the event "exceptions.0.stacktrace.2.inProject" is true
@@ -46,7 +46,7 @@ Scenario: Stack frames can be marked as in project with a handled string
   And I run the service "plain-ruby" with the command "bundle exec ruby stack_frame_modification/mark_frames_in_project.rb"
   And I wait to receive an error
   Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
-  And the "file" of the top non-bugsnag stackframe equals "/usr/src/app/stack_frame_modification/initiators/handled_block.rb"
+  And the "file" of the top non-bugsnag stackframe equals "stack_frame_modification/initiators/handled_block.rb"
   And the event "exceptions.0.stacktrace.0.inProject" is null
   And the event "exceptions.0.stacktrace.1.inProject" is true
   And the event "exceptions.0.stacktrace.2.inProject" is true

--- a/features/plain_features/unhandled_errors.feature
+++ b/features/plain_features/unhandled_errors.feature
@@ -9,8 +9,8 @@ Scenario Outline: An unhandled error sends a report
   And the event "severityReason.type" equals "unhandledException"
   And the event "device.time" is a timestamp
   And the exception "errorClass" equals "<error>"
-  And the "file" of stack frame 0 equals "/usr/src/app/unhandled/<file>.rb"
-  And the "lineNumber" of stack frame 0 equals <lineNumber>
+  And the "file" of the first in-project stack frame equals "unhandled/<file>.rb"
+  And the "lineNumber" of the first in-project stack frame equals <lineNumber>
 
   Examples:
   | file              | error          | lineNumber | command          |

--- a/features/rails_features/before_notify.feature
+++ b/features/rails_features/before_notify.feature
@@ -21,7 +21,7 @@ Scenario: Rails before_notify controller method works on unhandled errors
   And I wait to receive an error
   Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
   And the exception "errorClass" equals "NameError"
-  And the exception "message" starts with "undefined local variable or method `generate_unhandled_error' for #<BeforeNotifyController"
+  And the exception "message" matches "^undefined local variable or method `generate_unhandled_error' for (#<|an instance of )BeforeNotifyController"
   And the event "unhandled" is true
   And the event "app.type" equals "rails"
   And the event "metaData.request.url" ends with "/before_notify/unhandled"

--- a/features/rails_features/handled.feature
+++ b/features/rails_features/handled.feature
@@ -21,7 +21,7 @@ Scenario: Thrown handled NameError
   And I wait to receive an error
   Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
   And the exception "errorClass" equals "NameError"
-  And the exception "message" starts with "undefined local variable or method `generate_unhandled_error' for #<HandledController"
+  And the exception "message" matches "^undefined local variable or method `generate_unhandled_error' for (#<|an instance of )HandledController"
   And the event "unhandled" is false
   And the event "metaData.request.url" ends with "/handled/thrown"
   And the event "app.type" equals "rails"

--- a/features/rails_features/on_error.feature
+++ b/features/rails_features/on_error.feature
@@ -22,7 +22,7 @@ Scenario: Rails on_error works on unhandled errors
   And I wait to receive an error
   Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
   And the exception "errorClass" equals "NameError"
-  And the exception "message" starts with "undefined local variable or method `generate_unhandled_error' for #<UnhandledController"
+  And the exception "message" matches "^undefined local variable or method `generate_unhandled_error' for (#<|an instance of )UnhandledController"
   And the event "unhandled" is true
   And the event "app.type" equals "rails"
   And the event "metaData.request.url" ends with "/unhandled/error"

--- a/features/rails_features/request.feature
+++ b/features/rails_features/request.feature
@@ -8,7 +8,7 @@ Scenario: Request data is collected automatically
   Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
   And the event "unhandled" is true
   And the exception "errorClass" equals "NameError"
-  And the exception "message" starts with "undefined local variable or method `generate_unhandled_error' for #<UnhandledController"
+  And the exception "message" matches "^undefined local variable or method `generate_unhandled_error' for (#<|an instance of )UnhandledController"
   And the event "app.type" equals "rails"
   And the event "metaData.request.clientIp" is not null
   And the event "metaData.request.headers.Host" is not null
@@ -33,7 +33,7 @@ Scenario: Request data can be modified in callbacks
   Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
   And the event "unhandled" is true
   And the exception "errorClass" equals "NameError"
-  And the exception "message" starts with "undefined local variable or method `generate_unhandled_error' for #<UnhandledController"
+  And the exception "message" matches "^undefined local variable or method `generate_unhandled_error' for (#<|an instance of )UnhandledController"
   And the event "app.type" equals "rails"
   And the event "metaData.request.something" equals "hello"
   And the event "metaData.request.params.another_thing" equals "hi"

--- a/features/rails_features/unhandled.feature
+++ b/features/rails_features/unhandled.feature
@@ -8,7 +8,7 @@ Scenario: Unhandled RuntimeError
   Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
   And the event "unhandled" is true
   And the exception "errorClass" equals "NameError"
-  And the exception "message" starts with "undefined local variable or method `generate_unhandled_error' for #<UnhandledController"
+  And the exception "message" matches "^undefined local variable or method `generate_unhandled_error' for (#<|an instance of )UnhandledController"
   And the event "app.type" equals "rails"
   And the event "metaData.request.url" ends with "/unhandled/error"
   And the event "severity" equals "error"

--- a/features/steps/ruby_notifier_steps.rb
+++ b/features/steps/ruby_notifier_steps.rb
@@ -12,6 +12,21 @@ Then(/^the "(.+)" of the top non-bugsnag stackframe equals (\d+|".+")$/) do |ele
   }
 end
 
+Then(/^the "(.+)" of the first in-project stack frame equals (\d+|".+")$/) do |key, expected|
+  body = Maze::Server.errors.current[:body]
+  stacktrace = Maze::Helper.read_key_path(body, 'events.0.exceptions.0.stacktrace')
+
+  frame_index = stacktrace.find_index { |frame| frame["inProject"] == true }
+
+  if frame_index.nil?
+    raise "Unable to find an in-project stack frame in stacktrace: #{stacktrace.inspect}"
+  end
+
+  steps %Q{
+    the "#{key}" of stack frame #{frame_index} equals #{expected}
+  }
+end
+
 Then(/^the total sessionStarted count equals (\d+)$/) do |value|
   body = Maze::Server.sessions.current[:body]
   session_counts = Maze::Helper.read_key_path(body, "sessionCounts")


### PR DESCRIPTION
## Goal

Add Ruby 3.3 to CI

## Changeset

- assert against in-project frames in the plain ruby unhandled error tests — Ruby 3.3 adds additional frames to the top of these stacktraces
- update "undefined local variable" message assertions:
    - Ruby <3.3:
        > undefined local variable or method `generate_unhandled_error' for #\<BeforeNotifyController>
    - Ruby 3.3:
        > undefined local variable or method `generate_unhandled_error' for an instance of BeforeNotifyController
- add Ruby 3.3 to matrices
- fix dependency issue in the Rails 7 fixture when running with Ruby 2.7