### PR TITLE
Switch to ActiveSupport::Notifications.monotonic_subscribe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Changelog
 
 ### Enhancements
 
-* Use `ActiveSupport::Notifications.monotonic_subscribe` on compatible Rails versions
+* Use `ActiveSupport::Notifications.monotonic_subscribe` for performance improvement on compatible Rails versions
   | [#856](https://github.com/bugsnag/bugsnag-ruby/pull/856)
 
 ## v6.29.0 (21 January 2026)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+## TBD
+
+### Enhancements
+
+* Use `ActiveSupport::Notifications.monotonic_subscribe` on compatible Rails versions
+  | [#856](https://github.com/bugsnag/bugsnag-ruby/pull/856)
+
 ## v6.29.0 (21 January 2026)
 
 ### Enhancements

--- a/lib/bugsnag/integrations/railtie.rb
+++ b/lib/bugsnag/integrations/railtie.rb
@@ -15,7 +15,7 @@ module Bugsnag
     # @api private
     # @param event [Hash] details of the event to subscribe to
     def event_subscription(event)
-      ActiveSupport::Notifications.subscribe(event[:id]) do |*, event_id, data|
+      ActiveSupport::Notifications.monotonic_subscribe(event[:id]) do |*, event_id, data|
         filtered_data = data.slice(*event[:allowed_data])
         filtered_data[:event_name] = event[:id]
         filtered_data[:event_id] = event_id

--- a/lib/bugsnag/integrations/railtie.rb
+++ b/lib/bugsnag/integrations/railtie.rb
@@ -15,7 +15,9 @@ module Bugsnag
     # @api private
     # @param event [Hash] details of the event to subscribe to
     def event_subscription(event)
-      ActiveSupport::Notifications.monotonic_subscribe(event[:id]) do |*, event_id, data|
+      # monotonic_subscribe was introduced in Rails 6.1+, check if it exists
+      subscription_method = ActiveSupport::Notifications.respond_to?(:monotonic_subscribe) ? :monotonic_subscribe : :subscribe
+      ActiveSupport::Notifications.send(subscription_method, event[:id]) do |*, event_id, data|
         filtered_data = data.slice(*event[:allowed_data])
         filtered_data[:event_name] = event[:id]
         filtered_data[:event_id] = event_id


### PR DESCRIPTION
## Goal

Add ActiveSupport::Notifications.monotonic_subscribe for performance improvement. monotonic_subscribe was introduced in Rails 6.1+, so add a condition to use it only when available.

## Testing

- Verified locally with all supported Rails versions and Ruby versions.
- Ran RSpec and maze-runner test suites; all passed.
- Confirmed that event subscription and breadcrumbs work as expected in all environments.