### PR TITLE
Include warden scope in user info

### DIFF
--- a/lib/bugsnag/middleware/warden_user.rb
+++ b/lib/bugsnag/middleware/warden_user.rb
@@ -21,7 +21,7 @@ module Bugsnag::Middleware
           best_scope = warden_scopes.include?("user") ? "user" : warden_scopes.first
 
           # Extract useful user information
-          user = {}
+          user = { :warden_scope => best_scope }
           user_object = env["warden"].user({:scope => best_scope, :run_callbacks => false}) rescue nil
           if user_object
             # Build the user info for this scope


### PR DESCRIPTION
## Goal

Closes #777

The default user metadata includes `id` but without the Warden scope, if you have multiple user types, for example: `User` and `AdminUser`, it wouldn't be possible to know who's who when removing the default fields which are PII.

## Design

Simple approach as Warden scope is already used to determine the user object in this case, so the objective is to just include the scope value as another user field.

## Changeset

Just adds a `warden_scope` key to the user object.

## Testing

<!-- How was it tested? What manual and automated tests were
     run/added? -->