### PR TITLE
Switch to ActiveSupport::Notifications.monotonic_subscribe

### DIFF
--- a/lib/bugsnag/integrations/railtie.rb
+++ b/lib/bugsnag/integrations/railtie.rb
@@ -15,7 +15,7 @@ module Bugsnag
     # @api private
     # @param event [Hash] details of the event to subscribe to
     def event_subscription(event)
-      ActiveSupport::Notifications.subscribe(event[:id]) do |*, event_id, data|
+      ActiveSupport::Notifications.monotonic_subscribe(event[:id]) do |*, event_id, data|
         filtered_data = data.slice(*event[:allowed_data])
         filtered_data[:event_name] = event[:id]
         filtered_data[:event_id] = event_id


### PR DESCRIPTION
## Goal

This is a small performance improvement. `monotonic_subscribe` behaves the same as `subscribe`, except that the timestamps are computed slightly more efficiently. Since we don't use the timestamps here at all, there should be no impact for Bugsnag.



## Design

<!-- Why was this approach used? -->

See this benchmark:

```ruby
Benchmark.ips do |x|
  x.report("Time.now") { Time.now }
  x.report("Process.clock_gettime") { Process.clock_gettime(Process::CLOCK_MONOTONIC) }

  x.compare!
end
```

```
ruby 3.3.5 (2024-09-03 revision ef084cc8f4) +YJIT [arm64-darwin23]
Warming up --------------------------------------
            Time.now     1.619M i/100ms
Process.clock_gettime
                         2.191M i/100ms
Calculating -------------------------------------
            Time.now     17.496M (± 1.7%) i/s   (57.15 ns/i) -     89.054M in   5.091258s
Process.clock_gettime
                         21.589M (± 2.0%) i/s   (46.32 ns/i) -    109.528M in   5.075753s

Comparison:
Process.clock_gettime: 21588547.9 i/s
            Time.now: 17496424.0 i/s - 1.23x  slower
```

## Changeset

<!-- What changed? -->

## Testing

<!-- How was it tested? What manual and automated tests were
     run/added? -->