### PR TITLE
Only read Rack request body if it's rewindable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## TBD
+
+### Fixes
+
+* Only read Rack request body if it's rewindable
+  | [#829](https://github.com/bugsnag/bugsnag-ruby/pull/829)
+
 ## v6.27.0 (23 May 2024)
 
 ### Enhancements

--- a/features/fixtures/docker-compose.yml
+++ b/features/fixtures/docker-compose.yml
@@ -88,6 +88,7 @@ services:
       - BUGSNAG_API_KEY
       - BUGSNAG_ENDPOINT
       - BUGSNAG_METADATA_FILTERS
+      - BUGSNAG_RACK_NO_REWIND
     restart: "no"
     ports:
       - target: 3000

--- a/features/fixtures/rack/app/Gemfile
+++ b/features/fixtures/rack/app/Gemfile
@@ -6,6 +6,4 @@ gem 'webrick' if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('3.0.0')
 
 # Some functionality provided by Rack was moved to the 'rackup' gem in Rack v3
 # Specifically the test app uses Rack::Server, which is now Rackup::Server
-if ENV['RACK_VERSION'] == '3'
-  gem 'rackup', '~> 0.2.3'
-end
+gem 'rackup' if ENV['RACK_VERSION'] >= '3'

--- a/features/fixtures/rack/app/app.rb
+++ b/features/fixtures/rack/app/app.rb
@@ -71,12 +71,17 @@ class BugsnagTests
   end
 end
 
+app = Bugsnag::Rack.new(BugsnagTests.new)
+
 Server =
   if defined?(Rack::Server)
     Rack::Server
   else
     require 'rackup'
+
+    app = Rack::RewindableInput::Middleware.new(app) unless ENV["BUGSNAG_RACK_NO_REWIND"] == "true"
+
     Rackup::Server
   end
 
-Server.start(app: Bugsnag::Rack.new(BugsnagTests.new), Host: '0.0.0.0', Port: 3000)
+Server.start(app: app, Host: '0.0.0.0', Port: 3000)

--- a/features/rack.feature
+++ b/features/rack.feature
@@ -64,6 +64,9 @@ Scenario: A POST request with form data sends a report with the parsed request b
   And the event "metaData.request.httpVersion" matches "^HTTP/\d\.\d$"
   And the event "metaData.request.params.a" equals "123"
   And the event "metaData.request.params.b" equals "456"
+  And the event "metaData.request.params.name" equals "baba"
+  And the event "metaData.request.params.favourite_letter" equals "z"
+  And the event "metaData.request.params.password" equals "[FILTERED]"
   And the event "metaData.request.referer" is null
   And the event "metaData.request.url" ends with "/unhandled?a=123&b=456"
 
@@ -86,6 +89,9 @@ Scenario: A POST request with JSON sends a report with the parsed request body a
   And the event "metaData.request.httpVersion" matches "^HTTP/\d\.\d$"
   And the event "metaData.request.params.a" equals "123"
   And the event "metaData.request.params.b" equals "456"
+  And the event "metaData.request.params.name" is null
+  And the event "metaData.request.params.favourite_letter" is null
+  And the event "metaData.request.params.password" is null
   And the event "metaData.request.referer" is null
   And the event "metaData.request.url" ends with "/unhandled?a=123&b=456"
 
@@ -172,3 +178,55 @@ Scenario: clearing feature flags for an unhandled error
   And I wait to receive an error
   Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
   And the event has no feature flags
+
+@not-rack-1
+@not-rack-2
+Scenario: An unrewindable POST request with form data does not attach request body
+  Given I set environment variable "BUGSNAG_RACK_NO_REWIND" to "true"
+  And I start the rack service
+  When I send a POST request to "/unhandled?a=123&b=456" in the rack app with the following form data:
+    | name             | baba      |
+    | favourite_letter | z         |
+    | password         | password1 |
+  And I wait to receive an error
+  Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
+  And the event "metaData.request.body" is null
+  And the event "metaData.request.clientIp" is not null
+  And the event "metaData.request.cookies" is null
+  And the event "metaData.request.headers.Host" is not null
+  And the event "metaData.request.headers.User-Agent" is not null
+  And the event "metaData.request.httpMethod" equals "POST"
+  And the event "metaData.request.httpVersion" matches "^HTTP/\d\.\d$"
+  And the event "metaData.request.params.a" equals "123"
+  And the event "metaData.request.params.b" equals "456"
+  And the event "metaData.request.params.name" is null
+  And the event "metaData.request.params.favourite_letter" is null
+  And the event "metaData.request.params.password" is null
+  And the event "metaData.request.referer" is null
+  And the event "metaData.request.url" ends with "/unhandled?a=123&b=456"
+
+@not-rack-1
+@not-rack-2
+Scenario: An unrewindable POST request with JSON does not attach request body
+  Given I set environment variable "BUGSNAG_RACK_NO_REWIND" to "true"
+  And I start the rack service
+  When I send a POST request to "/unhandled?a=123&b=456" in the rack app with the following JSON:
+    | name             | baba      |
+    | favourite_letter | z         |
+    | password         | password1 |
+  And I wait to receive an error
+  Then the error is valid for the error reporting API version "4.0" for the "Ruby Bugsnag Notifier" notifier
+  And the event "metaData.request.body" is null
+  And the event "metaData.request.clientIp" is not null
+  And the event "metaData.request.cookies" is null
+  And the event "metaData.request.headers.Host" is not null
+  And the event "metaData.request.headers.User-Agent" is not null
+  And the event "metaData.request.httpMethod" equals "POST"
+  And the event "metaData.request.httpVersion" matches "^HTTP/\d\.\d$"
+  And the event "metaData.request.params.a" equals "123"
+  And the event "metaData.request.params.b" equals "456"
+  And the event "metaData.request.params.name" is null
+  And the event "metaData.request.params.favourite_letter" is null
+  And the event "metaData.request.params.password" is null
+  And the event "metaData.request.referer" is null
+  And the event "metaData.request.url" ends with "/unhandled?a=123&b=456"

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -63,3 +63,11 @@ Maze.hooks.before do
   Maze::Runner.environment["BUGSNAG_ENDPOINT"] = "http://#{host}:#{Maze.config.port}/notify"
   Maze::Runner.environment["BUGSNAG_SESSION_ENDPOINT"] = "http://#{host}:#{Maze.config.port}/sessions"
 end
+
+Before("@not-rack-1") do
+  skip_this_scenario if ENV["RACK_VERSION"] == "1"
+end
+
+Before("@not-rack-2") do
+  skip_this_scenario if ENV["RACK_VERSION"] == "2"
+end

--- a/spec/integrations/rack_spec.rb
+++ b/spec/integrations/rack_spec.rb
@@ -104,7 +104,10 @@ describe Bugsnag::Rack do
       }
 
       rack_request = double
