### PR TITLE
Set default endpoints based on API key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,20 +18,13 @@ pkg
 *.gem
 
 vendor
-# Have editor/IDE/OS specific files you need to ignore? Consider using a global gitignore:
-#
-# * Create a file at ~/.gitignore
-# * Include files you want ignored
-# * Run: git config --global core.excludesfile ~/.gitignore
-#
-# After doing this, these files will be ignored in all your git projects,
-# saving you from having to 'pollute' every project you touch with them
-#
-# Not sure what to needs to be ignored for particular editors/OSes? Here's some ideas to get you started. (Remember, remove the leading # of the line)
-#
-# For MacOS:
-#
-#.DS_Store
+
+# IDEs
+.idea/
+*.iml
+
+# macOS:
+.DS_Store
 
 # For TextMate
 #*.tmproj
@@ -54,3 +47,4 @@ bin
 
 # For Bugsnag-Maze-Runner:
 maze_output
+maze-runner.log

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -600,6 +600,7 @@ Style/RescueStandardError:
 Style/SafeNavigation:
   Exclude:
     - 'lib/bugsnag/middleware/callbacks.rb'
+    - 'lib/bugsnag/configuration.rb'
 
 # Offense count: 1
 # Cop supports --auto-correct.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## v6.28.0 (** June 2024)
