### PR TITLE
Bump Rails 6/7 test to Ruby 3.4

### DIFF
--- a/.github/workflows/maze-runner.yml
+++ b/.github/workflows/maze-runner.yml
@@ -140,7 +140,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby-version: ['2.7', '3.3']
+        ruby-version: ['2.7', '3.4']
         rails-version: ['6', '7']
         exclude:
           - ruby-version: '2.7'

--- a/features/fixtures/rails6/app/Gemfile
+++ b/features/fixtures/rails6/app/Gemfile
@@ -58,3 +58,10 @@ gem 'bugsnag', path: '/bugsnag'
 gem "mongoid"
 
 gem "clearance", "~> 1.16"
+
+if RUBY_VERSION >= "3.4.0"
+  gem "bigdecimal"
+  gem "mutex_m"
+  gem "benchmark"
+  gem "ostruct"
+end


### PR DESCRIPTION
## Goal

Bump Rails 6/7 test to Ruby 3.4.

## Testing

Covered by CI.