### PR TITLE
Add block variant of `add_on_error`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Changelog
 * Include the Warden scope in user metadata
   | [#821](https://github.com/bugsnag/bugsnag-ruby/pull/821)
   | [javierjulio](https://github.com/javierjulio)
+* Add a block variant of `add_on_error`
+  | [#824](https://github.com/bugsnag/bugsnag-ruby/pull/824)
 
 ## v6.26.4 (25 March 2024)
 

--- a/lib/bugsnag.rb
+++ b/lib/bugsnag.rb
@@ -310,6 +310,20 @@ module Bugsnag
     end
 
     ##
+    # Add the given block to the list of on_error callbacks
+    #
+    # The on_error callbacks will be called when an error is captured or reported
+    # and are passed a {Bugsnag::Report} object
+    #
+    # Returning false from an on_error callback will cause the error to be ignored
+    # and will prevent any remaining callbacks from being called
+    #
+    # @return [void]
+    def on_error(&block)
+      configuration.on_error(&block)
+    end
+
+    ##
     # Add the given callback to the list of on_error callbacks
     #
     # The on_error callbacks will be called when an error is captured or reported

--- a/lib/bugsnag/configuration.rb
+++ b/lib/bugsnag/configuration.rb
@@ -570,6 +570,20 @@ module Bugsnag
     end
 
     ##
+    # Add the given block to the list of on_error callbacks
+    #
+    # The on_error callbacks will be called when an error is captured or reported
+    # and are passed a {Bugsnag::Report} object
+    #
+    # Returning false from an on_error callback will cause the error to be ignored
+    # and will prevent any remaining callbacks from being called
+    #
+    # @return [void]
+    def on_error(&block)
+      middleware.use(block)
+    end
+
+    ##
     # Add the given callback to the list of on_error callbacks
     #
     # The on_error callbacks will be called when an error is captured or reported


### PR DESCRIPTION
## Goal

Add a block variant of `add_on_error`

Usage:

```ruby
Bugsnag.configure do |configuration|
  configuration.on_error do |event|
    event.add_metadata(:information, { a: 1 })
  end
end

# or

Bugsnag.on_error do |event|
  event.add_metadata(:information, { b: 2 })
end
```
