### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/maze-runner.yml
+++ b/.github/workflows/maze-runner.yml
@@ -166,6 +166,9 @@ jobs:
             rails-version: '8'
           - ruby-version: '3.4'
             rails-version: '_integrations'
+          # 2.7 integrations skipped pending PLAT-14389
+          - ruby-version: '2.7'
+            rails-version: '_integrations'
 
     uses: ./.github/workflows/run-maze-runner.yml
     with:

--- a/.github/workflows/maze-runner.yml
+++ b/.github/workflows/maze-runner.yml
@@ -7,7 +7,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ['1.9', '3.4']
+        # Ruby 1.9/2.0 skipped pending PLAT-14387
+        #ruby-version: ['1.9', '3.4']
+        ruby-version: ['3.4']
 
     uses: ./.github/workflows/run-maze-runner.yml
     with:
@@ -18,7 +20,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ['2.0', '3.0']
+        # Ruby 1.9/2.0 skipped pending PLAT-14387
+        #ruby-version: ['2.0', '3.0']
+        ruby-version: ['3.0']
 
     uses: ./.github/workflows/run-maze-runner.yml
     with:
@@ -30,8 +34,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - ruby-version: '1.9'
-            rack-version: '1'
+          # Ruby 1.9/2.0 skipped pending PLAT-14387
+          #- ruby-version: '1.9'
+          #  rack-version: '1'
           - ruby-version: '3.0'
             rack-version: '1'
           - ruby-version: '2.2'
@@ -54,8 +59,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - ruby-version: '2.0'
-            que-version: '0.14'
+          # Ruby 1.9/2.0 skipped pending PLAT-14387
+          #- ruby-version: '2.0'
+          #  que-version: '0.14'
           - ruby-version: '2.5'
             que-version: '0.14'
           - ruby-version: '2.5'
@@ -113,8 +119,9 @@ jobs:
         ruby-version: ['2.2', '2.5']
         rails-version: ['3', '4', '5']
         include:
-          - ruby-version: '2.0'
-            rails-version: '3'
+          # Ruby 1.9/2.0 skipped pending PLAT-14387
+          #- ruby-version: '2.0'
+          #  rails-version: '3'
           - ruby-version: '2.6'
             rails-version: '5'
         exclude:
@@ -170,7 +177,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ['1.9', '2.0', '2.1', '2.2', '2.3', '2.4', '2.5', '2.6', '2.7', '3.0', '3.1', '3.2', '3.3', '3.4']
+        # Ruby 1.9/2.0 skipped pending PLAT-14387
+        #ruby-version: ['1.9', '2.0', '2.1', '2.2', '2.3', '2.4', '2.5', '2.6', '2.7', '3.0', '3.1', '3.2', '3.3', '3.4']
+        ruby-version: ['2.1', '2.2', '2.3', '2.4', '2.5', '2.6', '2.7', '3.0', '3.1', '3.2', '3.3', '3.4']
 
     uses: ./.github/workflows/run-maze-runner.yml
     with:

--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 jobs:
   specs:
-    runs-on: ${{ matrix.os || 'ubuntu-latest' }}
+    runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false
@@ -19,9 +19,6 @@ jobs:
             optional-groups: 'test'
           - ruby-version: '2.1'
             optional-groups: 'test'
-          - ruby-version: '2.2'
-            optional-groups: 'test sidekiq'
-            os: 'ubuntu-22.04'
           - ruby-version: 'jruby'
             optional-groups: 'test'
 

--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -13,7 +13,7 @@ jobs:
         optional-groups: ['test sidekiq']
         include:
           - ruby-version: '1.9'
-            os: 'ubuntu-20.04'
+            os: 'ubuntu-22.04'
             optional-groups: 'test'
           - ruby-version: '2.0'
             optional-groups: 'test'
@@ -21,7 +21,7 @@ jobs:
             optional-groups: 'test'
           - ruby-version: '2.2'
             optional-groups: 'test sidekiq'
-            os: 'ubuntu-20.04'
+            os: 'ubuntu-22.04'
           - ruby-version: 'jruby'
             optional-groups: 'test'
 

--- a/Gemfile-maze-runner
+++ b/Gemfile-maze-runner
@@ -1,3 +1,3 @@
 source "https://rubygems.org"
 
-gem 'bugsnag-maze-runner', git: 'https://github.com/bugsnag/maze-runner', tag: 'v7.10.1'
+gem 'bugsnag-maze-runner', '~> 9.0'

--- a/features/fixtures/rails3/app/config/boot.rb
+++ b/features/fixtures/rails3/app/config/boot.rb
@@ -1,3 +1,4 @@
+require 'logger'
 require 'rubygems'
 
 # Set up gems listed in the Gemfile.

--- a/features/fixtures/rails4/app/config/boot.rb
+++ b/features/fixtures/rails4/app/config/boot.rb
@@ -1,4 +1,5 @@
 # Set up gems listed in the Gemfile.
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
 
