### PR TITLE
Fix circular require warning

### DIFF
--- a/lib/bugsnag.rb
+++ b/lib/bugsnag.rb
@@ -1,5 +1,10 @@
 require "rubygems"
 require "thread"
+require "set"
+require "json"
+require "uri"
+require "socket"
+require "logger"
 
 require "bugsnag/version"
 require "bugsnag/utility/feature_data_store"
@@ -21,21 +26,9 @@ require "bugsnag/feature_flag"
 # as it doesn't auto-configure when loaded
 require "bugsnag/integrations/rack"
 
-require "bugsnag/middleware/rack_request"
-require "bugsnag/middleware/warden_user"
-require "bugsnag/middleware/clearance_user"
-require "bugsnag/middleware/callbacks"
-require "bugsnag/middleware/rails3_request"
-require "bugsnag/middleware/sidekiq"
-require "bugsnag/middleware/mailman"
-require "bugsnag/middleware/rake"
-require "bugsnag/middleware/classify_error"
-require "bugsnag/middleware/delayed_job"
-
 require "bugsnag/breadcrumb_type"
 require "bugsnag/breadcrumbs/validator"
 require "bugsnag/breadcrumbs/breadcrumb"
-require "bugsnag/breadcrumbs/breadcrumbs"
 
 require "bugsnag/utility/duplicator"
 require "bugsnag/utility/metadata_delegate"

--- a/lib/bugsnag/breadcrumbs/on_breadcrumb_callback_list.rb
+++ b/lib/bugsnag/breadcrumbs/on_breadcrumb_callback_list.rb
@@ -1,5 +1,3 @@
-require "set"
-
 module Bugsnag::Breadcrumbs
   class OnBreadcrumbCallbackList
     def initialize(configuration)

--- a/lib/bugsnag/breadcrumbs/validator.rb
+++ b/lib/bugsnag/breadcrumbs/validator.rb
@@ -1,5 +1,3 @@
-require 'bugsnag/breadcrumbs/breadcrumbs'
-
 module Bugsnag::Breadcrumbs
   ##
   # Validates a given breadcrumb before it is stored

--- a/lib/bugsnag/cleaner.rb
+++ b/lib/bugsnag/cleaner.rb
@@ -1,5 +1,3 @@
-require 'uri'
-
 module Bugsnag
   # @api private
   class Cleaner

--- a/lib/bugsnag/configuration.rb
+++ b/lib/bugsnag/configuration.rb
@@ -1,20 +1,28 @@
-require "set"
-require "socket"
-require "logger"
-require "bugsnag/middleware_stack"
+require "bugsnag/breadcrumbs/on_breadcrumb_callback_list"
+
+require "bugsnag/endpoint_configuration"
+require "bugsnag/endpoint_validator"
+
+require "bugsnag/middleware/breadcrumbs"
 require "bugsnag/middleware/callbacks"
+require "bugsnag/middleware/classify_error"
+require "bugsnag/middleware/clearance_user"
+require "bugsnag/middleware/delayed_job"
 require "bugsnag/middleware/discard_error_class"
 require "bugsnag/middleware/exception_meta_data"
 require "bugsnag/middleware/ignore_error_class"
-require "bugsnag/middleware/suggestion_data"
-require "bugsnag/middleware/classify_error"
+require "bugsnag/middleware/mailman"
+require "bugsnag/middleware/rack_request"
+require "bugsnag/middleware/rails3_request"
+require "bugsnag/middleware/rake"
 require "bugsnag/middleware/session_data"
-require "bugsnag/middleware/breadcrumbs"
+require "bugsnag/middleware/sidekiq"
+require "bugsnag/middleware/suggestion_data"
+require "bugsnag/middleware/warden_user"
+
+require "bugsnag/middleware_stack"
+
 require "bugsnag/utility/circular_buffer"
-require "bugsnag/breadcrumbs/breadcrumbs"
-require "bugsnag/breadcrumbs/on_breadcrumb_callback_list"
-require "bugsnag/endpoint_configuration"
-require "bugsnag/endpoint_validator"
 
 module Bugsnag
   class Configuration

