### PR TITLE
Fix compatibility with Ruby 3.4-dev

### DIFF
--- a/lib/bugsnag/stacktrace.rb
+++ b/lib/bugsnag/stacktrace.rb
@@ -3,7 +3,7 @@ require_relative 'code_extractor'
 module Bugsnag
   module Stacktrace
     # e.g. "org/jruby/RubyKernel.java:1264:in `catch'"
-    BACKTRACE_LINE_REGEX = /^((?:[a-zA-Z]:)?[^:]+):(\d+)(?::in `([^']+)')?$/
+    BACKTRACE_LINE_REGEX = /^((?:[a-zA-Z]:)?[^:]+):(\d+)(?::in [`']([^']+)')?$/
 
     # e.g. "org.jruby.Ruby.runScript(Ruby.java:807)"
     JAVA_BACKTRACE_REGEX = /^(.*)\((.*)(?::([0-9]+))?\)$/


### PR DESCRIPTION
## Goal

Parse backtraces correctly with Ruby 3.4-dev

## Design

This PR deals with Ruby 3.4's backtrace incompatibility introduced at https://github.com/ruby/ruby/pull/9608.
They used <code>[`']</code> for fixing existing tests too.

## Changeset

Fixed `BACKTRACE_LINE_REGEX` to parse backtraces which use two `'`s.

## Testing

Reusing existing tests on Ruby 3.4-dev should be enough. Using this branch fixed our test cases.