+require 'logger'
 require 'bundler/setup' if File.exists?(ENV['BUNDLE_GEMFILE'])

--- a/features/fixtures/rails5/app/config/boot.rb
+++ b/features/fixtures/rails5/app/config/boot.rb
@@ -1,3 +1,4 @@
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
 
+require 'logger'
 require 'bundler/setup' # Set up gems listed in the Gemfile.

--- a/features/fixtures/rails6/app/config/boot.rb
+++ b/features/fixtures/rails6/app/config/boot.rb
@@ -1,4 +1,5 @@
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)
 
+require "logger"
 require 'bundler/setup' # Set up gems listed in the Gemfile.
 require 'bootsnap/setup' # Speed up boot time by caching expensive operations.

--- a/features/fixtures/rails7/app/config/boot.rb
+++ b/features/fixtures/rails7/app/config/boot.rb
@@ -1,4 +1,5 @@
 ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
 
+require "logger"
 require "bundler/setup" # Set up gems listed in the Gemfile.
 require "bootsnap/setup" # Speed up boot time by caching expensive operations.

--- a/features/plain_features/auto_notify.feature
+++ b/features/plain_features/auto_notify.feature
@@ -3,4 +3,4 @@ Feature: Auto notify configuration option
 Scenario: When Auto-notify is false notifications are not sent
   Given I set environment variable "BUGSNAG_AUTO_NOTIFY" to "false"
   When I run the service "plain-ruby" with the command "bundle exec ruby configuration/send_unhandled.rb"
-  Then I should receive no requests
+  Then I should receive no errors

--- a/features/plain_features/handled_errors.feature
+++ b/features/plain_features/handled_errors.feature
@@ -26,7 +26,7 @@ Scenario: A notified string sends a report
 
 Scenario: A handled error doesn't send a report when the :skip_bugsnag flag is set
   When I run the service "plain-ruby" with the command "bundle exec ruby handled/ignore_exception.rb"
-  Then I should receive no requests
+  Then I should receive no errors
 
 Scenario: A handled error can attach metadata in a block
   When I run the service "plain-ruby" with the command "bundle exec ruby handled/block_metadata.rb"

--- a/features/plain_features/ignore_classes.feature
+++ b/features/plain_features/ignore_classes.feature
@@ -2,7 +2,7 @@ Feature: Plain ignore classes
 
 Scenario Outline: An errors class is in the ignore_classes array
   When I run the service "plain-ruby" with the command "bundle exec ruby ignore_classes/<state>.rb"
-  Then I should receive no requests
+  Then I should receive no errors
 
   Examples:
   | state     |

--- a/features/plain_features/ignore_report.feature
+++ b/features/plain_features/ignore_report.feature
@@ -3,7 +3,7 @@ Feature: Plain ignore report
 Scenario Outline: A reports severity can be modified
   Given I set environment variable "CALLBACK_INITIATOR" to "<initiator>"
   When I run the service "plain-ruby" with the command "bundle exec ruby report_modification/ignore_report.rb"
-  Then I should receive no requests
+  Then I should receive no errors
 
   Examples:
   | initiator               |

--- a/features/plain_features/release_stages.feature
+++ b/features/plain_features/release_stages.feature
@@ -4,7 +4,7 @@ Scenario: Doesn't notify in the wrong release stage
   Given I set environment variable "BUGSNAG_NOTIFY_RELEASE_STAGE" to "stage_one"
   And I set environment variable "BUGSNAG_RELEASE_STAGE" to "stage_two"
   When I run the service "plain-ruby" with the command "bundle exec ruby configuration/send_unhandled.rb"
-  Then I should receive no requests
+  Then I should receive no errors
 
 Scenario: Does notify in the correct release stage
   Given I set environment variable "BUGSNAG_NOTIFY_RELEASE_STAGE" to "stage_one"

--- a/features/plain_features/unhandled_errors.feature
+++ b/features/plain_features/unhandled_errors.feature
@@ -33,7 +33,7 @@ Scenario Outline: An unhandled error sends a report
 
 Scenario Outline: An unhandled error doesn't send a report
   When I run the service "plain-ruby" with the command "<command> unhandled/<file>.rb"
-  Then I should receive no requests
+  Then I should receive no errors
 
   Examples:
   | file                 | command          |

--- a/features/rails_features/auto_capture_sessions.feature
+++ b/features/rails_features/auto_capture_sessions.feature
@@ -13,7 +13,7 @@ Scenario: Auto_capture_sessions can be set to false in the initializer
   Given I set environment variable "BUGSNAG_AUTO_CAPTURE_SESSIONS" to "false"
   And I start the rails service
   When I navigate to the route "/session_tracking/initializer" on the rails app
-  Then I should receive no requests
+  Then I should receive no sessions
 
 @rails3 @rails4 @rails5 @rails6 @rails7 @rails8
 Scenario: Manual sessions are still sent if Auto_capture_sessions is false

