### PR TITLE
Fix `Cleaner#clean_url` with mailto links

### DIFF
--- a/lib/bugsnag/cleaner.rb
+++ b/lib/bugsnag/cleaner.rb
@@ -30,16 +30,18 @@ module Bugsnag
 
       begin
         uri = URI(url)
+
+        if uri.is_a?(URI::MailTo)
+          clean_mailto_url(url, uri)
+        else
+          clean_generic_url(url, uri)
+        end
       rescue URI::InvalidURIError
         pre_query_string, _query_string = url.split('?', 2)
 
-        return "#{pre_query_string}?#{FILTERED}"
-      end
-
-      if uri.is_a?(URI::MailTo)
-        clean_mailto_url(url, uri)
-      else
-        clean_generic_url(url, uri)
+        "#{pre_query_string}?#{FILTERED}"
+      rescue StandardError
+        FILTERED
       end
     end
 

--- a/spec/cleaner_spec.rb
+++ b/spec/cleaner_spec.rb
@@ -552,5 +552,29 @@ describe Bugsnag::Cleaner do
       let(:url) { "https://host.example/a b c d e f g" }
       it { should eq "https://host.example/a b c d e f g" }
     end
+
+    context "with a mailto URL" do
+      let(:filters) { [/token/] }
+      let(:url) { "mailto:hello@example.com?token=secret&subject=Hello" }
+      it { should eq "mailto:hello@example.com?token=FILTERED&subject=Hello" }
+    end
+
+    context "with a mailto URL without a to address" do
+      let(:filters) { [/token/] }
+      let(:url) { "mailto:?subject=Hello&token=password" }
+      it { should eq "mailto:?subject=Hello&token=FILTERED" }
+    end
+
+    context "with a websocket URL" do
+      let(:filters) { [/secret/] }
+      let(:url) { "ws://example.com?abc=xyz&secret=password" }
+      it { should eq "ws://example.com?abc=xyz&secret=[FILTERED]" }
+    end
+
+    context "with a websocket over TLS URL" do
+      let(:filters) { [/secret/] }
+      let(:url) { "wss://example.com?abc=xyz&secret=password" }
+      it { should eq "wss://example.com?abc=xyz&secret=[FILTERED]" }
+    end
   end
 end


### PR DESCRIPTION
## Goal

mailto links don't have a `query` property, instead they use `headers`, e.g.:

```ruby
uri = URI('mailto:hello@example.com?subject=hi')
uri.headers #=> [['subject', 'hi']]
```

The current `Cleaner#clean_url` fails on mailto links and wouldn't filter the headers if it did succeed. This PR updates it to handle filtering the headers in mailto links