### PR TITLE
Guard against nil endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ Changelog
 * Amend secondary instance URL to bugsnag.smartbear.com
   | [#845](https://github.com/bugsnag/bugsnag-ruby/pull/845)
 
+* Guard against nil URI errors in synchronous delivery
+  | [#851](https://github.com/bugsnag/bugsnag-ruby/pull/851)
+
 ## v6.28.0 (8 July 2025)
 
 ### Enhancements

--- a/lib/bugsnag/delivery/synchronous.rb
+++ b/lib/bugsnag/delivery/synchronous.rb
@@ -7,6 +7,11 @@ module Bugsnag
         ##
         # Attempts to deliver a payload to the given endpoint synchronously.
         def deliver(url, body, configuration, options={})
+          if url.nil?
+            configuration.warn("Request to deliver Bugsnag payload before configure was called. Unable to send information to Bugsnag.")
+            return
+          end
+
           begin
             response = request(url, body, configuration, options)
             configuration.debug("Request to #{url} completed, status: #{response.code}")
@@ -19,6 +24,8 @@ module Bugsnag
 
             configuration.error("Unable to send information to Bugsnag (#{url}), #{e.inspect}")
             configuration.error(e.backtrace)
+          rescue URI::InvalidURIError => e
+            configuration.error("The configured Bugsnag endpoint URL (#{url}) is invalid, #{e.inspect}")
           end
         end
 

--- a/lib/bugsnag/delivery/synchronous.rb
+++ b/lib/bugsnag/delivery/synchronous.rb
@@ -18,14 +18,14 @@ module Bugsnag
             if response.code[0] != "2"
               configuration.warn("Notifications to #{url} was reported unsuccessful with code #{response.code}")
             end
+          rescue URI::InvalidURIError => e
+            configuration.error("The configured Bugsnag endpoint URL (#{url}) is invalid, #{e.inspect}")
           rescue StandardError => e
             # KLUDGE: Since we don't re-raise http exceptions, this breaks rspec
             raise if e.class.to_s == "RSpec::Expectations::ExpectationNotMetError"
 
             configuration.error("Unable to send information to Bugsnag (#{url}), #{e.inspect}")
             configuration.error(e.backtrace)
-          rescue URI::InvalidURIError => e
-            configuration.error("The configured Bugsnag endpoint URL (#{url}) is invalid, #{e.inspect}")
           end
         end
 

--- a/spec/bugsnag_spec.rb
+++ b/spec/bugsnag_spec.rb
@@ -209,6 +209,18 @@ describe Bugsnag do
 
       expect(Bugsnag).not_to have_sent_sessions
     end
+    it "does not send requests when the endpoints are nil" do
+      Bugsnag.configuration.endpoints = Bugsnag::EndpointConfiguration.new(nil, nil)
+
+      expect(Bugsnag.configuration).not_to receive(:debug)
+      expect(Bugsnag.configuration).not_to receive(:info)
+      expect(Bugsnag.configuration).not_to receive(:warn)
+      expect(Bugsnag.configuration).not_to receive(:error)
+
+      Bugsnag.notify(RuntimeError.new("abc"))
+
+      expect(Bugsnag).not_to have_sent_notification
+    end
   end
 
   describe "add_exit_handler" do


### PR DESCRIPTION
## Goal

Under specific circumstances, the notifier might attempt delivery before the endpoint is configured. This PR adds logic to guard against this behavior.

## Changeset

- Added a check for the `url` being `nil`
- Added explicit handling of URI parse errors