--- a/features/rails_features/auto_notify.feature
+++ b/features/rails_features/auto_notify.feature
@@ -5,7 +5,7 @@ Scenario: Auto_notify set to false in the initializer prevents unhandled error s
   Given I set environment variable "BUGSNAG_AUTO_NOTIFY" to "false"
   And I start the rails service
   When I navigate to the route "/auto_notify/unhandled" on the rails app
-  Then I should receive no requests
+  Then I should receive no errors
 
 @rails3 @rails4 @rails5 @rails6 @rails7 @rails8
 Scenario: Auto_notify set to false in the initializer still sends handled errors
@@ -24,7 +24,7 @@ Scenario: Auto_notify set to false in the initializer still sends handled errors
 Scenario: Auto_notify set to false after the initializer prevents unhandled error sending
   Given I start the rails service
   When I navigate to the route "/auto_notify/unhandled_after" on the rails app
-  Then I should receive no requests
+  Then I should receive no errors
 
 @rails3 @rails4 @rails5 @rails6 @rails7 @rails8
 Scenario: Auto_notify set to false after the initializer still sends handled errors

--- a/features/rails_features/ignore_classes.feature
+++ b/features/rails_features/ignore_classes.feature
@@ -5,10 +5,10 @@ Scenario: Ignore_classes can be set to a different value in initializer
   Given I set environment variable "BUGSNAG_IGNORE_CLASS" to "IgnoredError"
   And I start the rails service
   When I navigate to the route "/ignore_classes/initializer" on the rails app
-  Then I should receive no requests
+  Then I should receive no errors
 
 @rails3 @rails4 @rails5 @rails6 @rails7 @rails8
 Scenario: Ignore_classes can be set to a different value after initializer
   Given I start the rails service
   When I navigate to the route "/ignore_classes/after?ignore=IgnoredError" on the rails app
-  Then I should receive no requests
+  Then I should receive no errors

--- a/features/rails_features/integrations.feature
+++ b/features/rails_features/integrations.feature
@@ -238,7 +238,7 @@ Scenario: Using Sidekiq as the Active Job queue adapter for a job that works
   And I start the rails service
   And I run "bundle exec sidekiq" in the rails app in the background
   When I run the "fixture:queue_working_job" rake task in the rails app
-  Then I should receive no requests
+  Then I should receive no errors
 
 @rails_integrations
 Scenario: Using Resque as the Active Job queue adapter for a job that works
@@ -246,7 +246,7 @@ Scenario: Using Resque as the Active Job queue adapter for a job that works
   And I start the rails service
   And I run "bundle exec rake resque:work" in the rails app in the background
   When I run the "fixture:queue_working_job" rake task in the rails app
-  Then I should receive no requests
+  Then I should receive no errors
 
 @rails_integrations
 Scenario: Using Que as the Active Job queue adapter for a job that works
@@ -254,7 +254,7 @@ Scenario: Using Que as the Active Job queue adapter for a job that works
   And I start the rails service with the database
   And I run "bundle exec que -q default ./config/environment.rb" in the rails app in the background
   When I run the "fixture:queue_working_job" rake task in the rails app
-  Then I should receive no requests
+  Then I should receive no errors
 
 @rails_integrations
 Scenario: Using Delayed Job as the Active Job queue adapter for a job that works
@@ -262,4 +262,4 @@ Scenario: Using Delayed Job as the Active Job queue adapter for a job that works
   And I start the rails service with the database
   And I run the "jobs:work" rake task in the rails app in the background
   When I run the "fixture:queue_working_job" rake task in the rails app
-  Then I should receive no requests
+  Then I should receive no errors

--- a/spec/fixtures/apps/rails-invalid-initializer-config/config.ru
+++ b/spec/fixtures/apps/rails-invalid-initializer-config/config.ru
@@ -1,3 +1,5 @@
+require 'logger'
+
 Bundler.require
 
 run InitializerConfigApp ||= Class.new(Rails::Application) {

--- a/spec/fixtures/apps/rails-no-config/config.ru
+++ b/spec/fixtures/apps/rails-no-config/config.ru
@@ -1,3 +1,5 @@
+require 'logger'
+
 Bundler.require
 
 run NoConfigApp ||= Class.new(Rails::Application) {


### PR DESCRIPTION
## Goal

Fix tests running on CI, or skip pending further investigation.

## Changeset

- Spec tests for Ruby 2.2 removed due to the error discussed [here](https://github.com/ruby/setup-ruby/issues/496).  They were pinned to Ubuntu 20 due to the error on Ubuntu 22 and 20.04 is no longer available on GitHub Actions.
- Ruby 1.9/2.0 tests are skipped as we're unable to use the schema v1 Docker images with GitHub Action.  PLAT-14387 has been raised to reinstate these once we've converted the images to schema v2.
- I've bumped the version of Maze Runner to v9 to avoid an issue installing `curb` v0.9.11 when bundling Maze Runner.

## Testing

Covered by CI.