--- a/lib/bugsnag/delivery/synchronous.rb
+++ b/lib/bugsnag/delivery/synchronous.rb
@@ -1,5 +1,4 @@
 require "net/https"
-require "uri"
 
 module Bugsnag
   module Delivery

--- a/lib/bugsnag/delivery/thread_queue.rb
+++ b/lib/bugsnag/delivery/thread_queue.rb
@@ -1,5 +1,3 @@
-require "thread"
-
 module Bugsnag
   module Delivery
     class ThreadQueue < Synchronous

--- a/lib/bugsnag/event.rb
+++ b/lib/bugsnag/event.rb
@@ -1,5 +1,3 @@
-require "bugsnag/report"
-
 module Bugsnag
   # For now Event is just an alias of Report. This points to the same object so
   # any changes to Report will also affect Event

--- a/lib/bugsnag/helpers.rb
+++ b/lib/bugsnag/helpers.rb
@@ -1,8 +1,3 @@
-require 'uri'
-require 'set'
-require 'json'
-
-
 module Bugsnag
   module Helpers # rubocop:todo Metrics/ModuleLength
     MAX_STRING_LENGTH = 3072

--- a/lib/bugsnag/integrations/mongo.rb
+++ b/lib/bugsnag/integrations/mongo.rb
@@ -1,5 +1,4 @@
 require 'mongo'
-require 'bugsnag/breadcrumbs/breadcrumbs'
 
 module Bugsnag
   ##

--- a/lib/bugsnag/integrations/rails/active_job.rb
+++ b/lib/bugsnag/integrations/rails/active_job.rb
@@ -1,5 +1,3 @@
-require 'set'
-
 module Bugsnag::Rails
   module ActiveJob
     SEVERITY = 'error'

--- a/lib/bugsnag/integrations/rails/rails_breadcrumbs.rb
+++ b/lib/bugsnag/integrations/rails/rails_breadcrumbs.rb
@@ -1,5 +1,3 @@
-require "bugsnag/breadcrumbs/breadcrumbs"
-
 module Bugsnag::Rails
   DEFAULT_RAILS_BREADCRUMBS = [
     {

--- a/lib/bugsnag/integrations/railtie.rb
+++ b/lib/bugsnag/integrations/railtie.rb
@@ -1,10 +1,6 @@
 # Rails 3.x hooks
 
-require "json"
 require "rails"
-require "bugsnag"
-require "bugsnag/middleware/rails3_request"
-require "bugsnag/middleware/rack_request"
 require "bugsnag/integrations/rails/rails_breadcrumbs"
 
 module Bugsnag

--- a/lib/bugsnag/integrations/rake.rb
+++ b/lib/bugsnag/integrations/rake.rb
@@ -1,4 +1,7 @@
-require 'bugsnag'
+# this file can either be required manually by a user, in which case 'bugsnag'
+# needs to be required, or it can be required automatically in the railtie,
+# in which case 'bugsnag' has already been required
+require 'bugsnag' unless defined?(Bugsnag)
 
 Rake::TaskManager.record_task_metadata = true
 

--- a/lib/bugsnag/middleware/rack_request.rb
+++ b/lib/bugsnag/middleware/rack_request.rb
@@ -1,5 +1,3 @@
-require "json"
-
 module Bugsnag::Middleware
   ##
   # Extracts and attaches rack data to an error report

--- a/lib/bugsnag/report.rb
+++ b/lib/bugsnag/report.rb
@@ -1,4 +1,3 @@
-require "json"
 require "pathname"
 require "bugsnag/error"
 require "bugsnag/stacktrace"


### PR DESCRIPTION
## Goal

This PR fixes a circular require warning caused by several files requiring the main `bugsnag.rb` file

I've also gone through and removed other duplicate requires, consolidating them into `bugsnag.rb`

See https://github.com/bugsnag/bugsnag-ruby/issues/822