+
+### Enhancements
+
+* Set default endpoints based on API key
+| [#835](https://github.com/bugsnag/bugsnag-ruby/pull/835)
+
 ## v6.27.1 (18 June 2024)
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-## v6.28.0 (** June 2024)
+## v6.28.0 (** June 2025)
 
 ### Enhancements
 

--- a/example/rack/Gemfile
+++ b/example/rack/Gemfile
@@ -6,5 +6,5 @@ else
   gem 'bugsnag'
 end
 
-gem 'rack'
+gem 'rack', '~> 2.0'
 gem 'redcarpet'

--- a/lib/bugsnag.rb
+++ b/lib/bugsnag.rb
@@ -525,11 +525,11 @@ module Bugsnag
     # If only a session_endpoint has been set, and ArgumentError will be raised
     def check_endpoint_setup
       notify_set = configuration.notify_endpoint &&
-        configuration.notify_endpoint != Bugsnag::Configuration::DEFAULT_NOTIFY_ENDPOINT &&
-        configuration.notify_endpoint != Bugsnag::Configuration::HUB_NOTIFY
+                   configuration.notify_endpoint != Bugsnag::Configuration::DEFAULT_NOTIFY_ENDPOINT &&
+                   configuration.notify_endpoint != Bugsnag::Configuration::HUB_NOTIFY
       session_set = configuration.session_endpoint &&
-        configuration.session_endpoint != Bugsnag::Configuration::DEFAULT_SESSION_ENDPOINT &&
-        configuration.session_endpoint != Bugsnag::Configuration::HUB_SESSION
+                    configuration.session_endpoint != Bugsnag::Configuration::DEFAULT_SESSION_ENDPOINT &&
+                    configuration.session_endpoint != Bugsnag::Configuration::HUB_SESSION
       if notify_set && !session_set
         configuration.warn("The session endpoint has not been set, all further session capturing will be disabled")
         configuration.disable_sessions

--- a/lib/bugsnag.rb
+++ b/lib/bugsnag.rb
@@ -526,10 +526,10 @@ module Bugsnag
     def check_endpoint_setup
       notify_set = configuration.notify_endpoint &&
                    configuration.notify_endpoint != Bugsnag::Configuration::DEFAULT_NOTIFY_ENDPOINT &&
-                   configuration.notify_endpoint != Bugsnag::Configuration::HUB_NOTIFY
+                   configuration.notify_endpoint != Bugsnag::Configuration::HUB_NOTIFY_ENDPOINT
       session_set = configuration.session_endpoint &&
                     configuration.session_endpoint != Bugsnag::Configuration::DEFAULT_SESSION_ENDPOINT &&
-                    configuration.session_endpoint != Bugsnag::Configuration::HUB_SESSION
+                    configuration.session_endpoint != Bugsnag::Configuration::HUB_SESSION_ENDPOINT
       if notify_set && !session_set
         configuration.warn("The session endpoint has not been set, all further session capturing will be disabled")
         configuration.disable_sessions

--- a/lib/bugsnag.rb
+++ b/lib/bugsnag.rb
@@ -54,6 +54,8 @@ module Bugsnag
     def configure(validate_api_key=true)
       yield(configuration) if block_given?
 
+      configuration.set_default_endpoints
+
       # Create the session tracker if sessions are enabled to avoid the overhead
       # of creating it on the first request. We skip this if we're not validating
       # the API key as we use this internally before the user's configure block
@@ -522,8 +524,12 @@ module Bugsnag
     # If only a notify_endpoint has been set, session tracking will be disabled
     # If only a session_endpoint has been set, and ArgumentError will be raised
     def check_endpoint_setup
-      notify_set = configuration.notify_endpoint && configuration.notify_endpoint != Bugsnag::Configuration::DEFAULT_NOTIFY_ENDPOINT
-      session_set = configuration.session_endpoint && configuration.session_endpoint != Bugsnag::Configuration::DEFAULT_SESSION_ENDPOINT
+      notify_set = configuration.notify_endpoint &&
+        configuration.notify_endpoint != Bugsnag::Configuration::DEFAULT_NOTIFY_ENDPOINT &&
+        configuration.notify_endpoint != Bugsnag::Configuration::HUB_NOTIFY
+      session_set = configuration.session_endpoint &&
+        configuration.session_endpoint != Bugsnag::Configuration::DEFAULT_SESSION_ENDPOINT &&
+        configuration.session_endpoint != Bugsnag::Configuration::HUB_SESSION
       if notify_set && !session_set
         configuration.warn("The session endpoint has not been set, all further session capturing will be disabled")
         configuration.disable_sessions

--- a/lib/bugsnag/configuration.rb
+++ b/lib/bugsnag/configuration.rb
@@ -546,13 +546,13 @@ module Bugsnag
     # Sets the notification and session endpoints to default values if neither have been set
     #
     def set_default_endpoints
-      if @endpoints.notify.nil? && @endpoints.sessions.nil?
-        if self.hub_api_key?
-          self.endpoints = EndpointConfiguration.new(HUB_NOTIFY, HUB_SESSION)
-        else
-          self.endpoints = EndpointConfiguration.new(DEFAULT_NOTIFY_ENDPOINT, DEFAULT_SESSION_ENDPOINT)
-        end
-      end
+      return unless @endpoints.notify.nil? && @endpoints.sessions.nil?
+
+      self.endpoints = if self.hub_api_key?
+                         EndpointConfiguration.new(HUB_NOTIFY, HUB_SESSION)
+                       else
+                         EndpointConfiguration.new(DEFAULT_NOTIFY_ENDPOINT, DEFAULT_SESSION_ENDPOINT)
+                       end
     end
 
     ##
@@ -770,7 +770,7 @@ module Bugsnag
     end
 
     def hub_api_key?
-      @api_key && @api_key.start_with?(HUB_PREFIX)
+      @api_key&.start_with?(HUB_PREFIX)
     end
   end
 end

--- a/lib/bugsnag/configuration.rb
+++ b/lib/bugsnag/configuration.rb
@@ -546,9 +546,6 @@ module Bugsnag
     # Sets the notification and session endpoints to default values if neither have been set
     #
     def set_default_endpoints
-
-      puts @endpoints.inspect
-
       if @endpoints.notify.nil? && @endpoints.sessions.nil?
         if self.hub_api_key?
           self.endpoints = EndpointConfiguration.new(HUB_NOTIFY, HUB_SESSION)

--- a/lib/bugsnag/configuration.rb
+++ b/lib/bugsnag/configuration.rb
@@ -770,7 +770,7 @@ module Bugsnag
     end
 
     def hub_api_key?
-      @api_key&.start_with?(HUB_PREFIX)
+      @api_key && @api_key.start_with?(HUB_PREFIX)
     end
   end
 end

--- a/lib/bugsnag/configuration.rb
+++ b/lib/bugsnag/configuration.rb
@@ -548,7 +548,7 @@ module Bugsnag
     def set_default_endpoints
       return unless @endpoints.notify.nil? && @endpoints.sessions.nil?
 
-      self.endpoints = if self.hub_api_key?
+      self.endpoints = if hub_api_key?
                          EndpointConfiguration.new(HUB_NOTIFY, HUB_SESSION)
                        else
                          EndpointConfiguration.new(DEFAULT_NOTIFY_ENDPOINT, DEFAULT_SESSION_ENDPOINT)

--- a/lib/bugsnag/configuration.rb
+++ b/lib/bugsnag/configuration.rb
@@ -199,7 +199,9 @@ module Bugsnag
 
     DEFAULT_NOTIFY_ENDPOINT = "https://notify.bugsnag.com"
     DEFAULT_SESSION_ENDPOINT = "https://sessions.bugsnag.com"
-    DEFAULT_ENDPOINT = DEFAULT_NOTIFY_ENDPOINT
+    HUB_NOTIFY = "https://notify.insighthub.smartbear.com"
+    HUB_SESSION = "https://sessions.insighthub.smartbear.com"
+    HUB_PREFIX = "00000"
 
     DEFAULT_META_DATA_FILTERS = [
       /authorization/i,
@@ -249,7 +251,7 @@ module Bugsnag
       # to avoid infinite recursion when creating breadcrumb buffer
       @max_breadcrumbs = DEFAULT_MAX_BREADCRUMBS
 
-      @endpoints = EndpointConfiguration.new(DEFAULT_NOTIFY_ENDPOINT, DEFAULT_SESSION_ENDPOINT)
+      @endpoints = EndpointConfiguration.new(nil, nil)
 
       @enable_events = true
       @enable_sessions = true
@@ -541,6 +543,22 @@ module Bugsnag
     end
 
     ##
+    # Sets the notification and session endpoints to default values if neither have been set
+    #
+    def set_default_endpoints
+
+      puts @endpoints.inspect
+
+      if @endpoints.notify.nil? && @endpoints.sessions.nil?
+        if self.hub_api_key?
+          self.endpoints = EndpointConfiguration.new(HUB_NOTIFY, HUB_SESSION)
+        else
+          self.endpoints = EndpointConfiguration.new(DEFAULT_NOTIFY_ENDPOINT, DEFAULT_SESSION_ENDPOINT)
+        end
+      end
+    end
+
+    ##
     # Sets the notification and session endpoints
     #
     # @param new_notify_endpoint [String] The URL to deliver error notifications to
@@ -752,6 +770,10 @@ module Bugsnag
     def default_hostname
       # Send the heroku dyno name instead of hostname if available
       ENV["DYNO"] || Socket.gethostname;
+    end
+
+    def hub_api_key?
+      @api_key && @api_key.start_with?(HUB_PREFIX)
     end
   end
 end

--- a/lib/bugsnag/configuration.rb
+++ b/lib/bugsnag/configuration.rb
@@ -199,8 +199,8 @@ module Bugsnag
 
     DEFAULT_NOTIFY_ENDPOINT = "https://notify.bugsnag.com"
     DEFAULT_SESSION_ENDPOINT = "https://sessions.bugsnag.com"
-    HUB_NOTIFY = "https://notify.insighthub.smartbear.com"
-    HUB_SESSION = "https://sessions.insighthub.smartbear.com"
+    HUB_NOTIFY_ENDPOINT = "https://notify.insighthub.smartbear.com"
+    HUB_SESSION_ENDPOINT = "https://sessions.insighthub.smartbear.com"
     HUB_PREFIX = "00000"
 
     DEFAULT_META_DATA_FILTERS = [
@@ -549,7 +549,7 @@ module Bugsnag
       return unless @endpoints.notify.nil? && @endpoints.sessions.nil?
 
       self.endpoints = if hub_api_key?
-                         EndpointConfiguration.new(HUB_NOTIFY, HUB_SESSION)
+                         EndpointConfiguration.new(HUB_NOTIFY_ENDPOINT, HUB_SESSION_ENDPOINT)
                        else
                          EndpointConfiguration.new(DEFAULT_NOTIFY_ENDPOINT, DEFAULT_SESSION_ENDPOINT)
                        end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -445,8 +445,8 @@ describe Bugsnag::Configuration do
           Bugsnag.configure do |config|
             config.api_key = '00000472bd130ac0ab0f52715bbdc600'
           end
-          expect(Bugsnag.configuration.endpoints.notify).to eq(Bugsnag::Configuration::HUB_NOTIFY)
-          expect(Bugsnag.configuration.endpoints.sessions).to eq(Bugsnag::Configuration::HUB_SESSION)
+          expect(Bugsnag.configuration.endpoints.notify).to eq(Bugsnag::Configuration::HUB_NOTIFY_ENDPOINT)
+          expect(Bugsnag.configuration.endpoints.sessions).to eq(Bugsnag::Configuration::HUB_SESSION_ENDPOINT)
         end
       end
     end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -107,8 +107,8 @@ describe Bugsnag::Configuration do
 
   describe "endpoint configuration" do
     describe "#notify_endpoint" do
-      it "defaults to DEFAULT_NOTIFY_ENDPOINT" do
-        expect(subject.notify_endpoint).to eq(Bugsnag::Configuration::DEFAULT_NOTIFY_ENDPOINT)
+      it "defaults to nil" do
+        expect(subject.notify_endpoint).to eq(nil)
       end
 
       it "is readonly" do
@@ -121,9 +121,13 @@ describe Bugsnag::Configuration do
     end
 
     describe "#session_endpoint" do
-      it "defaults to DEFAULT_SESSION_ENDPOINT" do
-        expect(subject.session_endpoint).to eq(Bugsnag::Configuration::DEFAULT_SESSION_ENDPOINT)
+      it "defaults to nil" do
+        expect(subject.session_endpoint).to eq(nil)
       end
+    end
+
+    describe "#set_default_endpoints" do
+
     end
 
     describe "#endpoint=" do
@@ -171,11 +175,11 @@ describe Bugsnag::Configuration do
     end
 
     describe "#endpoints" do
-      it "defaults to 'DEFAULT_NOTIFY_ENDPOINT' & 'DEFAULT_SESSION_ENDPOINT'" do
+      it "defaults to nil & nil" do
         config = Bugsnag::Configuration.new
 
-        expect(config.endpoints.notify).to eq(Bugsnag::Configuration::DEFAULT_NOTIFY_ENDPOINT)
-        expect(config.endpoints.sessions).to eq(Bugsnag::Configuration::DEFAULT_SESSION_ENDPOINT)
+        expect(config.endpoints.notify).to eq(nil)
+        expect(config.endpoints.sessions).to eq(nil)
       end
     end
 
@@ -203,7 +207,7 @@ describe Bugsnag::Configuration do
         expect(config.enable_sessions).to be(false)
       end
 
-      # TODO: this behaviour exists for backwards compatibilitiy
+      # TODO: this behaviour exists for backwards compatibility
       #       ideally we should not send events in this case
       it "warns and disables sessions if only notify URL is given" do
         config = Bugsnag::Configuration.new
@@ -426,6 +430,23 @@ describe Bugsnag::Configuration do
           expect(output_lines.first).to eq(
             '[Bugsnag] WARN: No valid API key has been set, notifications will not be sent'
           )
+        end
+
+        it "uses the default endpoints for non-hub API keys", :no_configure => true do
+          Bugsnag.configure do |config|
+            config.api_key = '00002472bd130ac0ab0f52715bbdc600'
+          end
+
+          expect(Bugsnag.configuration.endpoints.notify).to eq(Bugsnag::Configuration::DEFAULT_NOTIFY_ENDPOINT)
+          expect(Bugsnag.configuration.endpoints.sessions).to eq(Bugsnag::Configuration::DEFAULT_SESSION_ENDPOINT)
+        end
+
+        it "uses the hub endpoints for hub API keys", :no_configure => true do
+          Bugsnag.configure do |config|
+            config.api_key = '00000472bd130ac0ab0f52715bbdc600'
+          end
+          expect(Bugsnag.configuration.endpoints.notify).to eq(Bugsnag::Configuration::HUB_NOTIFY)
+          expect(Bugsnag.configuration.endpoints.sessions).to eq(Bugsnag::Configuration::HUB_SESSION)
         end
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -47,11 +47,12 @@ def ruby_version_greater_equal?(target_version)
 end
 
 RSpec.configure do |config|
+
   config.order = "random"
   config.example_status_persistence_file_path = "#{Dir.tmpdir}/rspec_status"
   config.filter_run_when_matching(:focus)
 
-  config.before(:each) do
+  config.before(:each) do |example|
     WebMock.stub_request(:post, "https://notify.bugsnag.com/")
     WebMock.stub_request(:post, "https://sessions.bugsnag.com/")
 
@@ -61,12 +62,14 @@ RSpec.configure do |config|
 
     Thread.current[Bugsnag::SessionTracker::THREAD_SESSION] = nil
 
-    Bugsnag.configure do |bugsnag|
-      bugsnag.api_key = "c9d60ae4c7e70c4b6c4ebd3e8056d2b8"
-      bugsnag.release_stage = "production"
-      bugsnag.delivery_method = :synchronous
-      # silence logger in tests
-      bugsnag.logger = Logger.new(StringIO.new)
+    unless example.metadata[:no_configure]
+      Bugsnag.configure do |bugsnag|
+        bugsnag.api_key = "c9d60ae4c7e70c4b6c4ebd3e8056d2b8"
+        bugsnag.release_stage = "production"
+        bugsnag.delivery_method = :synchronous
+        # silence logger in tests
+        bugsnag.logger = Logger.new(StringIO.new)
+      end
     end
   end
 


### PR DESCRIPTION
## Goal

Set default endpoints based on API key. If no endpoint is configured, payloads should be sent to *.insighthub.smartbear.com if the API key starts with `00000`.

## Design

Because the API key can be set in a block passed to `Bugsng.configure`, setting of the default endpoints needs to be moved later in the process.  

## Changeset

Endpoints are now set to `nil` in `Configuraation.initialize` and a new routine `set_default_endpoints` added to set them after any block has been called.

## Testing

Unit tests added and I've run some manual tests locally with an example app, verifying that the requested host is as expected for different API keys.