+      rack_request_body = double
+
       allow(rack_request).to receive_messages(
+        body: rack_request_body,
         params: { param: 'test', param2: 'test2' },
         ip: "rack_ip",
         request_method: "TEST",
@@ -118,6 +121,9 @@ describe Bugsnag::Rack do
         POST: { param: 'test' },
         cookies: { session_id: 12345 }
       )
+
+      allow(rack_request_body).to receive(:respond_to?).with(:rewind).and_return(true)
+      allow(rack_request_body).to receive(:rewind)
 
       expect(::Rack::Request).to receive(:new).with(rack_env).and_return(rack_request)
 
@@ -160,7 +166,10 @@ describe Bugsnag::Rack do
       }
 
       rack_request = double
+      rack_request_body = double
+
       allow(rack_request).to receive_messages(
+        body: rack_request_body,
         params: { param: 'test', param2: 'test2' },
         ip: "rack_ip",
         request_method: "TEST",
@@ -174,6 +183,9 @@ describe Bugsnag::Rack do
         POST: { param: 'test' },
         cookies: { session_id: 12345 }
       )
+
+      allow(rack_request_body).to receive(:respond_to?).with(:rewind).and_return(true)
+      allow(rack_request_body).to receive(:rewind)
 
       expect(::Rack::Request).to receive(:new).with(rack_env).and_return(rack_request)
 
@@ -218,7 +230,10 @@ describe Bugsnag::Rack do
       }
 
       rack_request = double
+      rack_request_body = double
+
       allow(rack_request).to receive_messages(
+        body: rack_request_body,
         params: { param: 'test', param2: 'test2' },
         ip: "rack_ip",
         request_method: "TEST",
@@ -232,6 +247,9 @@ describe Bugsnag::Rack do
         POST: { param: 'test' },
         cookies: { session_id: 12345 }
       )
+
+      allow(rack_request_body).to receive(:respond_to?).with(:rewind).and_return(true)
+      allow(rack_request_body).to receive(:rewind)
 
       expect(Rack::Request).to receive(:new).with(rack_env).and_return(rack_request)
 
@@ -274,7 +292,10 @@ describe Bugsnag::Rack do
       }
 
       rack_request = double
+      rack_request_body = double
+
       allow(rack_request).to receive_messages(
+        body: rack_request_body,
         params: { param: 'test', param2: 'test2' },
         ip: "rack_ip",
         request_method: "TEST",
@@ -289,6 +310,9 @@ describe Bugsnag::Rack do
         POST: {},
         cookies: {}
       )
+
+      allow(rack_request_body).to receive(:respond_to?).with(:rewind).and_return(true)
+      allow(rack_request_body).to receive(:rewind)
 
       expect(Rack::Request).to receive(:new).with(rack_env).and_return(rack_request)
 


### PR DESCRIPTION
## Goal

Rack 3 made it possible for the request body to not be rewindable, meaning it can only be read once

We rely on reading the request body for two pieces of metadata, `request.params` (if it's a form request) and `request.body`. These won't be set if the body has already been read, which is quite likely

With `request.params` we will only read the query string if the request cannot be rewound

With `request.body` we will not read it at all if the request cannot be rewound